### PR TITLE
[TSPS-32] convert timeCreated Instant to timestamp before writing to db

### DIFF
--- a/service/src/main/java/bio/terra/pipelines/db/JobsDao.java
+++ b/service/src/main/java/bio/terra/pipelines/db/JobsDao.java
@@ -72,7 +72,7 @@ public class JobsDao {
             .addValue(USER_ID_PARAM, job.getUserId(), VARCHAR)
             .addValue(PIPELINE_ID_PARAM, job.getPipelineId(), VARCHAR)
             .addValue(PIPELINE_VERSION_PARAM, job.getPipelineVersion(), VARCHAR)
-            .addValue(TIME_SUBMITTED_PARAM, job.getTimeSubmitted(), TIMESTAMP)
+            .addValue(TIME_SUBMITTED_PARAM, Timestamp.from(job.getTimeSubmitted()), TIMESTAMP)
             .addValue(STATUS_PARAM, job.getStatus(), VARCHAR);
     try {
       jdbcTemplate.update(sql, params);


### PR DESCRIPTION
this PR converts the Instant class `timeCreated` to a Timestamp before writing to database (in JobsDao)

note this PR does NOT include tests! those should be added for this functionality in TSPS-30.