### PR TITLE
[TSPS-31] refactor pipelineId check to be called from controller layer

### DIFF
--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -77,6 +77,8 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '403':
           $ref: '#/components/responses/PermissionDenied'
+        '404':
+          $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/NotFound'
 

--- a/service/src/main/java/bio/terra/pipelines/app/controller/JobsApiController.java
+++ b/service/src/main/java/bio/terra/pipelines/app/controller/JobsApiController.java
@@ -9,6 +9,7 @@ import bio.terra.pipelines.generated.model.ApiGetJobsResponse;
 import bio.terra.pipelines.generated.model.ApiPostJobRequestBody;
 import bio.terra.pipelines.generated.model.ApiPostJobResponse;
 import bio.terra.pipelines.service.JobsService;
+import bio.terra.pipelines.service.PipelinesService;
 import bio.terra.pipelines.service.model.Job;
 import io.swagger.annotations.Api;
 import java.time.Instant;
@@ -32,17 +33,20 @@ public class JobsApiController implements JobsApi {
   private final SamUserFactory samUserFactory;
   private final HttpServletRequest request;
   private final JobsService jobsService;
+  private final PipelinesService pipelinesService;
 
   @Autowired
   public JobsApiController(
       SamConfiguration samConfiguration,
       SamUserFactory samUserFactory,
       HttpServletRequest request,
-      JobsService jobsService) {
+      JobsService jobsService,
+      PipelinesService pipelinesService) {
     this.samConfiguration = samConfiguration;
     this.samUserFactory = samUserFactory;
     this.request = request;
     this.jobsService = jobsService;
+    this.pipelinesService = pipelinesService;
   }
 
   private static final Logger logger = LoggerFactory.getLogger(JobsApiController.class);
@@ -59,6 +63,11 @@ public class JobsApiController implements JobsApi {
     final SamUser userRequest = getAuthenticatedInfo();
     String userId = userRequest.getSubjectId();
     String pipelineVersion = body.getPipelineVersion();
+
+    if (!pipelinesService.pipelineExists(pipelineId)) {
+      // TODO configure a reasonable error message (this currently returns only a 404 with no body)
+      return new ResponseEntity<>(null, HttpStatus.NOT_FOUND);
+    }
 
     logger.info(
         "Creating {} pipeline job (version {}) for {} subject {}",

--- a/service/src/main/java/bio/terra/pipelines/app/controller/JobsApiController.java
+++ b/service/src/main/java/bio/terra/pipelines/app/controller/JobsApiController.java
@@ -3,11 +3,9 @@ package bio.terra.pipelines.app.controller;
 import bio.terra.common.iam.SamUser;
 import bio.terra.common.iam.SamUserFactory;
 import bio.terra.pipelines.config.SamConfiguration;
+import bio.terra.pipelines.db.exception.PipelineNotFoundException;
 import bio.terra.pipelines.generated.api.JobsApi;
-import bio.terra.pipelines.generated.model.ApiGetJobResponse;
-import bio.terra.pipelines.generated.model.ApiGetJobsResponse;
-import bio.terra.pipelines.generated.model.ApiPostJobRequestBody;
-import bio.terra.pipelines.generated.model.ApiPostJobResponse;
+import bio.terra.pipelines.generated.model.*;
 import bio.terra.pipelines.service.JobsService;
 import bio.terra.pipelines.service.PipelinesService;
 import bio.terra.pipelines.service.model.Job;
@@ -65,8 +63,8 @@ public class JobsApiController implements JobsApi {
     String pipelineVersion = body.getPipelineVersion();
 
     if (!pipelinesService.pipelineExists(pipelineId)) {
-      // TODO configure a reasonable error message (this currently returns only a 404 with no body)
-      return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+      throw new PipelineNotFoundException(
+          String.format("Requested pipeline %s not found.", pipelineId));
     }
 
     logger.info(

--- a/service/src/main/java/bio/terra/pipelines/app/controller/JobsApiController.java
+++ b/service/src/main/java/bio/terra/pipelines/app/controller/JobsApiController.java
@@ -66,7 +66,7 @@ public class JobsApiController implements JobsApi {
 
     if (!pipelinesService.pipelineExists(pipelineId)) {
       // TODO configure a reasonable error message (this currently returns only a 404 with no body)
-      return new ResponseEntity<>(null, HttpStatus.NOT_FOUND);
+      return new ResponseEntity<>(HttpStatus.NOT_FOUND);
     }
 
     logger.info(

--- a/service/src/main/java/bio/terra/pipelines/service/JobsService.java
+++ b/service/src/main/java/bio/terra/pipelines/service/JobsService.java
@@ -38,9 +38,6 @@ public class JobsService {
    * @see bio.terra.pipelines.service.model.Job
    */
   public UUID createJob(String userId, String pipelineId, String pipelineVersion) {
-    // validate that the requested pipelineId exists
-    pipelinesService.validatePipeline(pipelineId);
-
     UUID jobId = createJobId();
     Instant timeSubmitted = getCurrentTimestamp();
 

--- a/service/src/main/java/bio/terra/pipelines/service/JobsService.java
+++ b/service/src/main/java/bio/terra/pipelines/service/JobsService.java
@@ -17,12 +17,10 @@ public class JobsService {
   private static final Logger logger = LoggerFactory.getLogger(JobsService.class);
 
   private final JobsDao jobsDao;
-  private final PipelinesService pipelinesService;
 
   @Autowired
-  public JobsService(JobsDao jobsDao, PipelinesService pipelinesService) {
+  public JobsService(JobsDao jobsDao) {
     this.jobsDao = jobsDao;
-    this.pipelinesService = pipelinesService;
   }
 
   /**

--- a/service/src/main/java/bio/terra/pipelines/service/PipelinesService.java
+++ b/service/src/main/java/bio/terra/pipelines/service/PipelinesService.java
@@ -1,7 +1,6 @@
 package bio.terra.pipelines.service;
 
 import bio.terra.pipelines.db.PipelinesDao;
-import bio.terra.pipelines.db.exception.PipelineNotFoundException;
 import bio.terra.pipelines.service.model.Pipeline;
 import java.util.List;
 import org.slf4j.Logger;
@@ -26,12 +25,7 @@ public class PipelinesService {
     return pipelinesDao.getPipelines();
   }
 
-  public void validatePipeline(String pipelineId) {
-    logger.info("Validate pipeline");
-
-    boolean pipelineExists = pipelinesDao.checkPipelineExists(pipelineId);
-    if (!pipelineExists) {
-      throw new PipelineNotFoundException(String.format("Pipeline %s not found.", pipelineId));
-    }
+  public boolean pipelineExists(String pipelineId) {
+    return pipelinesDao.checkPipelineExists(pipelineId);
   }
 }

--- a/service/src/test/java/bio/terra/pipelines/controller/JobsControllerTest.java
+++ b/service/src/test/java/bio/terra/pipelines/controller/JobsControllerTest.java
@@ -14,6 +14,7 @@ import bio.terra.pipelines.app.controller.JobsApiController;
 import bio.terra.pipelines.config.SamConfiguration;
 import bio.terra.pipelines.iam.SamService;
 import bio.terra.pipelines.service.JobsService;
+import bio.terra.pipelines.service.PipelinesService;
 import bio.terra.pipelines.service.model.Job;
 import java.time.Instant;
 import java.util.Optional;
@@ -32,6 +33,7 @@ import org.springframework.test.web.servlet.MockMvc;
 @WebMvcTest
 class JobsControllerTest {
   @MockBean JobsService serviceMock;
+  @MockBean PipelinesService pipelinesService;
   @MockBean SamUserFactory samUserFactoryMock;
   @MockBean BearerTokenFactory bearerTokenFactory;
   @MockBean SamConfiguration samConfiguration;

--- a/service/src/test/java/bio/terra/pipelines/service/PipelinesServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/PipelinesServiceTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
 
 import bio.terra.pipelines.db.PipelinesDao;
-import bio.terra.pipelines.db.exception.PipelineNotFoundException;
 import bio.terra.pipelines.testutils.BaseUnitTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,23 +14,20 @@ class PipelinesServiceTest extends BaseUnitTest {
   @MockBean private PipelinesDao mockPipelinesDao;
 
   @Test
-  void testValidatePipeline_exists() {
-    // when validating an existing pipeline, should not throw an error
+  void testPipelineExists_true() {
+    // when validating an existing pipeline, should return true
     String existingPipelineId = "existingPipeline";
     when(mockPipelinesDao.checkPipelineExists(existingPipelineId)).thenReturn(true);
 
-    // no error should be thrown
-    pipelinesService.validatePipeline(existingPipelineId);
+    assertTrue(pipelinesService.pipelineExists(existingPipelineId));
   }
 
   @Test
-  void testValidatePipeline_doesNotExist() {
-    // when validating a non-existing pipeline, should throw a NotFoundException
+  void testPipelineExists_false() {
+    // when validating a non-existing pipeline, should return false
     String notExistingPipelineId = "notExistingPipeline";
     when(mockPipelinesDao.checkPipelineExists(notExistingPipelineId)).thenReturn(false);
 
-    assertThrows(
-        PipelineNotFoundException.class,
-        () -> pipelinesService.validatePipeline(notExistingPipelineId));
+    assertFalse(pipelinesService.pipelineExists(notExistingPipelineId));
   }
 }


### PR DESCRIPTION
This PR:
- changes the PipelinesService method from `validatePipeline()` (throwing an exception if pipelineId not found) to `pipelineExists()` (returning a boolean)
- moves the validation step to call `pipelineExists()` from JobsService to JobsApiController
- updates PipelinesService tests for `validatePipeline()`
- DOES NOT include testing of validation in JobsApiController - this should be added in TSPS-27

Note - we probably want to invoke validatePipeline() in the other pipelines API requests - made TSPS-33 to do that