### PR TITLE
[Tsps-30] test coverage for jobs dao

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -61,6 +61,7 @@ dependencies {
         exclude group: 'com.vaadin.external.google', module: 'android-json'
     }
     testImplementation 'org.mockito:mockito-inline'
+    testImplementation 'com.h2database:h2:2.1.214'
 }
 
 test {

--- a/service/src/main/java/bio/terra/pipelines/db/JobsDao.java
+++ b/service/src/main/java/bio/terra/pipelines/db/JobsDao.java
@@ -79,8 +79,10 @@ public class JobsDao {
       logger.info("Inserted record for job {}", jobUuid);
     } catch (DuplicateKeyException e) {
       String message = e.getMessage();
-      if (message != null
-          && message.contains("duplicate key value violates unique constraint \"jobs_pkey\"")) {
+
+      // Check to see if the message contains a reference to a constraint on just the job_id field.
+      // If so, it's the primary key and we can retry it
+      if (message != null && message.toLowerCase().contains("(job_id)")) {
         // Job with job_id already exists.
         // TODO if this happens, JobsService should retry with a new UUID instead. see TSPS-19
         throw new DuplicateObjectException(

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -46,6 +46,7 @@ spring:
 
   liquibase:
     change-log: '/db/changelog.xml'
+    contexts: dev # This line currently does nothing but tell it NOT to pick up the test context, which holds test data
 
   main:
     allow-bean-definition-overriding: true

--- a/service/src/main/resources/db/changelog.xml
+++ b/service/src/main/resources/db/changelog.xml
@@ -5,4 +5,5 @@
 
   <include file="changesets/20221025.yaml" relativeToChangelogFile="true"/>
   <include file="changesets/20221128.yaml" relativeToChangelogFile="true"/>
+  <include file="changesets/20230324-testdata.yaml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/service/src/main/resources/db/changesets/20221025.yaml
+++ b/service/src/main/resources/db/changesets/20221025.yaml
@@ -11,7 +11,7 @@ databaseChangeLog:
             columns:
               - column:
                   name: pipeline_id
-                  type: text
+                  type: varchar(50)
                   constraints:
                     primaryKey: true
                     nullable: false

--- a/service/src/main/resources/db/changesets/20221128.yaml
+++ b/service/src/main/resources/db/changesets/20221128.yaml
@@ -11,7 +11,7 @@ databaseChangeLog:
             columns:
               - column:
                   name: job_id
-                  type: text
+                  type: varchar(50)
                   constraints:
                     primaryKey: true
                     nullable: false

--- a/service/src/main/resources/db/changesets/20230324-testdata.yaml
+++ b/service/src/main/resources/db/changesets/20230324-testdata.yaml
@@ -1,0 +1,31 @@
+# Insert a test job, but only
+databaseChangeLog:
+  - changeSet:
+      id: adding data for unit tests
+      author: ah
+      context: test
+      changes:
+        - insert:
+            columns:
+              - column:
+                  name: job_id
+                  value: deadbeef-dead-beef-deaf-beefdeadbeef
+              - column:
+                  name: user_id
+                  value: testUser
+              - column:
+                  name: status
+                  value: SUBMITTED
+              - column:
+                  name: pipeline_id
+                  value: testPipeline
+              - column:
+                  name: pipeline_version
+                  value: testVersion
+              - column:
+                  name: time_submitted
+                  valueDate: now()
+              - column:
+                  name: pipeline_version
+                  value: testVersion
+            tableName: jobs

--- a/service/src/test/java/bio/terra/pipelines/db/BaseDaoTest.java
+++ b/service/src/test/java/bio/terra/pipelines/db/BaseDaoTest.java
@@ -1,9 +1,22 @@
 package bio.terra.pipelines.db;
 
-import bio.terra.pipelines.BaseSpringBootTest;
-import org.springframework.test.annotation.Rollback;
-import org.springframework.transaction.annotation.Transactional;
+import bio.terra.pipelines.app.StartupInitializer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.jdbc.DataJdbcTest;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.ActiveProfiles;
 
-@Transactional
-@Rollback
-public abstract class BaseDaoTest extends BaseSpringBootTest {}
+@DataJdbcTest(properties = "spring.main.lazy-initialization=true")
+@ActiveProfiles({"test", "human-readable-logging"})
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public abstract class BaseDaoTest {
+  @Autowired ApplicationContext applicationContext;
+
+  //  @BeforeAll
+  @BeforeEach
+  void setupDatabase() {
+    StartupInitializer.initialize(applicationContext);
+  }
+}

--- a/service/src/test/java/bio/terra/pipelines/db/BaseDaoTest.java
+++ b/service/src/test/java/bio/terra/pipelines/db/BaseDaoTest.java
@@ -14,6 +14,12 @@ import org.springframework.test.context.ActiveProfiles;
 public abstract class BaseDaoTest {
   @Autowired ApplicationContext applicationContext;
 
+  // The initialize call kicks off liquibase to rebuild the db.  Ideally, it's done once at the beginning of each set of
+  // tests with the @BeforeAll annotation.  But due to transactions not actually rolling back the data between tests,
+  // I have given it a @BeforeEach so it rebuilds the db between every test.  This is cheap because it's an in-memory
+  // db, so the cost isn't too high.
+  // The @TestInstance(TestInstance.Lifecycle.PER_CLASS) annotation on the class above is to allow the @BeforeAll
+  // annotation to be applied to a non-static class, which is necessary to use the injected ApplicationContext
   //  @BeforeAll
   @BeforeEach
   void setupDatabase() {

--- a/service/src/test/java/bio/terra/pipelines/db/BaseDaoTest.java
+++ b/service/src/test/java/bio/terra/pipelines/db/BaseDaoTest.java
@@ -14,12 +14,14 @@ import org.springframework.test.context.ActiveProfiles;
 public abstract class BaseDaoTest {
   @Autowired ApplicationContext applicationContext;
 
-  // The initialize call kicks off liquibase to rebuild the db.  Ideally, it's done once at the beginning of each set of
-  // tests with the @BeforeAll annotation.  But due to transactions not actually rolling back the data between tests,
-  // I have given it a @BeforeEach so it rebuilds the db between every test.  This is cheap because it's an in-memory
-  // db, so the cost isn't too high.
-  // The @TestInstance(TestInstance.Lifecycle.PER_CLASS) annotation on the class above is to allow the @BeforeAll
-  // annotation to be applied to a non-static class, which is necessary to use the injected ApplicationContext
+  // The initialize call kicks off liquibase to rebuild the db.  Ideally, it's done once at the
+  // beginning of each set of tests with the @BeforeAll annotation.  But due to transactions not
+  // actually rolling back the data between tests, I have given it a @BeforeEach so it rebuilds
+  // the db between every test.  This is cheap because it's an in-memory db, so the cost isn't
+  // too high.
+  // The @TestInstance(TestInstance.Lifecycle.PER_CLASS) annotation on the class above is to
+  // allow the @BeforeAll annotation to be applied to a non-static class, which is necessary
+  // to use the injected ApplicationContext
   //  @BeforeAll
   @BeforeEach
   void setupDatabase() {

--- a/service/src/test/java/bio/terra/pipelines/db/JobsDaoTest.java
+++ b/service/src/test/java/bio/terra/pipelines/db/JobsDaoTest.java
@@ -1,0 +1,30 @@
+package bio.terra.pipelines.db;
+
+import bio.terra.pipelines.service.model.Job;
+import java.time.Instant;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class JobsDaoTest extends BaseDaoTest {
+
+  @Autowired JobsDao jobsDao;
+
+  private final String testUserId = "testUser";
+  private final String testPipelineId = "testPipeline";
+
+  @Test
+  void testWriteJob() {
+    UUID jobId = UUID.randomUUID();
+    Instant timeSubmitted = Instant.now();
+
+    String status = "SUBMITTED";
+    Job jobFull =
+        new Job(jobId, testUserId, testPipelineId, "testVersion", timeSubmitted, null, status);
+    UUID uuidResult = jobsDao.createJob(jobFull);
+
+    assertEquals(jobId, uuidResult);
+  }
+}

--- a/service/src/test/java/bio/terra/pipelines/db/JobsDaoTest.java
+++ b/service/src/test/java/bio/terra/pipelines/db/JobsDaoTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import bio.terra.pipelines.db.exception.DuplicateObjectException;
 import bio.terra.pipelines.service.model.Job;
 import java.time.Instant;
+import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,35 +14,71 @@ class JobsDaoTest extends BaseDaoTest {
 
   @Autowired JobsDao jobsDao;
 
-  private final String testPresentJobId = "deadbeef-dead-beef-deaf-beefdeadbeef";
   private final String testUserId = "testUser";
   private final String testPipelineId = "testPipeline";
 
+  private Job createTestJobWithUUID(UUID jobId) {
+    return createTestJobWithUUIDAndUser(jobId, testUserId);
+  }
+
+  private Job createTestJobWithUUIDAndUser(UUID jobId, String userId) {
+    Instant timeSubmitted = Instant.now();
+    String status = "SUBMITTED";
+    return new Job(jobId, userId, testPipelineId, "testVersion", timeSubmitted, null, status);
+  }
+
   @Test
   void testWriteValidJob() {
-    UUID jobId = UUID.randomUUID();
-    Instant timeSubmitted = Instant.now();
-
-    String status = "SUBMITTED";
-    Job jobFull =
-        new Job(jobId, testUserId, testPipelineId, "testVersion", timeSubmitted, null, status);
-    UUID uuidResult = jobsDao.createJob(jobFull);
+    String testNewJobId = "deadbeef-dead-beef-aaaa-aaaadeadbeef";
+    UUID jobId = UUID.fromString(testNewJobId);
+    Job newJob = createTestJobWithUUID(jobId);
+    UUID uuidResult = jobsDao.createJob(newJob);
 
     assertEquals(jobId, uuidResult);
   }
 
   @Test
   void testWriteDuplicateJob() {
-    // repeating the exact same logic as above, except using a job id that we know is preloaded in the test data
+    // repeating the exact same logic as above, except using a job id that we know is preloaded in
+    // the test data
+    String testPresentJobId = "deadbeef-dead-beef-deaf-beefdeadbeef";
     UUID jobId = UUID.fromString(testPresentJobId);
-    Instant timeSubmitted = Instant.now();
+    Job newJob = createTestJobWithUUID(jobId);
 
-    String status = "SUBMITTED";
-    Job jobFull =
-        new Job(jobId, testUserId, testPipelineId, "testVersion", timeSubmitted, null, status);
-
-    //    List<Job> jobs = jobsDao.getJobs(testUserId, testPipelineId);
-    assertThrows(DuplicateObjectException.class, () -> jobsDao.createJob(jobFull));
+    assertThrows(DuplicateObjectException.class, () -> jobsDao.createJob(newJob));
   }
 
+  @Test
+  void testGetCorrectNumberOfRows() {
+    // A test row should exist for this user.
+    List<Job> jobs = jobsDao.getJobs(testUserId, testPipelineId);
+    assertEquals(1, jobs.size());
+
+    // insert another row and verify that it shows up
+    Job newJob = createTestJobWithUUID(UUID.randomUUID());
+
+    jobsDao.createJob(newJob);
+    jobs = jobsDao.getJobs(testUserId, testPipelineId);
+    assertEquals(2, jobs.size());
+  }
+
+  @Test
+  void testCorrectUserIsolation() {
+    String testUserId2 = "testUser2";
+    // A test row should exist for this user.
+    List<Job> jobs = jobsDao.getJobs(testUserId, testPipelineId);
+    assertEquals(1, jobs.size());
+
+    // insert row for second user and verify that it shows up
+    Job newJob = createTestJobWithUUIDAndUser(UUID.randomUUID(), testUserId2);
+    jobsDao.createJob(newJob);
+
+    // Verify that the old userid still show only 1 record
+    jobs = jobsDao.getJobs(testUserId, testPipelineId);
+    assertEquals(1, jobs.size());
+
+    // Verify the new user's id shows a single job as well
+    jobs = jobsDao.getJobs(testUserId2, testPipelineId);
+    assertEquals(1, jobs.size());
+  }
 }

--- a/service/src/test/java/bio/terra/pipelines/db/JobsDaoTest.java
+++ b/service/src/test/java/bio/terra/pipelines/db/JobsDaoTest.java
@@ -1,10 +1,10 @@
 package bio.terra.pipelines.db;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 import bio.terra.pipelines.service.model.Job;
 import java.time.Instant;
 import java.util.UUID;
-
-import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 

--- a/service/src/test/java/bio/terra/pipelines/db/JobsDaoTest.java
+++ b/service/src/test/java/bio/terra/pipelines/db/JobsDaoTest.java
@@ -64,12 +64,12 @@ class JobsDaoTest extends BaseDaoTest {
 
   @Test
   void testCorrectUserIsolation() {
-    String testUserId2 = "testUser2";
     // A test row should exist for this user.
     List<Job> jobs = jobsDao.getJobs(testUserId, testPipelineId);
     assertEquals(1, jobs.size());
 
     // insert row for second user and verify that it shows up
+    String testUserId2 = "testUser2";
     Job newJob = createTestJobWithUUIDAndUser(UUID.randomUUID(), testUserId2);
     jobsDao.createJob(newJob);
 

--- a/service/src/test/java/bio/terra/pipelines/db/JobsDaoTest.java
+++ b/service/src/test/java/bio/terra/pipelines/db/JobsDaoTest.java
@@ -2,6 +2,7 @@ package bio.terra.pipelines.db;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import bio.terra.pipelines.db.exception.DuplicateObjectException;
 import bio.terra.pipelines.service.model.Job;
 import java.time.Instant;
 import java.util.UUID;
@@ -12,11 +13,12 @@ class JobsDaoTest extends BaseDaoTest {
 
   @Autowired JobsDao jobsDao;
 
+  private final String testPresentJobId = "deadbeef-dead-beef-deaf-beefdeadbeef";
   private final String testUserId = "testUser";
   private final String testPipelineId = "testPipeline";
 
   @Test
-  void testWriteJob() {
+  void testWriteValidJob() {
     UUID jobId = UUID.randomUUID();
     Instant timeSubmitted = Instant.now();
 
@@ -27,4 +29,19 @@ class JobsDaoTest extends BaseDaoTest {
 
     assertEquals(jobId, uuidResult);
   }
+
+  @Test
+  void testWriteDuplicateJob() {
+    // repeating the exact same logic as above, except using a job id that we know is preloaded in the test data
+    UUID jobId = UUID.fromString(testPresentJobId);
+    Instant timeSubmitted = Instant.now();
+
+    String status = "SUBMITTED";
+    Job jobFull =
+        new Job(jobId, testUserId, testPipelineId, "testVersion", timeSubmitted, null, status);
+
+    //    List<Job> jobs = jobsDao.getJobs(testUserId, testPipelineId);
+    assertThrows(DuplicateObjectException.class, () -> jobsDao.createJob(jobFull));
+  }
+
 }

--- a/service/src/test/resources/application-test.yml
+++ b/service/src/test/resources/application-test.yml
@@ -3,3 +3,13 @@ terra.common:
     in-kubernetes: false
   tracing:
     stackdriverExportEnabled: false
+
+# specifying the in-memory db for the "test" profile
+spring:
+  datasource:
+    url: jdbc:h2:mem:mydb
+    username: dbuser
+    password: dbpwd
+    driverClassName: org.h2.Driver
+  jpa:
+    spring.jpa.database-platform: org.hibernate.dialect.H2Dialect

--- a/service/src/test/resources/application-test.yml
+++ b/service/src/test/resources/application-test.yml
@@ -13,3 +13,7 @@ spring:
     driverClassName: org.h2.Driver
   jpa:
     spring.jpa.database-platform: org.hibernate.dialect.H2Dialect
+
+  # this will cause the test row insertion to run
+  liquibase:
+    contexts: test

--- a/service/src/test/resources/application-test.yml
+++ b/service/src/test/resources/application-test.yml
@@ -1,3 +1,12 @@
+env:
+  db:
+    host: jdbc:h2:mem
+    init: ${INIT_DB:false}
+    pipelines:
+      name: ${DATABASE_NAME:pipelines_db}
+      pass: ${DATABASE_USER_PASSWORD:dbpwd}
+      user: ${DATABASE_USER:dbuser}
+
 terra.common:
   kubernetes:
     in-kubernetes: false
@@ -7,9 +16,12 @@ terra.common:
 # specifying the in-memory db for the "test" profile
 spring:
   datasource:
-    url: jdbc:h2:mem:mydb
-    username: dbuser
-    password: dbpwd
+    initializeOnStart: true
+
+    username: ${env.db.pipelines.user}
+    password: ${env.db.pipelines.pass}
+    uri: ${env.db.host}:${env.db.pipelines.name}
+    url: ${env.db.host}:${env.db.pipelines.name}
     driverClassName: org.h2.Driver
   jpa:
     spring.jpa.database-platform: org.hibernate.dialect.H2Dialect


### PR DESCRIPTION
Testing writing records, getting duplicate entry errors, and ensuring that record for different users are properly isolated when we request them.

Also required changing the config some to allow for dao testing.  
Db changes 
- added in hibernate h2 in-memory database to the test config to allow for dao testing that doesn't touch the main db.
- Schema updated for both table to convert primary id to varchar(50) instead of text
- Liquibase now has contexts, allowing it to inserting test rows conditionally.  A new changlog contains jobs rows for testing

JobsDao has been slightly updated.  It now searches for a reference to the primary key "(job_id)" instead of matching on a long block of text, as the exact text varies between databases (and thus between postgres and the h2 instance used in testing)

BaseDaoTest no longer inherits from BaseSpringBootTest.  This allows it to use the narrower SpringBoot "slice" of @DataJdbcTest
- See test slice documentation here: https://docs.spring.io/spring-boot/docs/current/reference/html/test-auto-configuration.html
- this also required explicitly setting lazy initialization so non-Dao beans didn't fail creation
- BaseDao now explicitly initializes the db before every test


TRANSACTIONS ARE STILL BROKEN (???) so BaseDao uses the @BeforeEach annotation instead of the @BeforeAll one on its setup method, causing it to reinitialize the db between every test.  This is pretty cheap because it's an in-memory db, but after many days of debugging I will no longer sink time on this ticket into figuring out why we cannot get transaction rollback to behave properly in our tests.