### PR TITLE
[TSPS-7] README updates for new developers

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ To run locally:
 
 This service is written in Java 17, and uses Postgres 13. 
 
+To run locally, you'll also need: 
+- jq - install with `brew install jq`
+- vault - see DSP's setup instructions [here](https://docs.google.com/document/d/11pZE-GqeZFeSOG0UpGg_xyTDQpgBRfr0MLxpxvvQgEw/edit#heading=h.1k9ij99wmle2)
+  - Note that for Step 7, "Create a GitHub Personal Access Token", you'll want to choose the "Tokens (classic)" option, not the fine-grained access token option.
+
 ### Tech stack
 
 - Java 17 temurin

--- a/README.md
+++ b/README.md
@@ -1,3 +1,34 @@
 # Terra Scientific Pipelines Service
 
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=DataBiosphere_terra-scientific-pipelines-service&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=DataBiosphere_terra-scientific-pipelines-service)
+
+## Overview
+
+Terra Scientific Pipelines Service, or teaspoons (tsps), facilitates running a number of defined scientific pipelines 
+on behalf of users that users can't run themselves in Terra. The most common reason for this is that the pipeline 
+accesses proprietary data that users are not allowed to access directly, but that may be used as e.g. a reference panel 
+for imputation.
+
+## Supported pipelines
+
+Current supported pipelines are:
+- [in development] Imputation (TODO add link/info)
+
+## Architecture
+
+TODO
+
+## Development
+
+### Requirements
+
+This service is written in Java 17, and uses Postgres 13. 
+
+### Tech stack
+
+- Java 17 temurin
+- Postgres 13.1
+- Gradle - build automation tool
+- SonarQube - static code security and coverage
+- Trivy - security scanner for docker images
+- Jib - docker image builder for Java

--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ TODO
 
 ## Development
 
+This codebase is in initial development.
+
+To run locally:
+1. Make sure you have the requirements (below) installed. We recommend IntelliJ as an IDE.
+2. Clone the repo
+3. Run the commands in `scripts/postgres-init.sql` in your local postgres instance. You will need to be authenticated to access Vault.
+4. Run `scripts/write-config.sh`
+5. Run `./gradlew bootRun`
+6. Navigate to [http://localhost:8080/#](http://localhost:8080/#)
+
 ### Requirements
 
 This service is written in Java 17, and uses Postgres 13. 

--- a/README.md
+++ b/README.md
@@ -22,22 +22,15 @@ TODO
 
 This codebase is in initial development.
 
-To run locally:
-1. Make sure you have the requirements (below) installed. We recommend IntelliJ as an IDE.
-2. Clone the repo
-3. Run the commands in `scripts/postgres-init.sql` in your local postgres instance. You will need to be authenticated to access Vault.
-4. Run `scripts/write-config.sh`
-5. Run `./gradlew bootRun`
-6. Navigate to [http://localhost:8080/#](http://localhost:8080/#)
-
 ### Requirements
 
-This service is written in Java 17, and uses Postgres 13. 
+This service is written in Java 17, and uses Postgres 13.
 
-To run locally, you'll also need: 
+To run locally, you'll also need:
 - jq - install with `brew install jq`
 - vault - see DSP's setup instructions [here](https://docs.google.com/document/d/11pZE-GqeZFeSOG0UpGg_xyTDQpgBRfr0MLxpxvvQgEw/edit#heading=h.1k9ij99wmle2)
-  - Note that for Step 7, "Create a GitHub Personal Access Token", you'll want to choose the "Tokens (classic)" option, not the fine-grained access token option.
+  - Note that for Step 7, "Create a GitHub Personal Access Token", you'll want to choose
+    the "Tokens (classic)" option, not the fine-grained access token option.
 
 ### Tech stack
 
@@ -47,3 +40,32 @@ To run locally, you'll also need:
 - SonarQube - static code security and coverage
 - Trivy - security scanner for docker images
 - Jib - docker image builder for Java
+
+### Local development
+
+To run locally:
+1. Make sure you have the requirements (below) installed. We recommend IntelliJ as an IDE.
+2. Clone the repo
+3. Run the commands in `scripts/postgres-init.sql` in your local postgres instance. You will need to be authenticated to access Vault.
+4. Run `scripts/write-config.sh`
+5. Run `./gradlew bootRun`
+6. Navigate to [http://localhost:8080/#](http://localhost:8080/#)
+
+### Running SonarQube locally
+
+[SonarQube](https://www.sonarqube.org) is a static analysis code that scans code for a wide
+range of issues, including maintainability and possible bugs. If you get a build failure due to
+SonarQube and want to debug the problem locally, you need to get the sonar token from vault
+before running the gradle task.
+
+```shell
+export SONAR_TOKEN=$(vault read -field=sonar_token secret/secops/ci/sonarcloud/tsps)
+./gradlew sonarqube
+```
+
+Running this task produces no output unless your project has errors. To
+generate a report, run using `--info`:
+
+```shell
+./gradlew sonarqube --info
+```

--- a/scripts/write-config.sh
+++ b/scripts/write-config.sh
@@ -143,7 +143,7 @@ function dovault {
     local dofilename=$2
     case $vaultenv in
         docker)
-            docker run --rm -e VAULT_TOKEN="${vaulttoken}" broadinstitute/dsde-toolbox:consul-0.20.0 \
+            docker run --rm -e VAULT_TOKEN="${vaulttoken}" broadinstitute/dsde-toolbox:dev \
                    vault read -format=json "${dovaultpath}" > "${dofilename}"
             ;;
 

--- a/scripts/write-config.sh
+++ b/scripts/write-config.sh
@@ -50,8 +50,8 @@ Usage: $0 [<target>] [<vaulttoken>] [<outputdir>] [<vaultenv>]"
     help or ? - print this help
     clean - removes all files from the output directory
     * - anything else is assumed to be a personal environment using the terra-kernel-k8s
-  If <target> is not specified, then use the envvar TPS_WRITE_CONFIG
-  If TPS_WRITE_CONFIG is not specified, then use local
+  If <target> is not specified, then use the envvar TSPS_WRITE_CONFIG
+  If TSPS_WRITE_CONFIG is not specified, then use local
 
   <vaulttoken> defaults to the token found in ~/.vault-token.
 
@@ -61,8 +61,8 @@ Usage: $0 [<target>] [<vaulttoken>] [<outputdir>] [<vaultenv>]"
   <vaultenv> can be:
     docker - run a docker image containing vault
     local  - run the vault installed locally
-  If <vaultenv> is not specified, then use the envvar TPS_VAULT_ENV
-  If TPS_VAULT_ENV is not specified, then we use docker
+  If <vaultenv> is not specified, then use the envvar TSPS_VAULT_ENV
+  If TSPS_VAULT_ENV is not specified, then we use docker
 EOF
  exit 1
 }
@@ -70,11 +70,11 @@ EOF
 # Get the inputs with defaulting
 script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." &> /dev/null  && pwd )"
 default_outputdir="${script_dir}/config"
-default_target=${TPS_WRITE_CONFIG:-local}
+default_target=${TSPS_WRITE_CONFIG:-local}
 target=${1:-$default_target}
 vaulttoken=${2:-$(cat "$HOME"/.vault-token)}
 outputdir=${3:-$default_outputdir}
-default_vaultenv=${TPS_VAULT_ENV:-docker}
+default_vaultenv=${TSPS_VAULT_ENV:-docker}
 vaultenv=${4:-$default_vaultenv}
 
 # The vault paths are irregular, so we map the target into three variables:


### PR DESCRIPTION
This PR adds information to the README to help a developer who's new to the project get started. This includes requirements for programs that must be installed on the dev's local machine, as well as instructions for getting the service running locally.

We also needed to update the docker image used to access vault to make it compatible to be run on M1 machines (specifically: use an ARM-compatible build), per a recommendation from DevOps.