### PR TITLE
Updating db types

### DIFF
--- a/service/src/main/resources/db/changelog.xml
+++ b/service/src/main/resources/db/changelog.xml
@@ -6,4 +6,5 @@
   <include file="changesets/20221025.yaml" relativeToChangelogFile="true"/>
   <include file="changesets/20221128.yaml" relativeToChangelogFile="true"/>
   <include file="changesets/20230324-testdata.yaml" relativeToChangelogFile="true"/>
+  <include file="changesets/20230427.yaml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/service/src/main/resources/db/changesets/20230427.yaml
+++ b/service/src/main/resources/db/changesets/20230427.yaml
@@ -1,4 +1,4 @@
-# Add jobs table
+# Switch text types to varchar whenever possible
 databaseChangeLog:
   - changeSet:
       id: modifying text column types to varchar

--- a/service/src/main/resources/db/changesets/20230427.yaml
+++ b/service/src/main/resources/db/changesets/20230427.yaml
@@ -1,0 +1,32 @@
+# Add jobs table
+databaseChangeLog:
+  - changeSet:
+      id: modifying text column types to varchar
+      author: ah
+      changes:
+        # jobs table
+        - modifyDataType:
+            tableName: jobs
+            columnName: user_id
+            newDataType: varchar(200)
+        - modifyDataType:
+            tableName: jobs
+            columnName: pipeline_id
+            newDataType: varchar(50)
+        - modifyDataType:
+            tableName: jobs
+            columnName: pipeline_version
+            newDataType: varchar(200)
+        - modifyDataType:
+            tableName: jobs
+            columnName: status
+            newDataType: varchar(1000)
+        # pipelines table
+        - modifyDataType:
+            tableName: pipelines
+            columnName: display_name
+            newDataType: varchar(200)
+        - modifyDataType:
+            tableName: pipelines
+            columnName: description
+            newDataType: varchar(1000)


### PR DESCRIPTION
I got rid of the `text` type in the jobs and pipelines tables.  I used an upper bound of 50 for the main ids, an upper bound of 200 for display names and versions, and a generous upper bound of 1000 for freeform text fields like status and description.  This should give us plenty of room in the fields, and we can always tweak the values later if they cause problems (or trim them down, if we see that they are too generous.