### PR TITLE
[TSPS-97] Update tag-publish workflow to publish container images from PRs

### DIFF
--- a/.github/workflows/tag-publish.yml
+++ b/.github/workflows/tag-publish.yml
@@ -26,6 +26,12 @@ on:
       - 'README.md'
       - '.github/**'
       - 'local-dev/**'
+  # TODO - uncomment when ready to test
+  # pull_request:
+  #   paths-ignore:
+  #     - 'README.md'
+  #     - '.github/**'
+  #     - 'local-dev/**'
   workflow_dispatch:
     inputs:
       bump:
@@ -124,6 +130,7 @@ jobs:
 
       # Publish client to artifactory
       - name: Publish to Artifactory
+        if: ${{ github.event_name != 'pull_request }}
         run: ./gradlew :client:artifactoryPublish --scan
         env:
           ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
@@ -159,6 +166,7 @@ jobs:
         run: docker push ${{ steps.image-name.outputs.name }}
 
       - name: Make release
+        if: ${{ github.event_name != 'pull_request }}
         uses: ncipollo/release-action@v1
         id: create_release
         with:
@@ -193,7 +201,7 @@ jobs:
     # Put new TSPS version in Broad dev environment
     uses: broadinstitute/sherlock/.github/workflows/client-set-environment-app-version.yaml@main
     needs: [ bump-check, tag-publish-docker-deploy, report-to-sherlock ]
-    if: ${{ needs.bump-check.outputs.is-bump == 'no' }}
+    if: ${{ needs.bump-check.outputs.is-bump == 'no' && github.event_name != 'pull_request }}
     with:
       new-version: ${{ needs.tag-publish-docker-deploy.outputs.tag }}
       chart-name: 'tsps'

--- a/.github/workflows/tag-publish.yml
+++ b/.github/workflows/tag-publish.yml
@@ -26,12 +26,11 @@ on:
       - 'README.md'
       - '.github/**'
       - 'local-dev/**'
-  # TODO - uncomment when ready to test
-  # pull_request:
-  #   paths-ignore:
-  #     - 'README.md'
-  #     - '.github/**'
-  #     - 'local-dev/**'
+  pull_request:
+    paths-ignore:
+      - 'README.md'
+      - '.github/**'
+      - 'local-dev/**'
   workflow_dispatch:
     inputs:
       bump:

--- a/.github/workflows/tag-publish.yml
+++ b/.github/workflows/tag-publish.yml
@@ -130,7 +130,7 @@ jobs:
 
       # Publish client to artifactory
       - name: Publish to Artifactory
-        if: ${{ github.event_name != 'pull_request }}
+        if: ${{ github.event_name != 'pull_request' }}
         run: ./gradlew :client:artifactoryPublish --scan
         env:
           ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
@@ -166,7 +166,7 @@ jobs:
         run: docker push ${{ steps.image-name.outputs.name }}
 
       - name: Make release
-        if: ${{ github.event_name != 'pull_request }}
+        if: ${{ github.event_name != 'pull_request' }}
         uses: ncipollo/release-action@v1
         id: create_release
         with:
@@ -201,7 +201,7 @@ jobs:
     # Put new TSPS version in Broad dev environment
     uses: broadinstitute/sherlock/.github/workflows/client-set-environment-app-version.yaml@main
     needs: [ bump-check, tag-publish-docker-deploy, report-to-sherlock ]
-    if: ${{ needs.bump-check.outputs.is-bump == 'no' && github.event_name != 'pull_request }}
+    if: ${{ needs.bump-check.outputs.is-bump == 'no' && github.event_name != 'pull_request' }}
     with:
       new-version: ${{ needs.tag-publish-docker-deploy.outputs.tag }}
       chart-name: 'tsps'

--- a/.github/workflows/tag-publish.yml
+++ b/.github/workflows/tag-publish.yml
@@ -29,7 +29,7 @@ on:
   pull_request:
     paths-ignore:
       - 'README.md'
-      # - '.github/**' # TODO - uncomment before merging
+      - '.github/**'
       - 'local-dev/**'
   workflow_dispatch:
     inputs:

--- a/.github/workflows/tag-publish.yml
+++ b/.github/workflows/tag-publish.yml
@@ -29,7 +29,7 @@ on:
   pull_request:
     paths-ignore:
       - 'README.md'
-      - '.github/**'
+      # - '.github/**' # TODO - uncomment before merging
       - 'local-dev/**'
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Update TSPS's tag-publish workflow to publish container images from PRs, and also report them to Sherlock. This will allow TSPS devs to leverage Beehive's "deploy from a PR branch feature".

PR container image versions will consist of the next semver, suffixed with the git commit. (eg. `1.2.3-5e99528`).

### Testing

I've successfully deployed images from this PR to my BEE (version `0.0.37-143e6b2` was built in [this GHA run]


<img width="1037" alt="Screenshot 2023-11-13 at 2 10 35 PM" src="https://github.com/DataBiosphere/terra-scientific-pipelines-service/assets/60902147/0b48316b-43a5-42b4-bc3f-318d4b71fb0e">
<img width="1347" alt="Screenshot 2023-11-13 at 2 04 12 PM" src="https://github.com/DataBiosphere/terra-scientific-pipelines-service/assets/60902147/372600c0-580c-4de2-bdb4-0ec63e1744b8">
