### PR TITLE
TSPS-42 save pipeline inputs to a new table

### DIFF
--- a/service/src/main/java/bio/terra/pipelines/app/controller/JobsApiController.java
+++ b/service/src/main/java/bio/terra/pipelines/app/controller/JobsApiController.java
@@ -80,7 +80,8 @@ public class JobsApiController implements JobsApi {
     // TODO assuming we will write outputs back to source workspace, we will need to check user
     // permissions for write access to the workspace - explore interceptors
 
-    UUID createdJobUuid = jobsService.createJob(userId, pipelineId, pipelineVersion);
+    UUID createdJobUuid =
+        jobsService.createJob(userId, pipelineId, pipelineVersion, pipelineInputs);
     if (createdJobUuid == null) {
       logger.error("New {} pipeline job creation failed.", pipelineId);
       throw new ApiException("An internal error occurred.");
@@ -116,13 +117,13 @@ public class JobsApiController implements JobsApi {
 
   static ApiGetJobResponse jobToApi(Job job) {
     return new ApiGetJobResponse()
-        .jobId(job.getJobId().toString())
-        .userId(job.getUserId())
-        .pipelineId(job.getPipelineId())
-        .pipelineVersion(job.getPipelineVersion())
-        .timeSubmitted(job.getTimeSubmitted().toString())
-        .timeCompleted(job.getTimeCompleted().map(Instant::toString).orElse(null))
-        .status(job.getStatus());
+        .jobId(job.jobId().toString())
+        .userId(job.userId())
+        .pipelineId(job.pipelineId())
+        .pipelineVersion(job.pipelineVersion())
+        .timeSubmitted(job.timeSubmitted().toString())
+        .timeCompleted(job.timeCompleted().map(Instant::toString).orElse(null))
+        .status(job.status());
   }
 
   static ApiGetJobsResponse jobsToApi(List<Job> jobList) {

--- a/service/src/main/java/bio/terra/pipelines/app/controller/PipelinesApiController.java
+++ b/service/src/main/java/bio/terra/pipelines/app/controller/PipelinesApiController.java
@@ -39,9 +39,9 @@ public class PipelinesApiController implements PipelinesApi {
     for (Pipeline pipeline : pipelineList) {
       var apiPipeline =
           new ApiPipeline()
-              .pipelineId(pipeline.getPipelineId())
-              .displayName(pipeline.getDisplayName())
-              .description(pipeline.getDescription());
+              .pipelineId(pipeline.pipelineId())
+              .displayName(pipeline.displayName())
+              .description(pipeline.description());
 
       apiResult.add(apiPipeline);
     }

--- a/service/src/main/java/bio/terra/pipelines/db/DbPipelineInput.java
+++ b/service/src/main/java/bio/terra/pipelines/db/DbPipelineInput.java
@@ -1,0 +1,6 @@
+package bio.terra.pipelines.db;
+
+import java.util.UUID;
+
+/** Record to hold a PipelinesInput record when processing in the JobDao */
+public record DbPipelineInput(UUID jobId, String pipelineInputs) {}

--- a/service/src/main/java/bio/terra/pipelines/service/model/Job.java
+++ b/service/src/main/java/bio/terra/pipelines/service/model/Job.java
@@ -5,59 +5,14 @@ import java.time.Instant;
 import java.util.Optional;
 import java.util.UUID;
 
-public class Job {
-  private final UUID jobId;
-  private final String userId;
-  private final String pipelineId;
-  private final String pipelineVersion;
-  private final Instant timeSubmitted;
-  private final Optional<Instant> timeCompleted;
-  private final String status;
-
-  public Job(
-      UUID jobId,
-      String userId,
-      String pipelineId,
-      String pipelineVersion,
-      Instant timeSubmitted,
-      Optional<Instant> timeCompleted,
-      String status) {
-    this.jobId = jobId;
-    this.userId = userId;
-    this.pipelineId = pipelineId;
-    this.pipelineVersion = pipelineVersion;
-    this.timeSubmitted = timeSubmitted;
-    this.timeCompleted = timeCompleted;
-    this.status = status;
-  }
-
-  public UUID getJobId() {
-    return jobId;
-  }
-
-  public String getUserId() {
-    return userId;
-  }
-
-  public String getPipelineId() {
-    return pipelineId;
-  }
-
-  public String getPipelineVersion() {
-    return pipelineVersion;
-  }
-
-  public Instant getTimeSubmitted() {
-    return timeSubmitted;
-  }
-
-  public Optional<Instant> getTimeCompleted() {
-    return timeCompleted;
-  }
-
-  public String getStatus() {
-    return status;
-  }
+public record Job(
+    UUID jobId,
+    String userId,
+    String pipelineId,
+    String pipelineVersion,
+    Instant timeSubmitted,
+    Optional<Instant> timeCompleted,
+    String status) {
 
   public static Job fromDb(DbJob dbJob) {
     return new Job(

--- a/service/src/main/java/bio/terra/pipelines/service/model/Pipeline.java
+++ b/service/src/main/java/bio/terra/pipelines/service/model/Pipeline.java
@@ -3,28 +3,7 @@ package bio.terra.pipelines.service.model;
 import bio.terra.pipelines.db.DbPipeline;
 import java.util.StringJoiner;
 
-public class Pipeline {
-  private final String pipelineId;
-  private final String displayName;
-  private final String description;
-
-  public Pipeline(String pipelineId, String displayName, String description) {
-    this.pipelineId = pipelineId;
-    this.displayName = displayName;
-    this.description = description;
-  }
-
-  public String getPipelineId() {
-    return pipelineId;
-  }
-
-  public String getDisplayName() {
-    return displayName;
-  }
-
-  public String getDescription() {
-    return description;
-  }
+public record Pipeline(String pipelineId, String displayName, String description) {
 
   @Override
   public String toString() {

--- a/service/src/main/resources/db/changelog.xml
+++ b/service/src/main/resources/db/changelog.xml
@@ -7,4 +7,5 @@
   <include file="changesets/20221128.yaml" relativeToChangelogFile="true"/>
   <include file="changesets/20230324-testdata.yaml" relativeToChangelogFile="true"/>
   <include file="changesets/20230427.yaml" relativeToChangelogFile="true"/>
+  <include file="changesets/20230530.yaml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/service/src/main/resources/db/changesets/20230530.yaml
+++ b/service/src/main/resources/db/changesets/20230530.yaml
@@ -1,0 +1,25 @@
+# Add pipeline_inputs table
+databaseChangeLog:
+  - changeSet:
+      id: add pipeline_inputs table
+      author: js
+      changes:
+        - createTable:
+            tableName: pipeline_inputs
+            remarks: |
+              There is one row in the pipeline_inputs table per job submitted to the service.
+            columns:
+              - column:
+                  name: job_id
+                  type: varchar(50)
+                  constraints:
+                    nullable: false
+                    primaryKey: true
+                    foreignKeyName: pipeline_inputs_job_id_FK
+                    referencedTableName: jobs
+                    referencedColumnNames: job_id
+              - column:
+                  name: pipeline_inputs
+                  type: text
+                  constraints:
+                    nullable: false

--- a/service/src/test/java/bio/terra/pipelines/controller/JobsApiControllerTest.java
+++ b/service/src/test/java/bio/terra/pipelines/controller/JobsApiControllerTest.java
@@ -56,7 +56,7 @@ class JobsApiControllerTest {
   private final String pipelineId = "imputation";
   private final String pipelineVersion = "TestVersion";
   // should be updated once we do more thinking on what this will look like
-  private final Object pipelineInputs = new Object();
+  private final Object pipelineInputs = Map.of();
   private final Instant timestamp = Instant.now();
   private final UUID jobIdOkDone = UUID.randomUUID();
   private final UUID secondJobId = UUID.randomUUID();
@@ -125,7 +125,8 @@ class JobsApiControllerTest {
     UUID fakeJobId = UUID.randomUUID();
 
     // the mocks
-    when(jobsServiceMock.createJob(testUser.getSubjectId(), pipelineId, pipelineVersion))
+    when(jobsServiceMock.createJob(
+            testUser.getSubjectId(), pipelineId, pipelineVersion, pipelineInputs))
         .thenReturn(fakeJobId);
     when(pipelinesServiceMock.pipelineExists(pipelineId)).thenReturn(true);
 
@@ -173,7 +174,8 @@ class JobsApiControllerTest {
 
     // the mocks - if createJob repeatedly fails to write to the database, it returns null
     when(pipelinesServiceMock.pipelineExists(pipelineId)).thenReturn(true);
-    when(jobsServiceMock.createJob(testUser.getSubjectId(), pipelineId, pipelineVersion))
+    when(jobsServiceMock.createJob(
+            testUser.getSubjectId(), pipelineId, pipelineVersion, pipelineInputs))
         .thenReturn(null);
 
     mockMvc
@@ -211,7 +213,7 @@ class JobsApiControllerTest {
 
     // The ids should all match what was returned from jobsServiceMock
     for (int i = 0; i < response.size(); ++i) {
-      String rawJobId = bothJobs.get(i).getJobId().toString();
+      String rawJobId = bothJobs.get(i).jobId().toString();
       String responseJobId = response.get(i).getJobId();
       assertEquals(rawJobId, responseJobId);
     }

--- a/service/src/test/java/bio/terra/pipelines/db/PipelinesDaoTest.java
+++ b/service/src/test/java/bio/terra/pipelines/db/PipelinesDaoTest.java
@@ -18,9 +18,9 @@ class PipelinesDaoTest extends BaseDaoTest {
     assertEquals(retrievedPipelines.size(), nTotalPipelines);
 
     for (Pipeline pipeline : retrievedPipelines) {
-      assertNotNull(pipeline.getPipelineId());
-      assertNotNull(pipeline.getDisplayName());
-      assertNotNull(pipeline.getDescription());
+      assertNotNull(pipeline.pipelineId());
+      assertNotNull(pipeline.displayName());
+      assertNotNull(pipeline.description());
     }
   }
 

--- a/service/src/test/java/bio/terra/pipelines/service/JobsServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/JobsServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.*;
 import bio.terra.pipelines.db.JobsDao;
 import bio.terra.pipelines.service.model.Job;
 import bio.terra.pipelines.testutils.BaseUnitTest;
+import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -23,6 +24,7 @@ class JobsServiceTest extends BaseUnitTest {
   private final String testUserId = "testUser";
   private final String testGoodPipelineId = "testGoodPipeline";
   private final String testPipelineVersion = "testPipelineVersion";
+  private final Object pipelineInputs = Map.of();
 
   // We'll need these to configure the dao to return selectively good or bad values
   private final UUID testGoodUUID = UUID.randomUUID();
@@ -32,13 +34,14 @@ class JobsServiceTest extends BaseUnitTest {
   void initMocks() {
     // dao returns null on job containing duplicate id and returns good uuid on job containing good
     // uuid
-    when(jobsDao.createJob(argThat((Job j) -> j.getJobId() == testDuplicateUUID))).thenReturn(null);
+    when(jobsDao.createJob(argThat((Job j) -> j.jobId() == testDuplicateUUID), any()))
+        .thenReturn(null);
     // doReturn is the necessary syntax after an exception-stubbed method.
     // See:
     // https://javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/Mockito.html#doReturn(java.lang.Object)
     doReturn(testGoodUUID)
         .when(jobsDao)
-        .createJob(argThat((Job j) -> j.getJobId() == testGoodUUID));
+        .createJob(argThat((Job j) -> j.jobId() == testGoodUUID), any());
   }
 
   // JobsService.createJob has 3 pieces of business logic to check.
@@ -55,7 +58,9 @@ class JobsServiceTest extends BaseUnitTest {
     JobsService jobServiceSpy = spy(jobsService);
     doReturn(testGoodUUID).when(jobServiceSpy).createJobId();
 
-    UUID writtenUUID = jobServiceSpy.createJob(testUserId, testGoodPipelineId, testPipelineVersion);
+    UUID writtenUUID =
+        jobServiceSpy.createJob(
+            testUserId, testGoodPipelineId, testPipelineVersion, pipelineInputs);
     assertEquals(writtenUUID, testGoodUUID);
   }
 
@@ -65,7 +70,8 @@ class JobsServiceTest extends BaseUnitTest {
     JobsService jobServiceSpy = spy(jobsService);
     doReturn(testDuplicateUUID).when(jobServiceSpy).createJobId();
     UUID returnedUUID =
-        jobServiceSpy.createJob(testUserId, testGoodPipelineId, testPipelineVersion);
+        jobServiceSpy.createJob(
+            testUserId, testGoodPipelineId, testPipelineVersion, pipelineInputs);
 
     assertNull(returnedUUID);
   }
@@ -76,7 +82,8 @@ class JobsServiceTest extends BaseUnitTest {
     JobsService jobServiceSpy = spy(jobsService);
     doReturn(testDuplicateUUID, testGoodUUID).when(jobServiceSpy).createJobId();
     UUID returnedUUID =
-        jobServiceSpy.createJob(testUserId, testGoodPipelineId, testPipelineVersion);
+        jobServiceSpy.createJob(
+            testUserId, testGoodPipelineId, testPipelineVersion, pipelineInputs);
 
     assertEquals(returnedUUID, testGoodUUID);
   }


### PR DESCRIPTION
created a new table, pipeline_inputs, that is used to save the pipeline inputs provided through the api.  for now storing inputs as a string as we dont expect to need to parse the inputs directly through the database which would make jsonb the more correct solution.

screenshots showing requests and subsequent database store

![Screenshot 2023-05-31 at 12 17 53 PM](https://github.com/DataBiosphere/terra-scientific-pipelines-service/assets/13023616/97fba1c4-e67e-4934-97cc-60365a67b790)

<img width="761" alt="Screenshot 2023-05-31 at 12 18 59 PM" src="https://github.com/DataBiosphere/terra-scientific-pipelines-service/assets/13023616/ebc1da97-c99b-4d93-b26d-05782ac09cd2">
