### PR TITLE
[TSPS-11] format empty timeCompleted to null in API response

### DIFF
--- a/service/src/main/java/bio/terra/pipelines/App.java
+++ b/service/src/main/java/bio/terra/pipelines/App.java
@@ -1,7 +1,6 @@
 package bio.terra.pipelines;
 
 import bio.terra.common.logging.LoggingInitializer;
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -52,8 +51,7 @@ public class App {
     return new ObjectMapper()
         .registerModule(new ParameterNamesModule())
         .registerModule(new Jdk8Module())
-        .registerModule(new JavaTimeModule())
-        .setDefaultPropertyInclusion(JsonInclude.Include.NON_ABSENT);
+        .registerModule(new JavaTimeModule());
   }
 
   // This bean plus the @EnableTransactionManagement annotation above enables the use of the

--- a/service/src/main/java/bio/terra/pipelines/app/controller/JobsApiController.java
+++ b/service/src/main/java/bio/terra/pipelines/app/controller/JobsApiController.java
@@ -11,8 +11,8 @@ import bio.terra.pipelines.generated.model.ApiPostJobResponse;
 import bio.terra.pipelines.service.JobsService;
 import bio.terra.pipelines.service.model.Job;
 import io.swagger.annotations.Api;
+import java.sql.Timestamp;
 import java.util.List;
-import java.util.Objects;
 import java.util.UUID;
 import javax.servlet.http.HttpServletRequest;
 import org.slf4j.Logger;
@@ -107,7 +107,7 @@ public class JobsApiController implements JobsApi {
         .pipelineId(job.getPipelineId())
         .pipelineVersion(job.getPipelineVersion())
         .timeSubmitted(job.getTimeSubmitted().toString())
-        .timeCompleted(Objects.requireNonNullElse(job.getTimeCompleted(), "").toString())
+        .timeCompleted(job.getTimeCompleted().map(Timestamp::toString).orElse(null))
         .status(job.getStatus());
   }
 


### PR DESCRIPTION
This PR processes the Optional object returned by timeCompleted in the getJob(s) responses into a null rather than a string "Optional.empty"

I edited the objectMapper bean in App.java to remove a line that removes null values from API responses; we prefer to include `"timeCompleted": null` in the response rather than remove the "timeCompleted" field entirely.