### PR TITLE
Update publish image github action slack message

### DIFF
--- a/.github/workflows/tag-publish.yml
+++ b/.github/workflows/tag-publish.yml
@@ -179,9 +179,9 @@ jobs:
         with:
           channel: '#terra-tsps-alerts'
           status: failure
-          author_name: Publish to dev
+          author_name: Publish image
           fields: job
-          text: 'Publish failed :sadpanda:'
+          text: 'Publish image failed :sadpanda: ${{ github.event.pull_request.html_url || github.event.head_commit.url }}'
           username: 'Terra Scientific Pipelines Service Action'
 
   report-to-sherlock:


### PR DESCRIPTION
### Description 

Its useful to also have a link to the PR/commit that corresponds to the failed publish action. This is what it looks like now

Before

<img width="699" alt="Screenshot 2023-11-29 at 4 09 08 PM" src="https://github.com/DataBiosphere/terra-scientific-pipelines-service/assets/13023616/df94dc03-01a4-482f-a5a8-c1a70fb2f625">

After
<img width="755" alt="Screenshot 2023-11-29 at 4 09 19 PM" src="https://github.com/DataBiosphere/terra-scientific-pipelines-service/assets/13023616/e899b780-d316-4795-9145-de808b4fa34a">

Is it better or worse?
### Jira Ticket
N/A