### PR TITLE
[TSPS-12] store and return timestamps with UTC timezone

### DIFF
--- a/service/src/main/java/bio/terra/pipelines/app/controller/JobsApiController.java
+++ b/service/src/main/java/bio/terra/pipelines/app/controller/JobsApiController.java
@@ -11,7 +11,7 @@ import bio.terra.pipelines.generated.model.ApiPostJobResponse;
 import bio.terra.pipelines.service.JobsService;
 import bio.terra.pipelines.service.model.Job;
 import io.swagger.annotations.Api;
-import java.sql.Timestamp;
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 import javax.servlet.http.HttpServletRequest;
@@ -107,7 +107,7 @@ public class JobsApiController implements JobsApi {
         .pipelineId(job.getPipelineId())
         .pipelineVersion(job.getPipelineVersion())
         .timeSubmitted(job.getTimeSubmitted().toString())
-        .timeCompleted(job.getTimeCompleted().map(Timestamp::toString).orElse(null))
+        .timeCompleted(job.getTimeCompleted().map(Instant::toString).orElse(null))
         .status(job.getStatus());
   }
 

--- a/service/src/main/java/bio/terra/pipelines/db/DbJob.java
+++ b/service/src/main/java/bio/terra/pipelines/db/DbJob.java
@@ -1,6 +1,6 @@
 package bio.terra.pipelines.db;
 
-import java.sql.Timestamp;
+import java.time.Instant;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -10,6 +10,6 @@ public record DbJob(
     String userId,
     String pipelineId,
     String pipelineVersion,
-    Timestamp timeSubmitted,
-    Optional<Timestamp> timeCompleted,
+    Instant timeSubmitted,
+    Optional<Instant> timeCompleted,
     String status) {}

--- a/service/src/main/java/bio/terra/pipelines/db/JobsDao.java
+++ b/service/src/main/java/bio/terra/pipelines/db/JobsDao.java
@@ -9,6 +9,7 @@ import bio.terra.pipelines.app.configuration.TspsDatabaseConfiguration;
 import bio.terra.pipelines.db.exception.DuplicateObjectException;
 import bio.terra.pipelines.db.exception.JobNotFoundException;
 import bio.terra.pipelines.service.model.Job;
+import java.sql.Timestamp;
 import java.util.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,8 +38,8 @@ public class JobsDao {
               rs.getString("user_id"),
               rs.getString("pipeline_id"),
               rs.getString("pipeline_version"),
-              rs.getTimestamp("time_submitted"),
-              Optional.ofNullable(rs.getTimestamp("time_completed")),
+              rs.getTimestamp("time_submitted").toInstant(),
+              Optional.ofNullable(rs.getTimestamp("time_completed")).map(Timestamp::toInstant),
               rs.getString("status"));
 
   private final NamedParameterJdbcTemplate jdbcTemplate;

--- a/service/src/main/java/bio/terra/pipelines/service/JobsService.java
+++ b/service/src/main/java/bio/terra/pipelines/service/JobsService.java
@@ -2,7 +2,7 @@ package bio.terra.pipelines.service;
 
 import bio.terra.pipelines.db.JobsDao;
 import bio.terra.pipelines.service.model.Job;
-import java.sql.Timestamp;
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 import org.slf4j.Logger;
@@ -42,7 +42,7 @@ public class JobsService {
     pipelinesService.validatePipeline(pipelineId);
 
     UUID jobId = createJobId();
-    Timestamp timeSubmitted = getCurrentTimestamp();
+    Instant timeSubmitted = getCurrentTimestamp();
 
     logger.info("Create new {} version {} job with job_id {}", pipelineId, pipelineVersion, jobId);
 
@@ -59,9 +59,9 @@ public class JobsService {
     return UUID.randomUUID();
   }
 
-  private Timestamp getCurrentTimestamp() {
-    // TODO add time zone - TSPS-12
-    return new Timestamp(System.currentTimeMillis());
+  private Instant getCurrentTimestamp() {
+    // Instant creates a timestamp in UTC
+    return Instant.now();
   }
 
   public List<Job> getJobs(String userId, String pipelineId) {

--- a/service/src/main/java/bio/terra/pipelines/service/model/Job.java
+++ b/service/src/main/java/bio/terra/pipelines/service/model/Job.java
@@ -1,7 +1,7 @@
 package bio.terra.pipelines.service.model;
 
 import bio.terra.pipelines.db.DbJob;
-import java.sql.Timestamp;
+import java.time.Instant;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -10,8 +10,8 @@ public class Job {
   private final String userId;
   private final String pipelineId;
   private final String pipelineVersion;
-  private final Timestamp timeSubmitted;
-  private final Optional<Timestamp> timeCompleted;
+  private final Instant timeSubmitted;
+  private final Optional<Instant> timeCompleted;
   private final String status;
 
   public Job(
@@ -19,8 +19,8 @@ public class Job {
       String userId,
       String pipelineId,
       String pipelineVersion,
-      Timestamp timeSubmitted,
-      Optional<Timestamp> timeCompleted,
+      Instant timeSubmitted,
+      Optional<Instant> timeCompleted,
       String status) {
     this.jobId = jobId;
     this.userId = userId;
@@ -47,11 +47,11 @@ public class Job {
     return pipelineVersion;
   }
 
-  public Timestamp getTimeSubmitted() {
+  public Instant getTimeSubmitted() {
     return timeSubmitted;
   }
 
-  public Optional<Timestamp> getTimeCompleted() {
+  public Optional<Instant> getTimeCompleted() {
     return timeCompleted;
   }
 

--- a/service/src/test/java/bio/terra/pipelines/controller/JobsControllerTest.java
+++ b/service/src/test/java/bio/terra/pipelines/controller/JobsControllerTest.java
@@ -15,7 +15,7 @@ import bio.terra.pipelines.config.SamConfiguration;
 import bio.terra.pipelines.iam.SamService;
 import bio.terra.pipelines.service.JobsService;
 import bio.terra.pipelines.service.model.Job;
-import java.sql.Timestamp;
+import java.time.Instant;
 import java.util.Optional;
 import java.util.UUID;
 import javax.servlet.http.HttpServletRequest;
@@ -46,7 +46,7 @@ class JobsControllerTest {
 
   private String pipelineId = "imputation";
   private String badJobId = "bad_job_id";
-  private Timestamp timestamp = new Timestamp(System.currentTimeMillis());
+  private Instant timestamp = Instant.now();
   private UUID jobIdOkSubmitted = UUID.randomUUID();
   private Job jobOkSubmitted =
       new Job(


### PR DESCRIPTION
this PR ensures that timestamps are stored in UTC and returned by APIs in UTC. we do this by using `Instant` rather than `Timestamp`, as the former enforces UTC. 