### PR TITLE
TSPS-102 add instrumentation of prometheus metrics

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -48,6 +48,7 @@ dependencies {
     implementation 'org.springframework.retry:spring-retry:1.3.4'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator:2.7.0'
 
     // terra clients
     implementation 'org.broadinstitute.dsde.workbench:sam-client_2.12:0.1-61135c7'
@@ -64,6 +65,9 @@ dependencies {
     // Spotbugs dependencies
     compileOnly "com.github.spotbugs:spotbugs-annotations:${spotbugs.toolVersion.get()}"
     spotbugs "com.github.spotbugs:spotbugs:${spotbugs.toolVersion.get()}"
+
+    // prometheus metrics
+    implementation 'io.micrometer:micrometer-registry-prometheus'
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
     testImplementation('org.springframework.boot:spring-boot-starter-test:2.7.0') {

--- a/service/src/main/java/bio/terra/pipelines/app/common/MetricsUtils.java
+++ b/service/src/main/java/bio/terra/pipelines/app/common/MetricsUtils.java
@@ -1,0 +1,25 @@
+package bio.terra.pipelines.app.common;
+
+import io.micrometer.core.instrument.Metrics;
+
+/**
+ * Class used to interact with micrometer metrics that are exported to /actuator/prometheus. This
+ * was mostly taken from <a
+ * href="https://github.com/DataBiosphere/terra-billing-profile-manager/blob/main/service/src/main/java/bio/terra/profile/app/common/MetricUtils.java">bpm
+ * metrics</a>
+ */
+public class MetricsUtils {
+  private static final String NAMESPACE = "tsps";
+  private static final String PIPELINE_TAG = "pipeline";
+
+  /**
+   * increments metrics counter for a tsps pipeline that has been run
+   *
+   * @param pipelineId - pipelineId that was run e.g. "imputation"
+   */
+  public static void incrementPipelineRun(String pipelineId) {
+    Metrics.globalRegistry
+        .counter(String.format("%s.pipeline.run.count", NAMESPACE), PIPELINE_TAG, pipelineId)
+        .increment();
+  }
+}

--- a/service/src/main/java/bio/terra/pipelines/app/common/MetricsUtils.java
+++ b/service/src/main/java/bio/terra/pipelines/app/common/MetricsUtils.java
@@ -1,6 +1,8 @@
 package bio.terra.pipelines.app.common;
 
 import io.micrometer.core.instrument.Metrics;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 
 /**
  * Class used to interact with micrometer metrics that are exported to /actuator/prometheus. This
@@ -8,6 +10,7 @@ import io.micrometer.core.instrument.Metrics;
  * href="https://github.com/DataBiosphere/terra-billing-profile-manager/blob/main/service/src/main/java/bio/terra/profile/app/common/MetricUtils.java">bpm
  * metrics</a>
  */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class MetricsUtils {
   private static final String NAMESPACE = "tsps";
   private static final String PIPELINE_TAG = "pipeline";

--- a/service/src/main/java/bio/terra/pipelines/app/controller/JobsApiController.java
+++ b/service/src/main/java/bio/terra/pipelines/app/controller/JobsApiController.java
@@ -3,6 +3,7 @@ package bio.terra.pipelines.app.controller;
 import bio.terra.common.exception.ApiException;
 import bio.terra.common.iam.SamUser;
 import bio.terra.common.iam.SamUserFactory;
+import bio.terra.pipelines.app.common.MetricsUtils;
 import bio.terra.pipelines.app.configuration.external.SamConfiguration;
 import bio.terra.pipelines.db.entities.Job;
 import bio.terra.pipelines.db.exception.PipelineNotFoundException;
@@ -97,6 +98,7 @@ public class JobsApiController implements JobsApi {
     ApiPostJobResponse createdJobResponse = new ApiPostJobResponse();
     createdJobResponse.setJobId(createdJobUuid.toString());
     logger.info("Created {} job {}", pipelineId, createdJobUuid);
+    MetricsUtils.incrementPipelineRun(pipelineId);
 
     return new ResponseEntity<>(createdJobResponse, HttpStatus.OK);
   }

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -66,6 +66,14 @@ spring:
         use-last-modified: false
       static-locations: classpath:/static/
 
+management:
+  server:
+    port: 9098
+  endpoints:
+    web:
+      exposure:
+        include: "prometheus"
+
 imputation:
   workspaceId: ${env.imputation.workspaceId}
 

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -18,7 +18,7 @@ env:
     # default workspace id is for this workspace in the dev environment
     # https://bvdp-saturn-dev.appspot.com/#workspaces/tsps_dev_BP/Imputation_Control_Workspace_test
     # this should be updated when trying to run on a bee.
-    workspaceId: ${IMPUTATION_WORKSPACE_ID:5046acb0-32a1-437d-9a18-fac6897c8f03}
+    workspaceId: ${IMPUTATION_WORKSPACE_ID:a2e9cfbb-e4f0-4788-8aa1-de23533205fc}
 
 # Below here is non-deployment-specific
 

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -18,7 +18,7 @@ env:
     # default workspace id is for this workspace in the dev environment
     # https://bvdp-saturn-dev.appspot.com/#workspaces/tsps_dev_BP/Imputation_Control_Workspace_test
     # this should be updated when trying to run on a bee.
-    workspaceId: ${IMPUTATION_WORKSPACE_ID:a2e9cfbb-e4f0-4788-8aa1-de23533205fc}
+    workspaceId: ${IMPUTATION_WORKSPACE_ID:5046acb0-32a1-437d-9a18-fac6897c8f03}
 
 # Below here is non-deployment-specific
 

--- a/service/src/test/java/bio/terra/pipelines/common/MetricsUtilsTest.java
+++ b/service/src/test/java/bio/terra/pipelines/common/MetricsUtilsTest.java
@@ -1,0 +1,48 @@
+package bio.terra.pipelines.common;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import bio.terra.pipelines.app.common.MetricsUtils;
+import bio.terra.pipelines.testutils.BaseTest;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class MetricsUtilsTest extends BaseTest {
+
+  private SimpleMeterRegistry meterRegistry;
+
+  @BeforeEach
+  void setUp() {
+    meterRegistry = new SimpleMeterRegistry();
+    Metrics.globalRegistry.add(meterRegistry);
+  }
+
+  @AfterEach
+  void tearDown() {
+    meterRegistry.clear();
+    Metrics.globalRegistry.clear();
+  }
+
+  @Test
+  void createGcpProfileMetrics() {
+    String pipelineId = "imputation";
+
+    // increment counter once
+    MetricsUtils.incrementPipelineRun(pipelineId);
+
+    Counter counter = meterRegistry.find("tsps.pipeline.run.count").counter();
+    assertNotNull(counter);
+    assertEquals(1, counter.count());
+    assertEquals(pipelineId, counter.getId().getTag("pipeline"));
+
+    // increment counter again
+    MetricsUtils.incrementPipelineRun(pipelineId);
+    counter = meterRegistry.find("tsps.pipeline.run.count").counter();
+    assertEquals(2, counter.count());
+  }
+}


### PR DESCRIPTION
### Description 

adding the instrumentation to connect metrics to prometheus by adding in actuator and exporting a count metric for pipelines run.  We'll want to have a discussion for what other product level metrics we want to track but just putting this one in as a test for now. This will need to go with a infrastructure helmchart change in order to get metrics to show up in a grafana dashboard.

screenshot of metric being tracked in my local server
![Screenshot 2023-12-03 at 1 03 02 PM](https://github.com/DataBiosphere/terra-scientific-pipelines-service/assets/13023616/48aaac04-36a2-49f5-ad1b-3587b10c4157)

### Jira Ticket

https://broadworkbench.atlassian.net/browse/TSPS-102