### PR TITLE
[TSPS-28] add test for getPipelines() in PipelinesService

### DIFF
--- a/service/src/test/java/bio/terra/pipelines/service/PipelinesServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/PipelinesServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.when;
 import bio.terra.pipelines.db.PipelinesDao;
 import bio.terra.pipelines.service.model.Pipeline;
 import bio.terra.pipelines.testutils.BaseUnitTest;
+import bio.terra.pipelines.testutils.MockMvcUtils;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,11 +19,8 @@ class PipelinesServiceTest extends BaseUnitTest {
   @Test
   void testGetPipelines() {
     // getPipelines should return a list of Pipelines
-    Pipeline testPipeline1 =
-        new Pipeline("testPipeline1", "Test Pipeline One", "Test Pipeline One Description");
-    Pipeline testPipeline2 =
-        new Pipeline("testPipeline2", "Test Pipeline Two", "Test Pipeline Two Description");
-    List<Pipeline> pipelinesList = List.of(testPipeline1, testPipeline2);
+    List<Pipeline> pipelinesList =
+        List.of(MockMvcUtils.TEST_PIPELINE_1, MockMvcUtils.TEST_PIPELINE_2);
     when(mockPipelinesDao.getPipelines()).thenReturn(pipelinesList);
 
     List<Pipeline> returnedPipelines = pipelinesService.getPipelines();
@@ -33,7 +31,7 @@ class PipelinesServiceTest extends BaseUnitTest {
   @Test
   void testPipelineExists_true() {
     // when validating an existing pipeline, should return true
-    String existingPipelineId = "existingPipeline";
+    String existingPipelineId = MockMvcUtils.TEST_PIPELINE_ID_1;
     when(mockPipelinesDao.checkPipelineExists(existingPipelineId)).thenReturn(true);
 
     assertTrue(pipelinesService.pipelineExists(existingPipelineId));

--- a/service/src/test/java/bio/terra/pipelines/service/PipelinesServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/PipelinesServiceTest.java
@@ -4,7 +4,9 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
 
 import bio.terra.pipelines.db.PipelinesDao;
+import bio.terra.pipelines.service.model.Pipeline;
 import bio.terra.pipelines.testutils.BaseUnitTest;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -12,6 +14,21 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 class PipelinesServiceTest extends BaseUnitTest {
   @Autowired private PipelinesService pipelinesService;
   @MockBean private PipelinesDao mockPipelinesDao;
+
+  @Test
+  void testGetPipelines() {
+    // getPipelines should return a list of Pipelines
+    Pipeline testPipeline1 =
+        new Pipeline("testPipeline1", "Test Pipeline One", "Test Pipeline One Description");
+    Pipeline testPipeline2 =
+        new Pipeline("testPipeline2", "Test Pipeline Two", "Test Pipeline Two Description");
+    List<Pipeline> pipelinesList = List.of(testPipeline1, testPipeline2);
+    when(mockPipelinesDao.getPipelines()).thenReturn(pipelinesList);
+
+    List<Pipeline> returnedPipelines = pipelinesService.getPipelines();
+    assertEquals(2, returnedPipelines.size());
+    assertTrue(returnedPipelines.containsAll(pipelinesList));
+  }
 
   @Test
   void testPipelineExists_true() {

--- a/service/src/test/java/bio/terra/pipelines/testutils/MockMvcUtils.java
+++ b/service/src/test/java/bio/terra/pipelines/testutils/MockMvcUtils.java
@@ -1,5 +1,6 @@
 package bio.terra.pipelines.testutils;
 
+import bio.terra.pipelines.service.model.Pipeline;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
@@ -21,4 +22,19 @@ public class MockMvcUtils {
       MockHttpServletRequestBuilder request) {
     return request.contentType("application/json");
   }
+
+  // Pipelines test constants
+  public static final String TEST_PIPELINE_ID_1 = "test-pipeline-id-1";
+  public static final String TEST_PIPELINE_NAME_1 = "Test Pipeline Name One";
+  public static final String TEST_PIPELINE_DESCRIPTION_1 = "Test Pipeline Description One";
+  public static final String TEST_PIPELINE_ID_2 = "test-pipeline-id-2";
+  public static final String TEST_PIPELINE_NAME_2 = "Test Pipeline Name Two";
+  public static final String TEST_PIPELINE_DESCRIPTION_2 = "Test Pipeline Description Two";
+  public static final Pipeline TEST_PIPELINE_1 =
+      new Pipeline(TEST_PIPELINE_ID_1, TEST_PIPELINE_NAME_1, TEST_PIPELINE_DESCRIPTION_1);
+  public static final Pipeline TEST_PIPELINE_2 =
+      new Pipeline(TEST_PIPELINE_ID_2, TEST_PIPELINE_NAME_2, TEST_PIPELINE_DESCRIPTION_2);
+
+  public static final String TEST_USER_ID_1 = "test-user-id-1";
+  public static final String TEST_USER_ID_2 = "test-user-id-2";
 }


### PR DESCRIPTION
This PR adds a test for getPipelines() in PipelinesService

In the process, I also refactor some variables to MockMvcUtils that are likely to be reused elsewhere (TSPS-25)