### PR TITLE
TSPS-100 add logic to use service account credentials when talking to leonardo

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,15 @@ To run locally:
 1. Make sure you have the requirements installed from above. We recommend IntelliJ as an IDE.
 2. Clone the repo (if you see broken inputs build the project to get the generated sources)
 3. Run the commands in `scripts/postgres-init.sql` in your local postgres instance. You will need to be authenticated to access Vault.
-4. Run `scripts/write-config.sh`
-5. Run `./gradlew bootRun`
+4. Run `scripts/write-config.sh`.  Be sure to follow instructions from output, especially setting the GOOGLE_APPLICATION_CREDENTIALS environment variable
+5. Run `./gradlew bootRun` to spin of the server.
 6. Navigate to [http://localhost:8080/#](http://localhost:8080/#)
+
+#### Local development with debugging
+If using Intellij (only IDE we use on the team), you can run the server with a debugger. Follow
+the steps above but instead of running `./gradlew bootRun` to spin up the server, you can run
+(debug) the App.java class through intellij and set breakpoints in the code.  Be sure to set the
+GOOGLE_APPLICATION_CREDENTIALS in the Run/Debug configuration.
 
 ### Running Tests/Linter Locally
 - Testing

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ To run locally:
 If using Intellij (only IDE we use on the team), you can run the server with a debugger. Follow
 the steps above but instead of running `./gradlew bootRun` to spin up the server, you can run
 (debug) the App.java class through intellij and set breakpoints in the code.  Be sure to set the
-GOOGLE_APPLICATION_CREDENTIALS in the Run/Debug configuration.
+GOOGLE_APPLICATION_CREDENTIALS=config/tsps-sa.json in the Run/Debug configuration Environment Variables.
 
 ### Running Tests/Linter Locally
 - Testing

--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ To run locally:
 1. Make sure you have the requirements installed from above. We recommend IntelliJ as an IDE.
 2. Clone the repo (if you see broken inputs build the project to get the generated sources)
 3. Run the commands in `scripts/postgres-init.sql` in your local postgres instance. You will need to be authenticated to access Vault.
-4. Run `scripts/write-config.sh`.  Be sure to follow instructions from output, especially setting the GOOGLE_APPLICATION_CREDENTIALS environment variable
-5. Run `./gradlew bootRun` to spin of the server.
+4. Run `scripts/write-config.sh`
+5. Run `./gradlew bootRun` to spin up the server.
 6. Navigate to [http://localhost:8080/#](http://localhost:8080/#)
 
 #### Local development with debugging

--- a/scripts/write-config.sh
+++ b/scripts/write-config.sh
@@ -91,7 +91,7 @@ case $target in
         ;;
 
     local)
-        # for local development we will use the QA environemnt stuff for now to mimic our BEEs
+        # for local development we will use the QA environment stuff for now to mimic our BEEs
         fcenv=qa
         ;;
 

--- a/scripts/write-config.sh
+++ b/scripts/write-config.sh
@@ -179,10 +179,8 @@ function vaultgetdb {
     jq -r '.username' "${datafile}" > "${outputdir}/${fileprefix}-username.txt"
 }
 
+# grab tsps service account json from vault
 vaultget "secret/dsde/firecloud/${fcenv}/tsps/tsps-account.json" "${outputdir}/tsps-sa.json"
-echo "Run
-GOOGLE_APPLICATION_CREDENTIALS='${outputdir}/tsps-sa.json'
-to set the GOOGLE_APPLICATION_CREDENTIALS environment variable"
 
 # We made it to the end, so record the target and avoid redos
 echo "$target" > "${outputdir}/target.txt"

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -33,21 +33,25 @@ dependencies {
 
     implementation 'bio.terra:terra-common-lib'
     implementation 'org.apache.commons:commons-dbcp2:2.9.0'
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa:2.7.0'
-    implementation 'org.springframework.boot:spring-boot-starter-web:2.7.0'
-    implementation 'org.springframework.retry:spring-retry:1.3.4'
-
-    implementation 'org.broadinstitute.dsde.workbench:sam-client_2.12:0.1-61135c7'
-    implementation "org.broadinstitute.dsde.workbench:leonardo-client_2.13:1.3.6-66d9fcf"
     implementation 'javax.ws.rs:javax.ws.rs-api:2.1.1'
     implementation 'org.postgresql:postgresql:42.3.3'
     implementation 'javax.servlet:jstl:1.2'
-    implementation 'org.springframework.boot:spring-boot-starter-validation'
-    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
-
+    implementation 'com.google.auth:google-auth-library-oauth2-http:1.6.0'
     // https://projectlombok.org
     compileOnly 'org.projectlombok:lombok:1.18.20'
     annotationProcessor 'org.projectlombok:lombok:1.18.20'
+
+
+    // spring boot related dependencies
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa:2.7.0'
+    implementation 'org.springframework.boot:spring-boot-starter-web:2.7.0'
+    implementation 'org.springframework.retry:spring-retry:1.3.4'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+
+    // terra clients
+    implementation 'org.broadinstitute.dsde.workbench:sam-client_2.12:0.1-61135c7'
+    implementation "org.broadinstitute.dsde.workbench:leonardo-client_2.13:1.3.6-66d9fcf"
 
     liquibaseRuntime 'org.liquibase:liquibase-core:3.10.0'
     liquibaseRuntime 'info.picocli:picocli:4.6.1'

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -77,10 +77,15 @@ dependencies {
     testImplementation 'org.testcontainers:postgresql:1.17.3'
 
 }
-// set environment variable for google default credentials when running bootRun
+// workaround for local development
+// set GOOGLE_APPLICATION_CREDENTIALS if this file exists - should only exist when
+// write-config.sh is run.
+// GOOGLE_APPLICATION_CREDENTIALS is set for us when running in a deployed environment
 def googleCredentialsFile = "${rootDir}/config/tsps-sa.json"
 bootRun {
-    environment.put("GOOGLE_APPLICATION_CREDENTIALS", "${googleCredentialsFile}")
+    if(project.file(googleCredentialsFile).exists()) {
+        environment.put("GOOGLE_APPLICATION_CREDENTIALS", "${googleCredentialsFile}")
+    }
 }
 
 test {

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -77,6 +77,11 @@ dependencies {
     testImplementation 'org.testcontainers:postgresql:1.17.3'
 
 }
+// set environment variable for google default credentials when running bootRun
+def googleCredentialsFile = "${rootDir}/config/tsps-sa.json"
+bootRun {
+    environment.put("GOOGLE_APPLICATION_CREDENTIALS", "${googleCredentialsFile}")
+}
 
 test {
     useJUnitPlatform ()

--- a/service/src/main/java/bio/terra/pipelines/app/controller/JobsApiController.java
+++ b/service/src/main/java/bio/terra/pipelines/app/controller/JobsApiController.java
@@ -8,6 +8,7 @@ import bio.terra.pipelines.db.entities.Job;
 import bio.terra.pipelines.db.exception.PipelineNotFoundException;
 import bio.terra.pipelines.generated.api.JobsApi;
 import bio.terra.pipelines.generated.model.*;
+import bio.terra.pipelines.service.ImputationService;
 import bio.terra.pipelines.service.JobsService;
 import bio.terra.pipelines.service.PipelinesService;
 import io.swagger.annotations.Api;
@@ -32,6 +33,7 @@ public class JobsApiController implements JobsApi {
   private final HttpServletRequest request;
   private final JobsService jobsService;
   private final PipelinesService pipelinesService;
+  private final ImputationService imputationService;
 
   @Autowired
   public JobsApiController(
@@ -39,12 +41,14 @@ public class JobsApiController implements JobsApi {
       SamUserFactory samUserFactory,
       HttpServletRequest request,
       JobsService jobsService,
-      PipelinesService pipelinesService) {
+      PipelinesService pipelinesService,
+      ImputationService imputationService) {
     this.samConfiguration = samConfiguration;
     this.samUserFactory = samUserFactory;
     this.request = request;
     this.jobsService = jobsService;
     this.pipelinesService = pipelinesService;
+    this.imputationService = imputationService;
   }
 
   private static final Logger logger = LoggerFactory.getLogger(JobsApiController.class);
@@ -85,6 +89,10 @@ public class JobsApiController implements JobsApi {
       logger.error("New {} pipeline job creation failed.", pipelineId);
       throw new ApiException("An internal error occurred.");
     }
+
+    // eventually we'll expand this out to kick off the imputation pipeline flight but for
+    // now this is good enough.
+    imputationService.queryForWorkspaceApps();
 
     ApiPostJobResponse createdJobResponse = new ApiPostJobResponse();
     createdJobResponse.setJobId(createdJobUuid.toString());

--- a/service/src/main/java/bio/terra/pipelines/dependencies/leonardo/LeonardoService.java
+++ b/service/src/main/java/bio/terra/pipelines/dependencies/leonardo/LeonardoService.java
@@ -22,7 +22,7 @@ public class LeonardoService implements HealthCheck {
     this.leonardoClient = leonardoClient;
     this.listenerResetRetryTemplate = listenerResetRetryTemplate;
   }
-  
+
   AppsApi getAppsApi(String authToken) {
     return new AppsApi(leonardoClient.getApiClient(authToken));
   }

--- a/service/src/main/java/bio/terra/pipelines/dependencies/leonardo/LeonardoService.java
+++ b/service/src/main/java/bio/terra/pipelines/dependencies/leonardo/LeonardoService.java
@@ -1,6 +1,5 @@
 package bio.terra.pipelines.dependencies.leonardo;
 
-import bio.terra.common.iam.BearerToken;
 import bio.terra.pipelines.dependencies.common.HealthCheck;
 import java.util.List;
 import org.broadinstitute.dsde.workbench.client.leonardo.ApiException;
@@ -16,23 +15,18 @@ import org.springframework.stereotype.Service;
 public class LeonardoService implements HealthCheck {
 
   private final LeonardoClient leonardoClient;
-  private final BearerToken bearerToken;
   private final RetryTemplate listenerResetRetryTemplate;
 
   @Autowired
-  public LeonardoService(
-      LeonardoClient leonardoClient,
-      RetryTemplate listenerResetRetryTemplate,
-      BearerToken bearerToken) {
+  public LeonardoService(LeonardoClient leonardoClient, RetryTemplate listenerResetRetryTemplate) {
     this.leonardoClient = leonardoClient;
     this.listenerResetRetryTemplate = listenerResetRetryTemplate;
-    this.bearerToken = bearerToken;
   }
 
   // this will need to be reworked to use the service account credentials instead of the user who
   // made the request
-  AppsApi getAppsApi() {
-    return new AppsApi(leonardoClient.getApiClient(bearerToken.getToken()));
+  AppsApi getAppsApi(String authToken) {
+    return new AppsApi(leonardoClient.getApiClient(authToken));
   }
 
   ServiceInfoApi getServiceInfoApi() {
@@ -40,12 +34,13 @@ public class LeonardoService implements HealthCheck {
   }
 
   /** grab app information for a workspace id */
-  public List<ListAppResponse> getApps(String workspaceId, boolean creatorOnly)
+  public List<ListAppResponse> getApps(String workspaceId, String authToken, boolean creatorOnly)
       throws LeonardoServiceException {
     String creatorRoleSpecifier = creatorOnly ? "creator" : null;
     return executionWithRetryTemplate(
         listenerResetRetryTemplate,
-        () -> getAppsApi().listAppsV2(workspaceId, null, null, null, creatorRoleSpecifier));
+        () ->
+            getAppsApi(authToken).listAppsV2(workspaceId, null, null, null, creatorRoleSpecifier));
   }
 
   @Override

--- a/service/src/main/java/bio/terra/pipelines/dependencies/leonardo/LeonardoService.java
+++ b/service/src/main/java/bio/terra/pipelines/dependencies/leonardo/LeonardoService.java
@@ -22,9 +22,7 @@ public class LeonardoService implements HealthCheck {
     this.leonardoClient = leonardoClient;
     this.listenerResetRetryTemplate = listenerResetRetryTemplate;
   }
-
-  // this will need to be reworked to use the service account credentials instead of the user who
-  // made the request
+  
   AppsApi getAppsApi(String authToken) {
     return new AppsApi(leonardoClient.getApiClient(authToken));
   }

--- a/service/src/main/java/bio/terra/pipelines/dependencies/sam/SamService.java
+++ b/service/src/main/java/bio/terra/pipelines/dependencies/sam/SamService.java
@@ -7,7 +7,6 @@ import bio.terra.common.sam.exception.SamExceptionFactory;
 import bio.terra.pipelines.dependencies.common.HealthCheck;
 import bio.terra.pipelines.generated.model.ApiSystemStatusSystems;
 import com.google.auth.oauth2.GoogleCredentials;
-import com.google.common.collect.ImmutableSet;
 import java.io.IOException;
 import java.util.Set;
 import org.broadinstitute.dsde.workbench.client.sam.ApiException;
@@ -20,7 +19,7 @@ import org.springframework.stereotype.Component;
 /** Encapsulates logic for interacting with SAM */
 @Component
 public class SamService implements HealthCheck {
-  private static final Set<String> SAM_OAUTH_SCOPES = ImmutableSet.of("openid", "email", "profile");
+  private static final Set<String> SAM_OAUTH_SCOPES = Set.of("openid", "email", "profile");
   private static final Logger logger = LoggerFactory.getLogger(SamService.class);
   private final SamClient samClient;
 

--- a/service/src/main/java/bio/terra/pipelines/dependencies/sam/SamService.java
+++ b/service/src/main/java/bio/terra/pipelines/dependencies/sam/SamService.java
@@ -1,10 +1,15 @@
 package bio.terra.pipelines.dependencies.sam;
 
+import bio.terra.common.exception.InternalServerErrorException;
 import bio.terra.common.iam.BearerToken;
 import bio.terra.common.sam.SamRetry;
 import bio.terra.common.sam.exception.SamExceptionFactory;
 import bio.terra.pipelines.dependencies.common.HealthCheck;
 import bio.terra.pipelines.generated.model.ApiSystemStatusSystems;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.common.collect.ImmutableSet;
+import java.io.IOException;
+import java.util.Set;
 import org.broadinstitute.dsde.workbench.client.sam.ApiException;
 import org.broadinstitute.dsde.workbench.client.sam.model.SystemStatus;
 import org.slf4j.Logger;
@@ -12,8 +17,10 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+/** Encapsulates logic for interacting with SAM */
 @Component
 public class SamService implements HealthCheck {
+  private static final Set<String> SAM_OAUTH_SCOPES = ImmutableSet.of("openid", "email", "profile");
   private static final Logger logger = LoggerFactory.getLogger(SamService.class);
   private final SamClient samClient;
 
@@ -55,5 +62,17 @@ public class SamService implements HealthCheck {
     return new ApiSystemStatusSystems()
         .ok(healthResult.isOk())
         .addMessagesItem(healthResult.message());
+  }
+
+  public String getTspsServiceAccountToken() {
+    try {
+      GoogleCredentials creds =
+          GoogleCredentials.getApplicationDefault().createScoped(SAM_OAUTH_SCOPES);
+      creds.refreshIfExpired();
+      return creds.getAccessToken().getTokenValue();
+    } catch (IOException e) {
+      throw new InternalServerErrorException(
+          "Internal server error retrieving TSPS credentials", e);
+    }
   }
 }

--- a/service/src/main/java/bio/terra/pipelines/retry/RetryLoggingListener.java
+++ b/service/src/main/java/bio/terra/pipelines/retry/RetryLoggingListener.java
@@ -36,7 +36,7 @@ public class RetryLoggingListener implements RetryListener {
   @Override
   public <T, E extends Throwable> void onError(
       RetryContext context, RetryCallback<T, E> callback, Throwable throwable) {
-    logger.warn(
+    logger.error(
         "Retryable method threw exception (retry count: {})", context.getRetryCount(), throwable);
   }
 }

--- a/service/src/main/java/bio/terra/pipelines/service/ImputationService.java
+++ b/service/src/main/java/bio/terra/pipelines/service/ImputationService.java
@@ -1,0 +1,51 @@
+package bio.terra.pipelines.service;
+
+import bio.terra.pipelines.app.configuration.internal.ImputationConfiguration;
+import bio.terra.pipelines.dependencies.leonardo.LeonardoService;
+import bio.terra.pipelines.dependencies.leonardo.LeonardoServiceException;
+import bio.terra.pipelines.dependencies.sam.SamService;
+import java.util.List;
+import org.broadinstitute.dsde.workbench.client.leonardo.model.ListAppResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+/** Service to encapsulate logic used to run an imputation pipeline */
+@Service
+public class ImputationService {
+  private static final Logger logger = LoggerFactory.getLogger(ImputationService.class);
+  private LeonardoService leonardoService;
+  private SamService samService;
+  private ImputationConfiguration imputationConfiguration;
+
+  @Autowired
+  ImputationService(
+      LeonardoService leonardoService,
+      SamService samService,
+      ImputationConfiguration imputationConfiguration) {
+    this.leonardoService = leonardoService;
+    this.samService = samService;
+    this.imputationConfiguration = imputationConfiguration;
+  }
+
+  public List<ListAppResponse> queryForWorkspaceApps() {
+    try {
+      List<ListAppResponse> getAppsResponse =
+          leonardoService.getApps(
+              imputationConfiguration.workspaceId(),
+              samService.getTspsServiceAccountToken(),
+              false);
+
+      logger.info(
+          "GetAppsResponse for workspace id {}: {}",
+          imputationConfiguration.workspaceId(),
+          getAppsResponse.toString());
+      return getAppsResponse;
+    } catch (LeonardoServiceException e) {
+      logger.error(
+          "Get Apps called for workspace id {} failed", imputationConfiguration.workspaceId());
+      return null;
+    }
+  }
+}

--- a/service/src/main/java/bio/terra/pipelines/service/ImputationService.java
+++ b/service/src/main/java/bio/terra/pipelines/service/ImputationService.java
@@ -4,6 +4,7 @@ import bio.terra.pipelines.app.configuration.internal.ImputationConfiguration;
 import bio.terra.pipelines.dependencies.leonardo.LeonardoService;
 import bio.terra.pipelines.dependencies.leonardo.LeonardoServiceException;
 import bio.terra.pipelines.dependencies.sam.SamService;
+import java.util.Collections;
 import java.util.List;
 import org.broadinstitute.dsde.workbench.client.leonardo.model.ListAppResponse;
 import org.slf4j.Logger;
@@ -30,22 +31,19 @@ public class ImputationService {
   }
 
   public List<ListAppResponse> queryForWorkspaceApps() {
+    String workspaceId = imputationConfiguration.workspaceId();
     try {
       List<ListAppResponse> getAppsResponse =
-          leonardoService.getApps(
-              imputationConfiguration.workspaceId(),
-              samService.getTspsServiceAccountToken(),
-              false);
+          leonardoService.getApps(workspaceId, samService.getTspsServiceAccountToken(), false);
 
-      logger.info(
+      logger.debug(
           "GetAppsResponse for workspace id {}: {}",
           imputationConfiguration.workspaceId(),
-          getAppsResponse.toString());
+          getAppsResponse);
       return getAppsResponse;
     } catch (LeonardoServiceException e) {
-      logger.error(
-          "Get Apps called for workspace id {} failed", imputationConfiguration.workspaceId());
-      return null;
+      logger.error("Get Apps called for workspace id {} failed", workspaceId);
+      return Collections.emptyList();
     }
   }
 }

--- a/service/src/main/java/bio/terra/pipelines/service/ImputationService.java
+++ b/service/src/main/java/bio/terra/pipelines/service/ImputationService.java
@@ -36,7 +36,7 @@ public class ImputationService {
       List<ListAppResponse> getAppsResponse =
           leonardoService.getApps(workspaceId, samService.getTspsServiceAccountToken(), false);
 
-      logger.debug(
+      logger.info(
           "GetAppsResponse for workspace id {}: {}",
           imputationConfiguration.workspaceId(),
           getAppsResponse);

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -18,7 +18,7 @@ env:
     # default workspace id is for this workspace in the dev environment
     # https://bvdp-saturn-dev.appspot.com/#workspaces/tsps_dev_BP/Imputation_Control_Workspace_test
     # this should be updated when trying to run on a bee.
-    workspaceId: ${IMPUTATION_WORKSPACE_ID:5046acb0-32a1-437d-9a18-fac6897c8f03}
+    workspaceId: ${IMPUTATION_WORKSPACE_ID:a2e9cfbb-e4f0-4788-8aa1-de23533205fc}
 
 # Below here is non-deployment-specific
 

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -12,13 +12,13 @@ env:
     exportEnabled: ${CLOUD_TRACE_ENABLED:false}
     samplingRate: ${SAMPLING_PROBABILITY:0}
   urls:
-    sam: ${SAM_ADDRESS:https://sam.dsde-dev.broadinstitute.org}
-    leonardo: ${LEONARDO_ADDRESS:https://leonardo.dsde-dev.broadinstitute.org}
+    sam: ${SAM_ADDRESS:https://sam.jsoto-fourth-try.bee.envs-terra.bio/}
+    leonardo: ${LEONARDO_ADDRESS:https://leonardo.jsoto-fourth-try.bee.envs-terra.bio/}
   imputation:
     # default workspace id is for this workspace in the dev environment
-    # https://bvdp-saturn-dev.appspot.com/#workspaces/tsps_dev_BP/Imputation_Control_Workspace_test
-    # should be updated when trying to run on a bee.
-    workspaceId: ${IMPUTATION_WORKSPACE_ID:a2e9cfbb-e4f0-4788-8aa1-de23533205fc}
+    # https://bvdp-saturn-dev.appspot.com/#workspaces/tsps_dev_BP/Imputation_Control_Workspace_test.
+    # this should be updated when trying to run on a bee.
+    workspaceId: ${IMPUTATION_WORKSPACE_ID:5046acb0-32a1-437d-9a18-fac6897c8f03}
 
 # Below here is non-deployment-specific
 

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -12,13 +12,13 @@ env:
     exportEnabled: ${CLOUD_TRACE_ENABLED:false}
     samplingRate: ${SAMPLING_PROBABILITY:0}
   urls:
-    sam: ${SAM_ADDRESS:https://sam.jsoto-fourth-try.bee.envs-terra.bio/}
-    leonardo: ${LEONARDO_ADDRESS:https://leonardo.jsoto-fourth-try.bee.envs-terra.bio/}
+    sam: ${SAM_ADDRESS:https://sam.dsde-dev.broadinstitute.org}
+    leonardo: ${LEONARDO_ADDRESS:https://leonardo.dsde-dev.broadinstitute.org}
   imputation:
     # default workspace id is for this workspace in the dev environment
-    # https://bvdp-saturn-dev.appspot.com/#workspaces/tsps_dev_BP/Imputation_Control_Workspace_test.
+    # https://bvdp-saturn-dev.appspot.com/#workspaces/tsps_dev_BP/Imputation_Control_Workspace_test
     # this should be updated when trying to run on a bee.
-    workspaceId: ${IMPUTATION_WORKSPACE_ID:5046acb0-32a1-437d-9a18-fac6897c8f03}
+    workspaceId: ${IMPUTATION_WORKSPACE_ID:a2e9cfbb-e4f0-4788-8aa1-de23533205fc}
 
 # Below here is non-deployment-specific
 

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -18,7 +18,7 @@ env:
     # default workspace id is for this workspace in the dev environment
     # https://bvdp-saturn-dev.appspot.com/#workspaces/tsps_dev_BP/Imputation_Control_Workspace_test
     # this should be updated when trying to run on a bee.
-    workspaceId: ${IMPUTATION_WORKSPACE_ID:a2e9cfbb-e4f0-4788-8aa1-de23533205fc}
+    workspaceId: ${IMPUTATION_WORKSPACE_ID:5046acb0-32a1-437d-9a18-fac6897c8f03}
 
 # Below here is non-deployment-specific
 

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -14,6 +14,11 @@ env:
   urls:
     sam: ${SAM_ADDRESS:https://sam.dsde-dev.broadinstitute.org}
     leonardo: ${LEONARDO_ADDRESS:https://leonardo.dsde-dev.broadinstitute.org}
+  imputation:
+    # default workspace id is for this workspace in the dev environment
+    # https://bvdp-saturn-dev.appspot.com/#workspaces/tsps_dev_BP/Imputation_Control_Workspace_test
+    # should be updated when trying to run on a bee.
+    workspaceId: ${IMPUTATION_WORKSPACE_ID:a2e9cfbb-e4f0-4788-8aa1-de23533205fc}
 
 # Below here is non-deployment-specific
 
@@ -84,10 +89,7 @@ pipelines:
     basePath: ${env.urls.sam}
 
 imputation:
-  # workspace id for the imputation workspace, currently hardcoded to this workspace in dev
-  # https://bvdp-saturn-dev.appspot.com/#workspaces/tsps_dev_BP/Imputation_Control_Workspace_test
-  # needs to be updated in helmfile when other imputation workspaces are created in different environments
-  workspaceId: a2e9cfbb-e4f0-4788-8aa1-de23533205fc
+  workspaceId: ${env.imputation.workspaceId}
 
 leonardo:
   baseUri: ${env.urls.leonardo}

--- a/service/src/test/java/bio/terra/pipelines/controller/JobsApiControllerTest.java
+++ b/service/src/test/java/bio/terra/pipelines/controller/JobsApiControllerTest.java
@@ -23,6 +23,7 @@ import bio.terra.pipelines.dependencies.sam.SamService;
 import bio.terra.pipelines.generated.model.ApiGetJobResponse;
 import bio.terra.pipelines.generated.model.ApiGetJobsResponse;
 import bio.terra.pipelines.generated.model.ApiPostJobRequestBody;
+import bio.terra.pipelines.service.ImputationService;
 import bio.terra.pipelines.service.JobsService;
 import bio.terra.pipelines.service.PipelinesService;
 import bio.terra.pipelines.testutils.MockMvcUtils;
@@ -49,6 +50,7 @@ class JobsApiControllerTest {
   @MockBean BearerTokenFactory bearerTokenFactory;
   @MockBean SamConfiguration samConfiguration;
   @MockBean SamService samService;
+  @MockBean ImputationService imputationService;
 
   @Autowired private MockMvc mockMvc;
   private final SamUser testUser = MockMvcUtils.TEST_SAM_USER;

--- a/service/src/test/java/bio/terra/pipelines/service/ImputationServiceMockTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/ImputationServiceMockTest.java
@@ -1,0 +1,50 @@
+package bio.terra.pipelines.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.when;
+
+import bio.terra.pipelines.app.configuration.internal.ImputationConfiguration;
+import bio.terra.pipelines.dependencies.leonardo.LeonardoService;
+import bio.terra.pipelines.dependencies.leonardo.LeonardoServiceApiException;
+import bio.terra.pipelines.dependencies.sam.SamService;
+import bio.terra.pipelines.testutils.BaseContainerTest;
+import java.util.List;
+import org.broadinstitute.dsde.workbench.client.leonardo.ApiException;
+import org.broadinstitute.dsde.workbench.client.leonardo.model.ListAppResponse;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+public class ImputationServiceMockTest extends BaseContainerTest {
+  @InjectMocks private ImputationService imputationService;
+  @Mock private SamService samService;
+  @Mock private LeonardoService leonardoService;
+
+  private final String workspaceId = "workspaceId";
+  @Mock ImputationConfiguration imputationConfiguration = new ImputationConfiguration(workspaceId);
+
+  @Test
+  void queryForWorkspaceApps() {
+    when(samService.getTspsServiceAccountToken()).thenReturn("saToken");
+    when(leonardoService.getApps(any(), any(), anyBoolean()))
+        .thenReturn(
+            List.of(
+                new ListAppResponse().workspaceId(workspaceId),
+                new ListAppResponse().workspaceId(workspaceId)));
+
+    List<ListAppResponse> response = imputationService.queryForWorkspaceApps();
+    assertEquals(2, response.size());
+    response.stream().forEach(r -> assertEquals(workspaceId, r.getWorkspaceId()));
+  }
+
+  @Test
+  void queryForWorkspaceAppsIsNullWhenLeonardoException() {
+    when(samService.getTspsServiceAccountToken()).thenReturn("saToken");
+    when(leonardoService.getApps(any(), any(), anyBoolean()))
+        .thenThrow(new LeonardoServiceApiException(new ApiException()));
+    assertNull(imputationService.queryForWorkspaceApps());
+  }
+}

--- a/service/src/test/java/bio/terra/pipelines/service/ImputationServiceMockTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/ImputationServiceMockTest.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 
-public class ImputationServiceMockTest extends BaseContainerTest {
+class ImputationServiceMockTest extends BaseContainerTest {
   @InjectMocks private ImputationService imputationService;
   @Mock private SamService samService;
   @Mock private LeonardoService leonardoService;

--- a/service/src/test/java/bio/terra/pipelines/service/ImputationServiceMockTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/ImputationServiceMockTest.java
@@ -1,7 +1,6 @@
 package bio.terra.pipelines.service;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.when;
@@ -41,10 +40,10 @@ public class ImputationServiceMockTest extends BaseContainerTest {
   }
 
   @Test
-  void queryForWorkspaceAppsIsNullWhenLeonardoException() {
+  void queryForWorkspaceAppsIsEmptyWhenLeonardoException() {
     when(samService.getTspsServiceAccountToken()).thenReturn("saToken");
     when(leonardoService.getApps(any(), any(), anyBoolean()))
         .thenThrow(new LeonardoServiceApiException(new ApiException()));
-    assertNull(imputationService.queryForWorkspaceApps());
+    assertTrue(imputationService.queryForWorkspaceApps().isEmpty());
   }
 }


### PR DESCRIPTION
### Description 

Changing our usage of the leonardo client to use the google default credentials available instead of user credentials.  These can be supplied manually when developing and will be provided as part of the deployment in live environments

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-100