### PR TITLE
TSPS-42 store pipeline_inputs in the jobs table

### DIFF
--- a/service/src/main/java/bio/terra/pipelines/app/controller/JobsApiController.java
+++ b/service/src/main/java/bio/terra/pipelines/app/controller/JobsApiController.java
@@ -80,7 +80,8 @@ public class JobsApiController implements JobsApi {
     // TODO assuming we will write outputs back to source workspace, we will need to check user
     // permissions for write access to the workspace - explore interceptors
 
-    UUID createdJobUuid = jobsService.createJob(userId, pipelineId, pipelineVersion);
+    UUID createdJobUuid =
+        jobsService.createJob(userId, pipelineId, pipelineVersion, pipelineInputs);
     if (createdJobUuid == null) {
       logger.error("New {} pipeline job creation failed.", pipelineId);
       throw new ApiException("An internal error occurred.");

--- a/service/src/main/java/bio/terra/pipelines/db/DbJob.java
+++ b/service/src/main/java/bio/terra/pipelines/db/DbJob.java
@@ -12,4 +12,5 @@ public record DbJob(
     String pipelineVersion,
     Instant timeSubmitted,
     Optional<Instant> timeCompleted,
-    String status) {}
+    String status,
+    Object pipelineInputs) {}

--- a/service/src/main/java/bio/terra/pipelines/service/model/Job.java
+++ b/service/src/main/java/bio/terra/pipelines/service/model/Job.java
@@ -13,6 +13,7 @@ public class Job {
   private final Instant timeSubmitted;
   private final Optional<Instant> timeCompleted;
   private final String status;
+  private final Object pipelineInputs;
 
   public Job(
       UUID jobId,
@@ -21,7 +22,8 @@ public class Job {
       String pipelineVersion,
       Instant timeSubmitted,
       Optional<Instant> timeCompleted,
-      String status) {
+      String status,
+      Object pipelineInputs) {
     this.jobId = jobId;
     this.userId = userId;
     this.pipelineId = pipelineId;
@@ -29,6 +31,7 @@ public class Job {
     this.timeSubmitted = timeSubmitted;
     this.timeCompleted = timeCompleted;
     this.status = status;
+    this.pipelineInputs = pipelineInputs;
   }
 
   public UUID getJobId() {
@@ -59,6 +62,10 @@ public class Job {
     return status;
   }
 
+  public Object getPipelineInputs() {
+    return pipelineInputs;
+  }
+
   public static Job fromDb(DbJob dbJob) {
     return new Job(
         dbJob.jobId(),
@@ -67,6 +74,7 @@ public class Job {
         dbJob.pipelineVersion(),
         dbJob.timeSubmitted(),
         dbJob.timeCompleted(),
-        dbJob.status());
+        dbJob.status(),
+        dbJob.pipelineInputs());
   }
 }

--- a/service/src/main/resources/db/changelog.xml
+++ b/service/src/main/resources/db/changelog.xml
@@ -7,4 +7,5 @@
   <include file="changesets/20221128.yaml" relativeToChangelogFile="true"/>
   <include file="changesets/20230324-testdata.yaml" relativeToChangelogFile="true"/>
   <include file="changesets/20230427.yaml" relativeToChangelogFile="true"/>
+  <include file="changesets/20230523.yaml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/service/src/main/resources/db/changesets/20230523.yaml
+++ b/service/src/main/resources/db/changesets/20230523.yaml
@@ -1,0 +1,15 @@
+# Add pipeline_inputs column to jobs table
+databaseChangeLog:
+  - changeSet:
+      id: add pipeline_inputs column to jobs table
+      author: js
+      changes:
+        - addColumn:
+            tableName: jobs
+            columns:
+              - column:
+                  name: pipeline_inputs
+                  type: text
+                  defaultValue: "{}"
+                  constraints:
+                    nullable: false

--- a/service/src/test/java/bio/terra/pipelines/controller/JobsApiControllerTest.java
+++ b/service/src/test/java/bio/terra/pipelines/controller/JobsApiControllerTest.java
@@ -55,8 +55,10 @@ class JobsApiControllerTest {
 
   private final String pipelineId = "imputation";
   private final String pipelineVersion = "TestVersion";
-  // should be updated once we do more thinking on what this will look like
-  private final Object pipelineInputs = new Object();
+  // Should be updated once we do more thinking on what this will look like with validation. By
+  // default "{}" is parsed into a LinkedHashMap so in order for the mocking to line up I made this
+  // the same. Should definitely be updated.
+  private final Object pipelineInputs = Map.of();
   private final Instant timestamp = Instant.now();
   private final UUID jobIdOkDone = UUID.randomUUID();
   private final UUID secondJobId = UUID.randomUUID();
@@ -68,7 +70,8 @@ class JobsApiControllerTest {
           "v0",
           timestamp,
           Optional.of(timestamp),
-          "COMPLETED");
+          "COMPLETED",
+          pipelineInputs);
   private final Job secondJob =
       new Job(
           secondJobId,
@@ -77,7 +80,8 @@ class JobsApiControllerTest {
           "v0",
           timestamp,
           Optional.of(timestamp),
-          "COMPLETED");
+          "COMPLETED",
+          pipelineInputs);
 
   @BeforeEach
   void beforeEach() {
@@ -125,7 +129,8 @@ class JobsApiControllerTest {
     UUID fakeJobId = UUID.randomUUID();
 
     // the mocks
-    when(jobsServiceMock.createJob(testUser.getSubjectId(), pipelineId, pipelineVersion))
+    when(jobsServiceMock.createJob(
+            testUser.getSubjectId(), pipelineId, pipelineVersion, pipelineInputs))
         .thenReturn(fakeJobId);
     when(pipelinesServiceMock.pipelineExists(pipelineId)).thenReturn(true);
 
@@ -173,7 +178,8 @@ class JobsApiControllerTest {
 
     // the mocks - if createJob repeatedly fails to write to the database, it returns null
     when(pipelinesServiceMock.pipelineExists(pipelineId)).thenReturn(true);
-    when(jobsServiceMock.createJob(testUser.getSubjectId(), pipelineId, pipelineVersion))
+    when(jobsServiceMock.createJob(
+            testUser.getSubjectId(), pipelineId, pipelineVersion, pipelineInputs))
         .thenReturn(null);
 
     mockMvc

--- a/service/src/test/java/bio/terra/pipelines/db/JobsDaoTest.java
+++ b/service/src/test/java/bio/terra/pipelines/db/JobsDaoTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import bio.terra.pipelines.service.model.Job;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,6 +16,7 @@ class JobsDaoTest extends BaseDaoTest {
 
   private final String testUserId = "testUser";
   private final String testPipelineId = "testPipeline";
+  private final Object testPipelineInputs = Map.of("hi", "hello");
 
   private Job createTestJobWithUUID(UUID jobId) {
     return createTestJobWithUUIDAndUser(jobId, testUserId);
@@ -23,7 +25,15 @@ class JobsDaoTest extends BaseDaoTest {
   private Job createTestJobWithUUIDAndUser(UUID jobId, String userId) {
     Instant timeSubmitted = Instant.now();
     String status = "SUBMITTED";
-    return new Job(jobId, userId, testPipelineId, "testVersion", timeSubmitted, null, status);
+    return new Job(
+        jobId,
+        userId,
+        testPipelineId,
+        "testVersion",
+        timeSubmitted,
+        null,
+        status,
+        testPipelineInputs);
   }
 
   @Test
@@ -69,6 +79,8 @@ class JobsDaoTest extends BaseDaoTest {
     // A test row should exist for this user.
     List<Job> jobs = jobsDao.getJobs(testUserId, testPipelineId);
     assertEquals(1, jobs.size());
+    // test default value of pipeline_inputs column
+    assertEquals("{}", jobs.get(0).getPipelineInputs());
 
     // insert row for second user and verify that it shows up
     String testUserId2 = "testUser2";
@@ -82,5 +94,6 @@ class JobsDaoTest extends BaseDaoTest {
     // Verify the new user's id shows a single job as well
     jobs = jobsDao.getJobs(testUserId2, testPipelineId);
     assertEquals(1, jobs.size());
+    assertEquals("{hi=hello}", jobs.get(0).getPipelineInputs());
   }
 }

--- a/service/src/test/java/bio/terra/pipelines/service/JobsServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/JobsServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.*;
 import bio.terra.pipelines.db.JobsDao;
 import bio.terra.pipelines.service.model.Job;
 import bio.terra.pipelines.testutils.BaseUnitTest;
+import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -23,6 +24,8 @@ class JobsServiceTest extends BaseUnitTest {
   private final String testUserId = "testUser";
   private final String testGoodPipelineId = "testGoodPipeline";
   private final String testPipelineVersion = "testPipelineVersion";
+
+  private final Object testPipelineInputs = Map.of();
 
   // We'll need these to configure the dao to return selectively good or bad values
   private final UUID testGoodUUID = UUID.randomUUID();
@@ -55,7 +58,9 @@ class JobsServiceTest extends BaseUnitTest {
     JobsService jobServiceSpy = spy(jobsService);
     doReturn(testGoodUUID).when(jobServiceSpy).createJobId();
 
-    UUID writtenUUID = jobServiceSpy.createJob(testUserId, testGoodPipelineId, testPipelineVersion);
+    UUID writtenUUID =
+        jobServiceSpy.createJob(
+            testUserId, testGoodPipelineId, testPipelineVersion, testPipelineInputs);
     assertEquals(writtenUUID, testGoodUUID);
   }
 
@@ -65,7 +70,8 @@ class JobsServiceTest extends BaseUnitTest {
     JobsService jobServiceSpy = spy(jobsService);
     doReturn(testDuplicateUUID).when(jobServiceSpy).createJobId();
     UUID returnedUUID =
-        jobServiceSpy.createJob(testUserId, testGoodPipelineId, testPipelineVersion);
+        jobServiceSpy.createJob(
+            testUserId, testGoodPipelineId, testPipelineVersion, testPipelineInputs);
 
     assertNull(returnedUUID);
   }
@@ -76,7 +82,8 @@ class JobsServiceTest extends BaseUnitTest {
     JobsService jobServiceSpy = spy(jobsService);
     doReturn(testDuplicateUUID, testGoodUUID).when(jobServiceSpy).createJobId();
     UUID returnedUUID =
-        jobServiceSpy.createJob(testUserId, testGoodPipelineId, testPipelineVersion);
+        jobServiceSpy.createJob(
+            testUserId, testGoodPipelineId, testPipelineVersion, testPipelineInputs);
 
     assertEquals(returnedUUID, testGoodUUID);
   }


### PR DESCRIPTION
Still a bit of weirdness with the testing of the currently amorphous object as the pipeline inputs, having to use linkedmaps in some places as that is the object that naturally comes back from the jobs table query.  The actual jobsdaotest is nice though.

I stored things as a string since I dont think there is any reason we would want to be querying the inputs from the db directly so we dont need jsonb (but definitely let me know if this isnt the case anymore.

some screenshots showing how its stored now to make sure thats what we expect.
<img width="1303" alt="Screenshot 2023-05-24 at 6 11 29 PM" src="https://github.com/DataBiosphere/terra-scientific-pipelines-service/assets/13023616/b90a5c61-677b-4b22-993d-0e10ad10eebb">

<img width="1294" alt="Screenshot 2023-05-24 at 6 02 04 PM" src="https://github.com/DataBiosphere/terra-scientific-pipelines-service/assets/13023616/974dfe84-03d6-40f4-8934-2ac77c161899">

<img width="787" alt="Screenshot 2023-05-24 at 6 09 41 PM" src="https://github.com/DataBiosphere/terra-scientific-pipelines-service/assets/13023616/2081f7e1-a19f-4f01-8cdf-4108fe42c4c2">
