### PR TITLE
TSPS-135 add the get result endpoint

### DIFF
--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -124,6 +124,53 @@ paths:
         500:
           $ref: '#/components/responses/ServerError'
 
+  /api/pipelines/v1alpha1/{pipelineName}/result/{jobId}:
+    parameters:
+        - $ref: '#/components/parameters/PipelineName'
+        - $ref: '#/components/parameters/JobId'
+    get:
+      operationId: getPipelineJobResult
+      tags: [ pipelines ]
+      responses:
+        200:
+          description: Job is complete (succeeded or failed)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateJobResponse'
+        202:
+          description: Job is running
+          headers:
+            Retry-After:
+              description: >-
+                optional - estimated seconds to wait before polling again. This allows a server to offer a hint as to when the job might be complete.
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateJobResponse'
+        400:
+          description: Bad request - invalid id, id not for a createJobRequest job
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        403:
+          description: No permission to see job
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        404:
+          description: Not found - job id does not exist
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        500:
+          $ref: '#/components/responses/ServerError'
+
   /api/job/v1alpha1/jobs:
     get:
       tags: [ jobs ]
@@ -182,11 +229,10 @@ paths:
 components:
 
   parameters:
-
     JobId:
       name: jobId
       in: path
-      description: A UUID string identifier to used to identify a job in the service
+      description: A UUID identifier for a pipelines job
       required: true
       schema:
         type: string
@@ -340,10 +386,7 @@ components:
       required: [ id ]
       properties:
         id:
-          description: >-
-            Required unique identifier (UUID) for the job.
-          type: string
-          format: uuid
+          $ref: '#/components/schemas/Id'
         # In the future, notification configuration will also be part of JobControl.
 
     JobResult:
@@ -385,6 +428,8 @@ components:
           $ref: '#/components/schemas/JobReport'
         errorReport:
           $ref: '#/components/schemas/ErrorReport'
+        pipelineOutput:
+          $ref: '#/components/schemas/PipelineJobOutput'
 
     GetPipelinesResult:
       type: array
@@ -408,11 +453,11 @@ components:
           items:
             $ref: '#/components/schemas/JobReport'
 
-    JobId:
+    Id:
       description: |
-        Unique identifier (UUID) for a job request.
+        Required unique identifier (UUID) for a pipelines job.
       type: string
-      format: string
+      format: uuid
 
     JobStatus:
       description: |
@@ -462,6 +507,11 @@ components:
         The identifier string for the Pipeline.
       type: string
       format: string
+
+    PipelineJobOutput:
+      description: |
+          The output of a successful pipeline job.
+      type: object
 
     PipelineVersion:
       description: |

--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -511,7 +511,7 @@ components:
     PipelineJobOutput:
       description: |
           The output of a successful pipeline job.
-      type: object
+      type: string
 
     PipelineVersion:
       description: |

--- a/service/src/main/java/bio/terra/pipelines/app/configuration/external/IngressConfiguration.java
+++ b/service/src/main/java/bio/terra/pipelines/app/configuration/external/IngressConfiguration.java
@@ -1,0 +1,22 @@
+package bio.terra.pipelines.app.configuration.external;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties
+@ConfigurationProperties(prefix = "pipelines.ingress")
+public class IngressConfiguration {
+
+  /** Fully-qualified domain name. The base URL this instance can be accessed at. */
+  private String domainName;
+
+  public String getDomainName() {
+    return domainName;
+  }
+
+  public void setDomainName(String domainName) {
+    this.domainName = domainName;
+  }
+}

--- a/service/src/main/java/bio/terra/pipelines/app/controller/JobApiUtils.java
+++ b/service/src/main/java/bio/terra/pipelines/app/controller/JobApiUtils.java
@@ -2,10 +2,7 @@ package bio.terra.pipelines.app.controller;
 
 import bio.terra.common.exception.ErrorReportException;
 import bio.terra.pipelines.app.configuration.external.IngressConfiguration;
-import bio.terra.pipelines.common.utils.PipelinesEnum;
 import bio.terra.pipelines.dependencies.stairway.JobMapKeys;
-import bio.terra.pipelines.dependencies.stairway.JobService;
-import bio.terra.pipelines.dependencies.stairway.exception.InternalStairwayException;
 import bio.terra.pipelines.dependencies.stairway.exception.InvalidResultStateException;
 import bio.terra.pipelines.dependencies.stairway.model.EnumeratedJob;
 import bio.terra.pipelines.dependencies.stairway.model.EnumeratedJobs;
@@ -15,33 +12,27 @@ import bio.terra.pipelines.generated.model.ApiJobReport;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.FlightState;
 import bio.terra.stairway.FlightStatus;
-import bio.terra.stairway.exception.StairwayException;
-import com.fasterxml.jackson.core.type.TypeReference;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 
 @Component
 public class JobApiUtils {
-  private final JobService jobService;
-  private final IngressConfiguration ingressConfiguration;
 
   @Autowired
-  public JobApiUtils(JobService jobService, IngressConfiguration ingressConfiguration) {
-    this.jobService = jobService;
-    this.ingressConfiguration = ingressConfiguration;
-  }
+  public JobApiUtils() {}
 
-  public ApiGetJobsResponse mapEnumeratedJobsToApi(EnumeratedJobs enumeratedJobs) {
+  public static ApiGetJobsResponse mapEnumeratedJobsToApi(
+      IngressConfiguration ingressConfiguration, EnumeratedJobs enumeratedJobs) {
     // Convert the result to API-speak
     List<ApiJobReport> apiJobList = new ArrayList<>();
     for (EnumeratedJob enumeratedJob : enumeratedJobs.getResults()) {
-      ApiJobReport jobReport = mapFlightStateToApiJobReport(enumeratedJob.getFlightState());
+      ApiJobReport jobReport =
+          mapFlightStateToApiJobReport(ingressConfiguration, enumeratedJob.getFlightState());
       apiJobList.add(jobReport);
     }
     return new ApiGetJobsResponse()
@@ -50,7 +41,8 @@ public class JobApiUtils {
         .results(apiJobList);
   }
 
-  public ApiJobReport mapFlightStateToApiJobReport(FlightState flightState) {
+  public static ApiJobReport mapFlightStateToApiJobReport(
+      IngressConfiguration ingressConfiguration, FlightState flightState) {
     FlightMap inputParameters = flightState.getInputParameters();
     String description = inputParameters.get(JobMapKeys.DESCRIPTION.getKeyName(), String.class);
     FlightStatus flightStatus = flightState.getFlightStatus();
@@ -104,7 +96,7 @@ public class JobApiUtils {
         .statusCode(statusCode.value())
         .submitted(submittedDate)
         .completed(completedDate)
-        .resultURL(resultUrlFromFlightState(flightState));
+        .resultURL(resultUrlFromFlightState(ingressConfiguration, flightState));
   }
 
   private static ApiJobReport.StatusEnum mapFlightStatusToApi(FlightStatus flightStatus) {
@@ -120,7 +112,7 @@ public class JobApiUtils {
     }
   }
 
-  public ApiErrorReport buildApiErrorReport(Exception exception) {
+  public static ApiErrorReport buildApiErrorReport(Exception exception) {
     if (exception instanceof ErrorReportException errorReport) {
       return new ApiErrorReport()
           .message(errorReport.getMessage())
@@ -134,49 +126,8 @@ public class JobApiUtils {
     }
   }
 
-  /**
-   * Retrieves the result of an asynchronous job.
-   *
-   * <p>Stairway has no concept of synchronous vs asynchronous flights. However, MC Terra has a
-   * service-level standard result for asynchronous jobs which includes a ApiJobReport and either a
-   * result or error if the job is complete. This is a convenience for callers who would otherwise
-   * need to construct their own AsyncJobResult object.
-   *
-   * <p>Unlike retrieveJobResult, this will not throw for a flight in progress. Instead, it will
-   * return a ApiJobReport without a result or error.
-   */
-  public <T> AsyncJobResult<T> retrieveAsyncJobResult(
-      UUID jobId,
-      String userId,
-      PipelinesEnum pipelineId,
-      Class<T> resultClass,
-      TypeReference<T> typeReference) {
-    try {
-      FlightState flightState = jobService.retrieveJob(jobId, userId, pipelineId);
-      ApiJobReport jobReport = mapFlightStateToApiJobReport(flightState);
-      if (jobReport.getStatus().equals(ApiJobReport.StatusEnum.RUNNING)) {
-        return new AsyncJobResult<T>().jobReport(jobReport);
-      }
-
-      // Job is complete, get the result
-      JobService.JobResultOrException<T> resultOrException =
-          jobService.retrieveJobResult(jobId, resultClass, typeReference);
-      final ApiErrorReport errorReport;
-      if (jobReport.getStatus().equals(ApiJobReport.StatusEnum.FAILED)) {
-        errorReport = buildApiErrorReport(resultOrException.getException());
-      } else {
-        errorReport = null;
-      }
-      return new AsyncJobResult<T>()
-          .jobReport(jobReport)
-          .result(resultOrException.getResult())
-          .errorReport(errorReport);
-    } catch (StairwayException stairwayEx) {
-      throw new InternalStairwayException(stairwayEx);
-    }
-  }
-
-  private String resultUrlFromFlightState(FlightState flightState) {
+  private static String resultUrlFromFlightState(
+      IngressConfiguration ingressConfiguration, FlightState flightState) {
     String resultPath =
         flightState.getInputParameters().get(JobMapKeys.RESULT_PATH.getKeyName(), String.class);
     if (resultPath == null) {

--- a/service/src/main/java/bio/terra/pipelines/app/controller/JobApiUtils.java
+++ b/service/src/main/java/bio/terra/pipelines/app/controller/JobApiUtils.java
@@ -16,15 +16,10 @@ import java.nio.file.Path;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
-import org.springframework.stereotype.Component;
 
-@Component
 public class JobApiUtils {
-
-  @Autowired
-  public JobApiUtils() {}
+  private JobApiUtils() {}
 
   public static ApiGetJobsResponse mapEnumeratedJobsToApi(
       IngressConfiguration ingressConfiguration, EnumeratedJobs enumeratedJobs) {

--- a/service/src/main/java/bio/terra/pipelines/app/controller/JobApiUtils.java
+++ b/service/src/main/java/bio/terra/pipelines/app/controller/JobApiUtils.java
@@ -1,7 +1,10 @@
 package bio.terra.pipelines.app.controller;
 
 import bio.terra.common.exception.ErrorReportException;
+import bio.terra.pipelines.common.utils.PipelinesEnum;
 import bio.terra.pipelines.dependencies.stairway.JobMapKeys;
+import bio.terra.pipelines.dependencies.stairway.JobService;
+import bio.terra.pipelines.dependencies.stairway.exception.InternalStairwayException;
 import bio.terra.pipelines.dependencies.stairway.exception.InvalidResultStateException;
 import bio.terra.pipelines.dependencies.stairway.model.EnumeratedJob;
 import bio.terra.pipelines.dependencies.stairway.model.EnumeratedJobs;
@@ -11,26 +14,33 @@ import bio.terra.pipelines.generated.model.ApiJobReport;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.FlightState;
 import bio.terra.stairway.FlightStatus;
+import bio.terra.stairway.exception.StairwayException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 
 @Component
 public class JobApiUtils {
 
-  JobApiUtils() {}
+  private final JobService jobService;
+
+  @Autowired
+  JobApiUtils(JobService jobService) {
+    this.jobService = jobService;
+  }
 
   public static ApiGetJobsResponse mapEnumeratedJobsToApi(EnumeratedJobs enumeratedJobs) {
-
     // Convert the result to API-speak
     List<ApiJobReport> apiJobList = new ArrayList<>();
     for (EnumeratedJob enumeratedJob : enumeratedJobs.getResults()) {
       ApiJobReport jobReport = mapFlightStateToApiJobReport(enumeratedJob.getFlightState());
       apiJobList.add(jobReport);
     }
-
     return new ApiGetJobsResponse()
         .pageToken(enumeratedJobs.getPageToken())
         .totalResults(enumeratedJobs.getTotalResults())
@@ -121,6 +131,48 @@ public class JobApiUtils {
     }
   }
 
+  /**
+   * Retrieves the result of an asynchronous job.
+   *
+   * <p>Stairway has no concept of synchronous vs asynchronous flights. However, MC Terra has a
+   * service-level standard result for asynchronous jobs which includes a ApiJobReport and either a
+   * result or error if the job is complete. This is a convenience for callers who would otherwise
+   * need to construct their own AsyncJobResult object.
+   *
+   * <p>Unlike retrieveJobResult, this will not throw for a flight in progress. Instead, it will
+   * return a ApiJobReport without a result or error.
+   */
+  public <T> AsyncJobResult<T> retrieveAsyncJobResult(
+      UUID jobId,
+      String userId,
+      PipelinesEnum pipelineId,
+      Class<T> resultClass,
+      TypeReference<T> typeReference) {
+    try {
+      FlightState flightState = jobService.retrieveJob(jobId, userId, pipelineId);
+      ApiJobReport jobReport = mapFlightStateToApiJobReport(flightState);
+      if (jobReport.getStatus().equals(ApiJobReport.StatusEnum.RUNNING)) {
+        return new AsyncJobResult<T>().jobReport(jobReport);
+      }
+
+      // Job is complete, get the result
+      JobService.JobResultOrException<T> resultOrException =
+          jobService.retrieveJobResult(jobId, resultClass, typeReference);
+      final ApiErrorReport errorReport;
+      if (jobReport.getStatus().equals(ApiJobReport.StatusEnum.FAILED)) {
+        errorReport = buildApiErrorReport(resultOrException.getException());
+      } else {
+        errorReport = null;
+      }
+      return new AsyncJobResult<T>()
+          .jobReport(jobReport)
+          .result(resultOrException.getResult())
+          .errorReport(errorReport);
+    } catch (StairwayException stairwayEx) {
+      throw new InternalStairwayException(stairwayEx);
+    }
+  }
+
   private static String resultUrlFromFlightState(FlightState flightState) {
     String resultPath =
         flightState.getInputParameters().get(JobMapKeys.RESULT_PATH.getKeyName(), String.class);
@@ -129,5 +181,44 @@ public class JobApiUtils {
     }
     // TSPS-135 will implement the GET result endpoint, at which point this path should be created
     return resultPath;
+  }
+
+  /**
+   * The API result of an asynchronous job is a ApiJobReport and exactly one of a job result of an
+   * ApiErrorReport. If the job is incomplete, only jobReport will be present.
+   *
+   * @param <T> Class of the result object
+   */
+  public static class AsyncJobResult<T> {
+    private ApiJobReport jobReport;
+    private T result;
+    private ApiErrorReport errorReport;
+
+    public T getResult() {
+      return result;
+    }
+
+    public AsyncJobResult<T> result(T result) {
+      this.result = result;
+      return this;
+    }
+
+    public ApiErrorReport getApiErrorReport() {
+      return errorReport;
+    }
+
+    public AsyncJobResult<T> errorReport(ApiErrorReport errorReport) {
+      this.errorReport = errorReport;
+      return this;
+    }
+
+    public ApiJobReport getJobReport() {
+      return jobReport;
+    }
+
+    public AsyncJobResult<T> jobReport(ApiJobReport jobReport) {
+      this.jobReport = jobReport;
+      return this;
+    }
   }
 }

--- a/service/src/main/java/bio/terra/pipelines/app/controller/JobsApiController.java
+++ b/service/src/main/java/bio/terra/pipelines/app/controller/JobsApiController.java
@@ -53,7 +53,7 @@ public class JobsApiController implements JobsApi {
     final SamUser userRequest = getAuthenticatedInfo();
     String userId = userRequest.getSubjectId();
     logger.info("Retrieving jobId {} for userId {}", jobId, userId);
-    FlightState flightState = jobService.retrieveJob(jobId, userId);
+    FlightState flightState = jobService.retrieveJob(jobId, userId, null);
     ApiJobReport result = JobApiUtils.mapFlightStateToApiJobReport(flightState);
     return new ResponseEntity<>(result, HttpStatus.OK);
   }

--- a/service/src/main/java/bio/terra/pipelines/app/controller/JobsApiController.java
+++ b/service/src/main/java/bio/terra/pipelines/app/controller/JobsApiController.java
@@ -5,7 +5,6 @@ import static bio.terra.pipelines.app.controller.JobApiUtils.mapFlightStateToApi
 
 import bio.terra.common.iam.SamUser;
 import bio.terra.common.iam.SamUserFactory;
-import bio.terra.pipelines.app.configuration.external.IngressConfiguration;
 import bio.terra.pipelines.app.configuration.external.SamConfiguration;
 import bio.terra.pipelines.dependencies.stairway.JobService;
 import bio.terra.pipelines.dependencies.stairway.model.EnumeratedJobs;
@@ -31,20 +30,17 @@ public class JobsApiController implements JobsApi {
   private final SamUserFactory samUserFactory;
   private final HttpServletRequest request;
   private final JobService jobService;
-  private final IngressConfiguration ingressConfiguration;
 
   @Autowired
   public JobsApiController(
       SamConfiguration samConfiguration,
       SamUserFactory samUserFactory,
       HttpServletRequest request,
-      JobService jobService,
-      IngressConfiguration ingressConfiguration) {
+      JobService jobService) {
     this.samConfiguration = samConfiguration;
     this.samUserFactory = samUserFactory;
     this.request = request;
     this.jobService = jobService;
-    this.ingressConfiguration = ingressConfiguration;
   }
 
   private static final Logger logger = LoggerFactory.getLogger(JobsApiController.class);
@@ -61,7 +57,7 @@ public class JobsApiController implements JobsApi {
     String userId = userRequest.getSubjectId();
     logger.info("Retrieving jobId {} for userId {}", jobId, userId);
     FlightState flightState = jobService.retrieveJob(jobId, userId);
-    ApiJobReport result = mapFlightStateToApiJobReport(ingressConfiguration, flightState);
+    ApiJobReport result = mapFlightStateToApiJobReport(flightState);
     return new ResponseEntity<>(result, HttpStatus.OK);
   }
 
@@ -71,7 +67,7 @@ public class JobsApiController implements JobsApi {
     String userId = userRequest.getSubjectId();
     logger.info("Retrieving all jobs for userId {}", userId);
     EnumeratedJobs enumeratedJobs = jobService.enumerateJobs(userId, limit, pageToken, null);
-    ApiGetJobsResponse result = mapEnumeratedJobsToApi(ingressConfiguration, enumeratedJobs);
+    ApiGetJobsResponse result = mapEnumeratedJobsToApi(enumeratedJobs);
     return new ResponseEntity<>(result, HttpStatus.OK);
   }
 }

--- a/service/src/main/java/bio/terra/pipelines/app/controller/JobsApiController.java
+++ b/service/src/main/java/bio/terra/pipelines/app/controller/JobsApiController.java
@@ -60,7 +60,7 @@ public class JobsApiController implements JobsApi {
     final SamUser userRequest = getAuthenticatedInfo();
     String userId = userRequest.getSubjectId();
     logger.info("Retrieving jobId {} for userId {}", jobId, userId);
-    FlightState flightState = jobService.retrieveJob(jobId, userId, null);
+    FlightState flightState = jobService.retrieveJob(jobId, userId);
     ApiJobReport result = mapFlightStateToApiJobReport(ingressConfiguration, flightState);
     return new ResponseEntity<>(result, HttpStatus.OK);
   }

--- a/service/src/main/java/bio/terra/pipelines/app/controller/JobsApiController.java
+++ b/service/src/main/java/bio/terra/pipelines/app/controller/JobsApiController.java
@@ -27,17 +27,20 @@ public class JobsApiController implements JobsApi {
   private final SamUserFactory samUserFactory;
   private final HttpServletRequest request;
   private final JobService jobService;
+  private final JobApiUtils jobApiUtils;
 
   @Autowired
   public JobsApiController(
       SamConfiguration samConfiguration,
       SamUserFactory samUserFactory,
       HttpServletRequest request,
-      JobService jobService) {
+      JobService jobService,
+      JobApiUtils jobApiUtils) {
     this.samConfiguration = samConfiguration;
     this.samUserFactory = samUserFactory;
     this.request = request;
     this.jobService = jobService;
+    this.jobApiUtils = jobApiUtils;
   }
 
   private static final Logger logger = LoggerFactory.getLogger(JobsApiController.class);
@@ -54,7 +57,7 @@ public class JobsApiController implements JobsApi {
     String userId = userRequest.getSubjectId();
     logger.info("Retrieving jobId {} for userId {}", jobId, userId);
     FlightState flightState = jobService.retrieveJob(jobId, userId, null);
-    ApiJobReport result = JobApiUtils.mapFlightStateToApiJobReport(flightState);
+    ApiJobReport result = jobApiUtils.mapFlightStateToApiJobReport(flightState);
     return new ResponseEntity<>(result, HttpStatus.OK);
   }
 
@@ -64,7 +67,7 @@ public class JobsApiController implements JobsApi {
     String userId = userRequest.getSubjectId();
     logger.info("Retrieving all jobs for userId {}", userId);
     EnumeratedJobs enumeratedJobs = jobService.enumerateJobs(userId, limit, pageToken, null);
-    ApiGetJobsResponse result = JobApiUtils.mapEnumeratedJobsToApi(enumeratedJobs);
+    ApiGetJobsResponse result = jobApiUtils.mapEnumeratedJobsToApi(enumeratedJobs);
     return new ResponseEntity<>(result, HttpStatus.OK);
   }
 }

--- a/service/src/main/java/bio/terra/pipelines/app/controller/PipelinesApiController.java
+++ b/service/src/main/java/bio/terra/pipelines/app/controller/PipelinesApiController.java
@@ -186,7 +186,7 @@ public class PipelinesApiController implements PipelinesApi {
     PipelinesEnum validatedPipelineId = validatePipelineName(pipelineName);
 
     JobApiUtils.AsyncJobResult<ApiPipelineJobOutput> jobResult =
-        jobApiUtils.retrieveAsyncJobResult(
+        jobService.retrieveAsyncJobResult(
             jobId, userId, validatedPipelineId, ApiPipelineJobOutput.class, null);
 
     //    ApiPipelineJobOutput pipelineOutput = null;

--- a/service/src/main/java/bio/terra/pipelines/app/controller/PipelinesApiController.java
+++ b/service/src/main/java/bio/terra/pipelines/app/controller/PipelinesApiController.java
@@ -40,7 +40,6 @@ public class PipelinesApiController implements PipelinesApi {
   private final JobService jobService;
   private final PipelinesService pipelinesService;
   private final ImputationService imputationService;
-  private final JobApiUtils jobApiUtils;
 
   @Autowired
   public PipelinesApiController(
@@ -49,15 +48,13 @@ public class PipelinesApiController implements PipelinesApi {
       HttpServletRequest request,
       JobService jobService,
       PipelinesService pipelinesService,
-      ImputationService imputationService,
-      JobApiUtils jobApiUtils) {
+      ImputationService imputationService) {
     this.samConfiguration = samConfiguration;
     this.samUserFactory = samUserFactory;
     this.request = request;
     this.pipelinesService = pipelinesService;
     this.jobService = jobService;
     this.imputationService = imputationService;
-    this.jobApiUtils = jobApiUtils;
   }
 
   private static final Logger logger = LoggerFactory.getLogger(PipelinesApiController.class);
@@ -189,10 +186,6 @@ public class PipelinesApiController implements PipelinesApi {
         jobService.retrieveAsyncJobResult(
             jobId, userId, validatedPipelineId, ApiPipelineJobOutput.class, null);
 
-    //    ApiPipelineJobOutput pipelineOutput = null;
-    //    if (jobResult.getJobReport().getStatus().equals(ApiJobReport.StatusEnum.SUCCEEDED)) {
-    //      pipelineOutput = jobResult.getResult();
-    //    }
     ApiCreateJobResponse response =
         new ApiCreateJobResponse()
             .jobReport(jobResult.getJobReport())

--- a/service/src/main/java/bio/terra/pipelines/app/controller/PipelinesApiController.java
+++ b/service/src/main/java/bio/terra/pipelines/app/controller/PipelinesApiController.java
@@ -143,7 +143,7 @@ public class PipelinesApiController implements PipelinesApi {
         userId,
         pipelineInputs);
 
-    String resultPath = getAsyncResultEndpoint(request, jobId, "result");
+    String resultPath = getAsyncResultEndpoint(request, jobId);
 
     if (validatedPipelineName == IMPUTATION_MINIMAC4) {
       Pipeline pipeline = pipelinesService.getPipeline(IMPUTATION_MINIMAC4);
@@ -226,20 +226,16 @@ public class PipelinesApiController implements PipelinesApi {
   }
 
   /**
-   * Returns the result endpoint corresponding to an async request. The endpoint is used to build a
+   * Returns the result endpoint corresponding to an async request. The endpoint is used to build an
    * ApiJobReport. This method generates a result endpoint with the form
-   * {servletpath}/{resultWord}/{jobId} relative to the async endpoint.
-   *
-   * <p>Sometimes we have more than one async endpoint with the same prefix, so need to distinguish
-   * them with different result words. For example, "update-result".
+   * {servletpath}/result/{jobId} relative to the async endpoint.
    *
    * @param jobId the job id
-   * @param resultWord the path component identifying the result
    * @return a string with the result endpoint URL
    */
   public static String getAsyncResultEndpoint(
-      HttpServletRequest request, UUID jobId, String resultWord) {
-    return String.format("%s/%s/%s", request.getServletPath(), resultWord, jobId);
+      HttpServletRequest request, UUID jobId) {
+    return String.format("%s/result/%s", request.getServletPath(), jobId);
   }
 
   /**

--- a/service/src/main/java/bio/terra/pipelines/app/controller/PipelinesApiController.java
+++ b/service/src/main/java/bio/terra/pipelines/app/controller/PipelinesApiController.java
@@ -233,8 +233,7 @@ public class PipelinesApiController implements PipelinesApi {
    * @param jobId the job id
    * @return a string with the result endpoint URL
    */
-  public static String getAsyncResultEndpoint(
-      HttpServletRequest request, UUID jobId) {
+  public static String getAsyncResultEndpoint(HttpServletRequest request, UUID jobId) {
     return String.format("%s/result/%s", request.getServletPath(), jobId);
   }
 

--- a/service/src/main/java/bio/terra/pipelines/dependencies/stairway/JobMapKeys.java
+++ b/service/src/main/java/bio/terra/pipelines/dependencies/stairway/JobMapKeys.java
@@ -9,8 +9,10 @@ public enum JobMapKeys {
   USER_ID("user_id"),
   PIPELINE_NAME("pipeline_name"),
   STATUS_CODE("status_code"),
-  RESPONSE("response"), // used for synchronous jobs
-  RESULT_PATH("result_path"); // used for asynchronous jobs
+  RESPONSE("response"), // result or output of the job
+  RESULT_PATH(
+      "result_path"); // path to the result API endpoint for this job; only used for asynchronous
+  // endpoints
 
   private final String keyName;
 

--- a/service/src/main/java/bio/terra/pipelines/dependencies/stairway/JobService.java
+++ b/service/src/main/java/bio/terra/pipelines/dependencies/stairway/JobService.java
@@ -269,9 +269,15 @@ public class JobService {
     return stairwayComponent.get();
   }
 
+  /** Retrieve a stairway job by its jobId, checking that the calling user has access to it. */
+  @Traced
+  public FlightState retrieveJob(UUID jobId, String userId) {
+    return retrieveJob(jobId, userId, /*pipelineName=*/ null);
+  }
+
   /**
    * Retrieve a stairway job by its jobId, checking that the calling user has access to it, and
-   * optionally checking that the job is for the requested pipeline.
+   * checking that the job is for the requested pipeline.
    */
   @Traced
   public FlightState retrieveJob(UUID jobId, String userId, @Nullable PipelinesEnum pipelineName) {

--- a/service/src/main/java/bio/terra/pipelines/dependencies/stairway/JobService.java
+++ b/service/src/main/java/bio/terra/pipelines/dependencies/stairway/JobService.java
@@ -5,15 +5,12 @@ import bio.terra.common.logging.LoggingUtils;
 import bio.terra.common.stairway.MonitoringHook;
 import bio.terra.common.stairway.StairwayComponent;
 import bio.terra.pipelines.app.configuration.internal.StairwayDatabaseConfiguration;
-import bio.terra.pipelines.app.controller.JobApiUtils;
 import bio.terra.pipelines.common.utils.FlightBeanBag;
 import bio.terra.pipelines.common.utils.MdcHook;
 import bio.terra.pipelines.common.utils.PipelinesEnum;
 import bio.terra.pipelines.dependencies.stairway.exception.*;
 import bio.terra.pipelines.dependencies.stairway.model.EnumeratedJob;
 import bio.terra.pipelines.dependencies.stairway.model.EnumeratedJobs;
-import bio.terra.pipelines.generated.model.ApiErrorReport;
-import bio.terra.pipelines.generated.model.ApiJobReport;
 import bio.terra.stairway.*;
 import bio.terra.stairway.exception.DuplicateFlightIdException;
 import bio.terra.stairway.exception.FlightNotFoundException;
@@ -175,48 +172,6 @@ public class JobService {
       logger.warn(INTERRUPTED_MSG, jobId);
       Thread.currentThread().interrupt();
       throw new InternalStairwayException(e);
-    }
-  }
-
-  /**
-   * Retrieves the result of an asynchronous job.
-   *
-   * <p>Stairway has no concept of synchronous vs asynchronous flights. However, MC Terra has a
-   * service-level standard result for asynchronous jobs which includes a ApiJobReport and either a
-   * result or error if the job is complete. This is a convenience for callers who would otherwise
-   * need to construct their own AsyncJobResult object.
-   *
-   * <p>Unlike retrieveJobResult, this will not throw for a flight in progress. Instead, it will
-   * return a ApiJobReport without a result or error.
-   */
-  public <T> JobApiUtils.AsyncJobResult<T> retrieveAsyncJobResult(
-      UUID jobId,
-      String userId,
-      PipelinesEnum pipelineId,
-      Class<T> resultClass,
-      TypeReference<T> typeReference) {
-    try {
-      FlightState flightState = retrieveJob(jobId, userId, pipelineId);
-      ApiJobReport jobReport = JobApiUtils.mapFlightStateToApiJobReport(flightState);
-      if (jobReport.getStatus().equals(ApiJobReport.StatusEnum.RUNNING)) {
-        return new JobApiUtils.AsyncJobResult<T>().jobReport(jobReport);
-      }
-
-      // Job is complete, get the result
-      JobService.JobResultOrException<T> resultOrException =
-          retrieveJobResult(jobId, resultClass, typeReference);
-      final ApiErrorReport errorReport;
-      if (jobReport.getStatus().equals(ApiJobReport.StatusEnum.FAILED)) {
-        errorReport = JobApiUtils.buildApiErrorReport(resultOrException.getException());
-      } else {
-        errorReport = null;
-      }
-      return new JobApiUtils.AsyncJobResult<T>()
-          .jobReport(jobReport)
-          .result(resultOrException.getResult())
-          .errorReport(errorReport);
-    } catch (StairwayException stairwayEx) {
-      throw new InternalStairwayException(stairwayEx);
     }
   }
 

--- a/service/src/main/java/bio/terra/pipelines/dependencies/stairway/JobService.java
+++ b/service/src/main/java/bio/terra/pipelines/dependencies/stairway/JobService.java
@@ -296,6 +296,7 @@ public class JobService {
         flightState
             .getInputParameters()
             .get(JobMapKeys.PIPELINE_NAME.getKeyName(), PipelinesEnum.class);
+    // note we currently can't test the follow block since we only have one pipeline
     if (!requestedPipelineName.equals(pipelineFromFlight)) {
       logger.info(
           "Attempt to retrieve job {} for pipeline {} but that job was for pipeline {}",

--- a/service/src/main/java/bio/terra/pipelines/dependencies/stairway/JobService.java
+++ b/service/src/main/java/bio/terra/pipelines/dependencies/stairway/JobService.java
@@ -7,7 +7,6 @@ import bio.terra.common.exception.InternalServerErrorException;
 import bio.terra.common.logging.LoggingUtils;
 import bio.terra.common.stairway.MonitoringHook;
 import bio.terra.common.stairway.StairwayComponent;
-import bio.terra.pipelines.app.configuration.external.IngressConfiguration;
 import bio.terra.pipelines.app.configuration.internal.StairwayDatabaseConfiguration;
 import bio.terra.pipelines.app.controller.JobApiUtils;
 import bio.terra.pipelines.common.utils.FlightBeanBag;
@@ -194,7 +193,6 @@ public class JobService {
    * return a ApiJobReport without a result or error.
    */
   public <T> JobApiUtils.AsyncJobResult<T> retrieveAsyncJobResult(
-      IngressConfiguration ingressConfiguration,
       UUID jobId,
       String userId,
       PipelinesEnum pipelineId,
@@ -202,7 +200,7 @@ public class JobService {
       TypeReference<T> typeReference) {
     try {
       FlightState flightState = retrieveJob(jobId, userId, pipelineId);
-      ApiJobReport jobReport = mapFlightStateToApiJobReport(ingressConfiguration, flightState);
+      ApiJobReport jobReport = mapFlightStateToApiJobReport(flightState);
       if (jobReport.getStatus().equals(ApiJobReport.StatusEnum.RUNNING)) {
         return new JobApiUtils.AsyncJobResult<T>().jobReport(jobReport);
       }

--- a/service/src/main/java/bio/terra/pipelines/service/ImputationService.java
+++ b/service/src/main/java/bio/terra/pipelines/service/ImputationService.java
@@ -85,7 +85,8 @@ public class ImputationService {
       String userId,
       String description,
       Pipeline imputationPipeline,
-      Object pipelineInputs) {
+      Object pipelineInputs,
+      String resultPath) {
 
     PipelinesEnum pipelineName = PipelinesEnum.valueOf(imputationPipeline.getName().toUpperCase());
     logger.info("Create new {} job for user {}", pipelineName, userId);
@@ -99,7 +100,8 @@ public class ImputationService {
             .addParameter(JobMapKeys.USER_ID.getKeyName(), userId)
             .addParameter(JobMapKeys.DESCRIPTION.getKeyName(), description)
             .addParameter(RunImputationJobFlightMapKeys.PIPELINE_ID, imputationPipeline.getId())
-            .addParameter(RunImputationJobFlightMapKeys.PIPELINE_INPUTS, pipelineInputs);
+            .addParameter(RunImputationJobFlightMapKeys.PIPELINE_INPUTS, pipelineInputs)
+            .addParameter(JobMapKeys.RESULT_PATH.getKeyName(), resultPath);
 
     return jobBuilder.submit();
   }

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -18,6 +18,8 @@ env:
   urls:
     sam: ${SAM_ADDRESS:https://sam.dsde-dev.broadinstitute.org}
     leonardo: ${LEONARDO_ADDRESS:https://leonardo.dsde-dev.broadinstitute.org}
+  ingress:
+    domainName: ${TSPS_INGRESS_DOMAIN_NAME:localhost:8080}
   imputation:
     # default workspace id is for this workspace in the dev environment
     # https://bvdp-saturn-dev.appspot.com/#workspaces/tsps_dev_bp_02_01_2024_v1/tsps_imputation_service_v1
@@ -89,8 +91,7 @@ imputation:
 
 pipelines:
   ingress:
-    # Default value that's overridden by Helm.
-    domainName: localhost:8080
+    domainName: ${env.ingress.domainName}
 
   stairway-job:
     max-threads: 4

--- a/service/src/test/java/bio/terra/pipelines/configuration/external/IngressConfigurationTest.java
+++ b/service/src/test/java/bio/terra/pipelines/configuration/external/IngressConfigurationTest.java
@@ -7,7 +7,7 @@ import bio.terra.pipelines.testutils.BaseEmbeddedDbTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-public class IngressConfigurationTest extends BaseEmbeddedDbTest {
+class IngressConfigurationTest extends BaseEmbeddedDbTest {
   @Autowired IngressConfiguration ingressConfiguration;
 
   @Test

--- a/service/src/test/java/bio/terra/pipelines/configuration/external/IngressConfigurationTest.java
+++ b/service/src/test/java/bio/terra/pipelines/configuration/external/IngressConfigurationTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import bio.terra.pipelines.app.configuration.external.IngressConfiguration;
 import bio.terra.pipelines.testutils.BaseEmbeddedDbTest;
+import bio.terra.pipelines.testutils.TestUtils;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -12,6 +13,6 @@ class IngressConfigurationTest extends BaseEmbeddedDbTest {
 
   @Test
   void verifyIngressConfiguration() {
-    assertEquals("testDomainName", ingressConfiguration.getDomainName());
+    assertEquals(TestUtils.TEST_DOMAIN, ingressConfiguration.getDomainName());
   }
 }

--- a/service/src/test/java/bio/terra/pipelines/configuration/external/IngressConfigurationTest.java
+++ b/service/src/test/java/bio/terra/pipelines/configuration/external/IngressConfigurationTest.java
@@ -1,0 +1,17 @@
+package bio.terra.pipelines.configuration.external;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import bio.terra.pipelines.app.configuration.external.IngressConfiguration;
+import bio.terra.pipelines.testutils.BaseEmbeddedDbTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class IngressConfigurationTest extends BaseEmbeddedDbTest {
+  @Autowired IngressConfiguration ingressConfiguration;
+
+  @Test
+  void verifyIngressConfiguration() {
+    assertNotNull(ingressConfiguration.getDomainName());
+  }
+}

--- a/service/src/test/java/bio/terra/pipelines/configuration/external/IngressConfigurationTest.java
+++ b/service/src/test/java/bio/terra/pipelines/configuration/external/IngressConfigurationTest.java
@@ -1,6 +1,6 @@
 package bio.terra.pipelines.configuration.external;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import bio.terra.pipelines.app.configuration.external.IngressConfiguration;
 import bio.terra.pipelines.testutils.BaseEmbeddedDbTest;
@@ -12,6 +12,6 @@ class IngressConfigurationTest extends BaseEmbeddedDbTest {
 
   @Test
   void verifyIngressConfiguration() {
-    assertNotNull(ingressConfiguration.getDomainName());
+    assertEquals("testDomainName", ingressConfiguration.getDomainName());
   }
 }

--- a/service/src/test/java/bio/terra/pipelines/controller/JobApiUtilsTest.java
+++ b/service/src/test/java/bio/terra/pipelines/controller/JobApiUtilsTest.java
@@ -1,32 +1,56 @@
 package bio.terra.pipelines.controller;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
 import bio.terra.common.exception.ErrorReportException;
+import bio.terra.pipelines.app.configuration.external.IngressConfiguration;
 import bio.terra.pipelines.app.controller.JobApiUtils;
+import bio.terra.pipelines.common.utils.PipelinesEnum;
 import bio.terra.pipelines.dependencies.stairway.JobMapKeys;
+import bio.terra.pipelines.dependencies.stairway.JobService;
 import bio.terra.pipelines.dependencies.stairway.exception.InternalStairwayException;
 import bio.terra.pipelines.dependencies.stairway.exception.InvalidResultStateException;
 import bio.terra.pipelines.dependencies.stairway.model.EnumeratedJobs;
 import bio.terra.pipelines.generated.model.ApiErrorReport;
 import bio.terra.pipelines.generated.model.ApiGetJobsResponse;
 import bio.terra.pipelines.generated.model.ApiJobReport;
+import bio.terra.pipelines.testutils.BaseEmbeddedDbTest;
 import bio.terra.pipelines.testutils.StairwayTestUtils;
 import bio.terra.pipelines.testutils.TestUtils;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.FlightState;
 import bio.terra.stairway.FlightStatus;
+import bio.terra.stairway.exception.MakeFlightException;
 import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.springframework.http.HttpStatus;
 
-class JobApiUtilsTest {
+class JobApiUtilsTest extends BaseEmbeddedDbTest {
+
+  @InjectMocks private JobApiUtils jobApiUtils;
+  @Mock private JobService jobService;
+  @Mock private IngressConfiguration ingressConfiguration;
+
+  // we mock IngressConfiguration.getDomainName() to return "localhost", which maps to "http://"
+  private final String fullResultURL =
+      String.format("http://localhost/%s", TestUtils.TEST_RESULT_PATH);
+
+  @BeforeEach
+  void initMocks() {
+    when(ingressConfiguration.getDomainName()).thenReturn("localhost");
+  }
 
   @Test
   void testMapEnumeratedJobsToApi() {
     EnumeratedJobs bothJobs = StairwayTestUtils.ENUMERATED_JOBS;
 
-    ApiGetJobsResponse mappedResponse = JobApiUtils.mapEnumeratedJobsToApi(bothJobs);
+    ApiGetJobsResponse mappedResponse = jobApiUtils.mapEnumeratedJobsToApi(bothJobs);
 
     assertEquals(bothJobs.getTotalResults(), mappedResponse.getTotalResults());
     assertEquals(bothJobs.getPageToken(), mappedResponse.getPageToken());
@@ -43,7 +67,7 @@ class JobApiUtilsTest {
   void testMapFlightStateToApiJobReportSucceeded() {
     FlightState flightState = StairwayTestUtils.FLIGHT_STATE_DONE_SUCCESS_1;
 
-    ApiJobReport apiJobReport = JobApiUtils.mapFlightStateToApiJobReport(flightState);
+    ApiJobReport apiJobReport = jobApiUtils.mapFlightStateToApiJobReport(flightState);
 
     assertEquals(TestUtils.TEST_NEW_UUID.toString(), apiJobReport.getId());
     assertEquals(StairwayTestUtils.TEST_DESCRIPTION, apiJobReport.getDescription());
@@ -51,7 +75,7 @@ class JobApiUtilsTest {
         "SUCCEEDED", apiJobReport.getStatus().name()); // "SUCCESS" gets mapped to "SUCCEEDED"
     assertEquals(StairwayTestUtils.TIME_SUBMITTED_1.toString(), apiJobReport.getSubmitted());
     assertEquals(StairwayTestUtils.TIME_COMPLETED_1.toString(), apiJobReport.getCompleted());
-    assertEquals("", apiJobReport.getResultURL());
+    assertEquals(fullResultURL, apiJobReport.getResultURL());
     // if there is no status code in the working map, we assume it's a success/200
     assertEquals(200, apiJobReport.getStatusCode());
   }
@@ -70,7 +94,7 @@ class JobApiUtilsTest {
     // a completed job should have a completed time, otherwise it's an error
     assertThrows(
         InvalidResultStateException.class,
-        () -> JobApiUtils.mapFlightStateToApiJobReport(flightState));
+        () -> jobApiUtils.mapFlightStateToApiJobReport(flightState));
   }
 
   @Test
@@ -89,7 +113,7 @@ class JobApiUtilsTest {
             StairwayTestUtils.TIME_SUBMITTED_1,
             StairwayTestUtils.TIME_COMPLETED_1);
 
-    ApiJobReport apiJobReport = JobApiUtils.mapFlightStateToApiJobReport(flightState);
+    ApiJobReport apiJobReport = jobApiUtils.mapFlightStateToApiJobReport(flightState);
 
     assertEquals(
         "SUCCEEDED", apiJobReport.getStatus().name()); // "SUCCESS" gets mapped to "SUCCEEDED"
@@ -103,7 +127,7 @@ class JobApiUtilsTest {
             FlightStatus.ERROR, TestUtils.TEST_NEW_UUID);
     flightState.setException(new InternalStairwayException("some message"));
 
-    ApiJobReport apiJobReport = JobApiUtils.mapFlightStateToApiJobReport(flightState);
+    ApiJobReport apiJobReport = jobApiUtils.mapFlightStateToApiJobReport(flightState);
 
     assertEquals(TestUtils.TEST_NEW_UUID.toString(), apiJobReport.getId());
     assertEquals("FAILED", apiJobReport.getStatus().name()); // ERROR gets mapped to FAILED
@@ -124,7 +148,7 @@ class JobApiUtilsTest {
 
     assertThrows(
         InvalidResultStateException.class,
-        () -> JobApiUtils.mapFlightStateToApiJobReport(flightState));
+        () -> jobApiUtils.mapFlightStateToApiJobReport(flightState));
   }
 
   @Test
@@ -133,13 +157,13 @@ class JobApiUtilsTest {
         StairwayTestUtils.constructFlightStateWithStatusAndId(
             FlightStatus.RUNNING, TestUtils.TEST_NEW_UUID);
 
-    ApiJobReport apiJobReport = JobApiUtils.mapFlightStateToApiJobReport(flightState);
+    ApiJobReport apiJobReport = jobApiUtils.mapFlightStateToApiJobReport(flightState);
 
     assertEquals(TestUtils.TEST_NEW_UUID.toString(), apiJobReport.getId());
     assertEquals(StairwayTestUtils.TEST_DESCRIPTION, apiJobReport.getDescription());
     assertEquals("RUNNING", apiJobReport.getStatus().name());
     assertNull(apiJobReport.getCompleted());
-    assertEquals("", apiJobReport.getResultURL());
+    assertEquals(fullResultURL, apiJobReport.getResultURL());
     assertEquals(202, apiJobReport.getStatusCode());
   }
 
@@ -151,7 +175,7 @@ class JobApiUtilsTest {
         StairwayTestUtils.constructFlightStateWithStatusAndId(
             FlightStatus.QUEUED, TestUtils.TEST_NEW_UUID);
 
-    ApiJobReport apiJobReport = JobApiUtils.mapFlightStateToApiJobReport(flightState);
+    ApiJobReport apiJobReport = jobApiUtils.mapFlightStateToApiJobReport(flightState);
 
     assertEquals("RUNNING", apiJobReport.getStatus().name());
     assertNull(apiJobReport.getCompleted());
@@ -164,7 +188,7 @@ class JobApiUtilsTest {
         StairwayTestUtils.constructFlightStateWithStatusAndId(
             FlightStatus.WAITING, TestUtils.TEST_NEW_UUID);
 
-    ApiJobReport apiJobReport = JobApiUtils.mapFlightStateToApiJobReport(flightState);
+    ApiJobReport apiJobReport = jobApiUtils.mapFlightStateToApiJobReport(flightState);
 
     assertEquals("RUNNING", apiJobReport.getStatus().name());
     assertNull(apiJobReport.getCompleted());
@@ -177,7 +201,7 @@ class JobApiUtilsTest {
         StairwayTestUtils.constructFlightStateWithStatusAndId(
             FlightStatus.READY, TestUtils.TEST_NEW_UUID);
 
-    ApiJobReport apiJobReport = JobApiUtils.mapFlightStateToApiJobReport(flightState);
+    ApiJobReport apiJobReport = jobApiUtils.mapFlightStateToApiJobReport(flightState);
 
     assertEquals("RUNNING", apiJobReport.getStatus().name());
     assertNull(apiJobReport.getCompleted());
@@ -190,7 +214,7 @@ class JobApiUtilsTest {
         StairwayTestUtils.constructFlightStateWithStatusAndId(
             FlightStatus.READY_TO_RESTART, TestUtils.TEST_NEW_UUID);
 
-    ApiJobReport apiJobReport = JobApiUtils.mapFlightStateToApiJobReport(flightState);
+    ApiJobReport apiJobReport = jobApiUtils.mapFlightStateToApiJobReport(flightState);
 
     assertEquals("RUNNING", apiJobReport.getStatus().name());
     assertNull(apiJobReport.getCompleted());
@@ -204,7 +228,7 @@ class JobApiUtilsTest {
             FlightStatus.FATAL, TestUtils.TEST_NEW_UUID);
     flightState.setException(new InternalStairwayException("some message"));
 
-    ApiJobReport apiJobReport = JobApiUtils.mapFlightStateToApiJobReport(flightState);
+    ApiJobReport apiJobReport = jobApiUtils.mapFlightStateToApiJobReport(flightState);
 
     assertEquals("FAILED", apiJobReport.getStatus().name());
     assertEquals(500, apiJobReport.getStatusCode());
@@ -216,7 +240,7 @@ class JobApiUtilsTest {
     ErrorReportException exception =
         new ErrorReportException(errorMessage, null, HttpStatus.I_AM_A_TEAPOT) {};
 
-    ApiErrorReport apiErrorReport = JobApiUtils.buildApiErrorReport(exception);
+    ApiErrorReport apiErrorReport = jobApiUtils.buildApiErrorReport(exception);
 
     assertEquals(errorMessage, apiErrorReport.getMessage());
     assertEquals(418, apiErrorReport.getStatusCode());
@@ -230,7 +254,7 @@ class JobApiUtilsTest {
     ErrorReportException exception =
         new ErrorReportException(errorMessage, causes, HttpStatus.I_AM_A_TEAPOT) {};
 
-    ApiErrorReport apiErrorReport = JobApiUtils.buildApiErrorReport(exception);
+    ApiErrorReport apiErrorReport = jobApiUtils.buildApiErrorReport(exception);
 
     assertEquals(errorMessage, apiErrorReport.getMessage());
     assertEquals(418, apiErrorReport.getStatusCode());
@@ -242,10 +266,102 @@ class JobApiUtilsTest {
     String errorMessage = "some message";
     InternalStairwayException exception = new InternalStairwayException(errorMessage);
 
-    ApiErrorReport apiErrorReport = JobApiUtils.buildApiErrorReport(exception);
+    ApiErrorReport apiErrorReport = jobApiUtils.buildApiErrorReport(exception);
 
     assertEquals(errorMessage, apiErrorReport.getMessage());
     assertEquals(500, apiErrorReport.getStatusCode());
     assertTrue(apiErrorReport.getCauses().isEmpty());
+  }
+
+  @Test
+  void testRetrieveAsyncJobResultRunning() throws InterruptedException {
+    UUID jobId = TestUtils.TEST_NEW_UUID;
+    FlightMap inputParameters = StairwayTestUtils.CREATE_JOB_INPUT_PARAMS;
+    FlightState flightState =
+        StairwayTestUtils.constructFlightStateWithStatusAndId(
+            FlightStatus.RUNNING, jobId, inputParameters, new FlightMap());
+
+    when(jobService.retrieveJob(any(), any(), any())).thenReturn(flightState);
+
+    JobApiUtils.AsyncJobResult<String> result =
+        jobApiUtils.retrieveAsyncJobResult(
+            jobId, TestUtils.TEST_USER_ID_1, PipelinesEnum.IMPUTATION_MINIMAC4, String.class, null);
+
+    assertEquals(jobId.toString(), result.getJobReport().getId());
+    assertEquals(202, result.getJobReport().getStatusCode());
+    assertNull(result.getResult());
+    assertNull(result.getApiErrorReport());
+  }
+
+  @Test
+  void testRetrieveAsyncJobResultSucceeded() {
+    UUID jobId = TestUtils.TEST_NEW_UUID;
+    FlightMap inputParameters = StairwayTestUtils.CREATE_JOB_INPUT_PARAMS;
+    FlightMap workingMap = new FlightMap();
+    String testResponse = "test response";
+    workingMap.put(JobMapKeys.RESPONSE.getKeyName(), testResponse);
+    FlightState flightState =
+        StairwayTestUtils.constructFlightStateWithStatusAndId(
+            FlightStatus.SUCCESS, jobId, inputParameters, workingMap);
+
+    when(jobService.retrieveJob(any(), any(), any())).thenReturn(flightState);
+    when(jobService.retrieveJobResult(any(), any(), any()))
+        .thenReturn(new JobService.JobResultOrException<>().result(testResponse));
+
+    JobApiUtils.AsyncJobResult<String> result =
+        jobApiUtils.retrieveAsyncJobResult(
+            jobId, TestUtils.TEST_USER_ID_1, PipelinesEnum.IMPUTATION_MINIMAC4, String.class, null);
+
+    assertEquals(jobId.toString(), result.getJobReport().getId());
+    assertEquals(200, result.getJobReport().getStatusCode());
+    assertEquals(testResponse, result.getResult());
+    assertNull(result.getApiErrorReport());
+  }
+
+  @Test
+  void testRetrieveAsyncJobResultFailed() {
+    UUID jobId = TestUtils.TEST_NEW_UUID;
+    FlightMap inputParameters = StairwayTestUtils.CREATE_JOB_INPUT_PARAMS;
+    // even on a fatal failure the response might have been written to the working map
+    FlightMap workingMap = new FlightMap();
+    String testResponse = "test response";
+    workingMap.put(JobMapKeys.RESPONSE.getKeyName(), testResponse);
+    FlightState flightState =
+        StairwayTestUtils.constructFlightStateWithStatusAndId(
+            FlightStatus.ERROR, jobId, inputParameters, workingMap);
+    String testErrorMsg = "test exception";
+    RuntimeException exception = new RuntimeException(testErrorMsg);
+    flightState.setException(exception);
+
+    when(jobService.retrieveJob(any(), any(), any())).thenReturn(flightState);
+    when(jobService.retrieveJobResult(any(), any(), any()))
+        .thenReturn(new JobService.JobResultOrException<>().exception(exception));
+
+    JobApiUtils.AsyncJobResult<String> result =
+        jobApiUtils.retrieveAsyncJobResult(
+            jobId, TestUtils.TEST_USER_ID_1, PipelinesEnum.IMPUTATION_MINIMAC4, String.class, null);
+
+    assertEquals(jobId.toString(), result.getJobReport().getId());
+    assertEquals(500, result.getJobReport().getStatusCode());
+    assertNull(result.getResult());
+    assertEquals(testErrorMsg, result.getApiErrorReport().getMessage());
+  }
+
+  @Test
+  void retrieveAsyncJobResultStairwayException() {
+    UUID flightId = TestUtils.TEST_NEW_UUID;
+    // a MakeFlightException is an instance of StairwayException
+    when(jobService.retrieveJob(any(), any(), any()))
+        .thenThrow(new MakeFlightException("test exception"));
+
+    assertThrows(
+        InternalStairwayException.class,
+        () ->
+            jobApiUtils.retrieveAsyncJobResult(
+                flightId,
+                TestUtils.TEST_USER_ID_1,
+                TestUtils.TEST_PIPELINE_1_ENUM,
+                String.class,
+                null));
   }
 }

--- a/service/src/test/java/bio/terra/pipelines/controller/JobApiUtilsTest.java
+++ b/service/src/test/java/bio/terra/pipelines/controller/JobApiUtilsTest.java
@@ -23,7 +23,7 @@ import org.springframework.http.HttpStatus;
 class JobApiUtilsTest {
 
   @Test
-  void testMapEnumeratedJobsToApi() {
+  void mapEnumeratedJobsToApiOk() {
     EnumeratedJobs bothJobs = StairwayTestUtils.ENUMERATED_JOBS;
 
     ApiGetJobsResponse mappedResponse = mapEnumeratedJobsToApi(bothJobs);
@@ -40,7 +40,7 @@ class JobApiUtilsTest {
   }
 
   @Test
-  void testMapFlightStateToApiJobReportSucceeded() {
+  void mapFlightStateToApiJobReportSucceeded() {
     FlightState flightState = StairwayTestUtils.FLIGHT_STATE_DONE_SUCCESS_1;
 
     ApiJobReport apiJobReport = mapFlightStateToApiJobReport(flightState);
@@ -57,7 +57,7 @@ class JobApiUtilsTest {
   }
 
   @Test
-  void testMapFlightStateToApiJobReportSucceededNoCompletedTime() {
+  void mapFlightStateToApiJobReportSucceededNoCompletedTime() {
     FlightState flightState =
         StairwayTestUtils.constructFlightStateWithStatusAndId(
             FlightStatus.SUCCESS,
@@ -73,7 +73,7 @@ class JobApiUtilsTest {
   }
 
   @Test
-  void testMapFlightStateToApiJobReportSucceededWithStatusCode() {
+  void mapFlightStateToApiJobReportSucceededWithStatusCode() {
     // Ensure the custom status code in the working map gets extracted and used
     HttpStatus httpStatus = HttpStatus.I_AM_A_TEAPOT; // status code 418
     FlightMap flightMapWithStatusCode = new FlightMap();
@@ -96,7 +96,7 @@ class JobApiUtilsTest {
   }
 
   @Test
-  void testMapFlightStateToApiJobReportFailed() {
+  void mapFlightStateToApiJobReportFailed() {
     FlightState flightState =
         StairwayTestUtils.constructFlightStateWithStatusAndId(
             FlightStatus.ERROR, TestUtils.TEST_NEW_UUID);
@@ -111,7 +111,7 @@ class JobApiUtilsTest {
   }
 
   @Test
-  void testMapFlightStateToApiJobReportFailedMissingException() {
+  void mapFlightStateToApiJobReportFailedMissingException() {
     FlightState flightState =
         StairwayTestUtils.constructFlightStateWithStatusAndId(
             FlightStatus.ERROR,
@@ -126,7 +126,7 @@ class JobApiUtilsTest {
   }
 
   @Test
-  void testMapFlightStateToApiJobReportRunning() {
+  void mapFlightStateToApiJobReportRunning() {
     FlightState flightState =
         StairwayTestUtils.constructFlightStateWithStatusAndId(
             FlightStatus.RUNNING, TestUtils.TEST_NEW_UUID);
@@ -144,7 +144,7 @@ class JobApiUtilsTest {
   // the following tests are effectively tests of mapFlightStatusToApi(), which is private
 
   @Test
-  void testMapFlightStateToApiJobReportRunningQueued() {
+  void mapFlightStateToApiJobReportRunningQueued() {
     FlightState flightState =
         StairwayTestUtils.constructFlightStateWithStatusAndId(
             FlightStatus.QUEUED, TestUtils.TEST_NEW_UUID);
@@ -157,7 +157,7 @@ class JobApiUtilsTest {
   }
 
   @Test
-  void testMapFlightStateToApiJobReportRunningWaiting() {
+  void mapFlightStateToApiJobReportRunningWaiting() {
     FlightState flightState =
         StairwayTestUtils.constructFlightStateWithStatusAndId(
             FlightStatus.WAITING, TestUtils.TEST_NEW_UUID);
@@ -170,7 +170,7 @@ class JobApiUtilsTest {
   }
 
   @Test
-  void testMapFlightStateToApiJobReportRunningReady() {
+  void mapFlightStateToApiJobReportRunningReady() {
     FlightState flightState =
         StairwayTestUtils.constructFlightStateWithStatusAndId(
             FlightStatus.READY, TestUtils.TEST_NEW_UUID);
@@ -183,7 +183,7 @@ class JobApiUtilsTest {
   }
 
   @Test
-  void testMapFlightStateToApiJobReportRunningReadyToRestart() {
+  void mapFlightStateToApiJobReportRunningReadyToRestart() {
     FlightState flightState =
         StairwayTestUtils.constructFlightStateWithStatusAndId(
             FlightStatus.READY_TO_RESTART, TestUtils.TEST_NEW_UUID);
@@ -196,7 +196,7 @@ class JobApiUtilsTest {
   }
 
   @Test
-  void testMapFlightStateToApiJobReportFailedFatal() {
+  void mapFlightStateToApiJobReportFailedFatal() {
     FlightState flightState =
         StairwayTestUtils.constructFlightStateWithStatusAndId(
             FlightStatus.FATAL, TestUtils.TEST_NEW_UUID);
@@ -209,7 +209,7 @@ class JobApiUtilsTest {
   }
 
   @Test
-  void testBuildApiErrorReportErrorReportExceptionCustomStatus() {
+  void buildApiErrorReportErrorReportExceptionCustomStatus() {
     String errorMessage = "some message";
     ErrorReportException exception =
         new ErrorReportException(errorMessage, null, HttpStatus.I_AM_A_TEAPOT) {};
@@ -222,7 +222,7 @@ class JobApiUtilsTest {
   }
 
   @Test
-  void testBuildApiErrorReportErrorReportExceptionCustomStatusWithCauses() {
+  void buildApiErrorReportErrorReportExceptionCustomStatusWithCauses() {
     String errorMessage = "some message";
     List<String> causes = List.of("cause 1", "cause 2");
     ErrorReportException exception =
@@ -236,7 +236,7 @@ class JobApiUtilsTest {
   }
 
   @Test
-  void testBuildApiErrorReport() {
+  void buildApiErrorReportInternalStairway500() {
     String errorMessage = "some message";
     InternalStairwayException exception = new InternalStairwayException(errorMessage);
 

--- a/service/src/test/java/bio/terra/pipelines/controller/JobsApiControllerTest.java
+++ b/service/src/test/java/bio/terra/pipelines/controller/JobsApiControllerTest.java
@@ -68,7 +68,7 @@ class JobsApiControllerTest {
     UUID jobId = TestUtils.TEST_NEW_UUID;
     FlightState flightState = StairwayTestUtils.FLIGHT_STATE_DONE_SUCCESS_1;
 
-    when(jobServiceMock.retrieveJob(jobId, testUserId, null)).thenReturn(flightState);
+    when(jobServiceMock.retrieveJob(jobId, testUserId)).thenReturn(flightState);
 
     MvcResult result =
         mockMvc
@@ -97,7 +97,7 @@ class JobsApiControllerTest {
             StairwayTestUtils.TIME_COMPLETED_1);
     flightState.setException(new Exception("Test exception"));
 
-    when(jobServiceMock.retrieveJob(jobId, testUserId, null)).thenReturn(flightState);
+    when(jobServiceMock.retrieveJob(jobId, testUserId)).thenReturn(flightState);
 
     // even though the job itself failed, it completed successfully so the status code should be 200
     // (ok)
@@ -118,7 +118,7 @@ class JobsApiControllerTest {
   @Test
   void testGetJobNotFound() throws Exception {
     UUID badJobId = UUID.randomUUID();
-    when(jobServiceMock.retrieveJob(badJobId, testUserId, null))
+    when(jobServiceMock.retrieveJob(badJobId, testUserId))
         .thenThrow(new ImputationJobNotFoundException("some message"));
 
     mockMvc
@@ -129,7 +129,7 @@ class JobsApiControllerTest {
   @Test
   void testGetJobNoAccess() throws Exception {
     UUID badJobId = UUID.randomUUID();
-    when(jobServiceMock.retrieveJob(badJobId, testUserId, null))
+    when(jobServiceMock.retrieveJob(badJobId, testUserId))
         .thenThrow(new JobUnauthorizedException("some message"));
 
     mockMvc

--- a/service/src/test/java/bio/terra/pipelines/controller/JobsApiControllerTest.java
+++ b/service/src/test/java/bio/terra/pipelines/controller/JobsApiControllerTest.java
@@ -10,7 +10,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import bio.terra.common.iam.BearerTokenFactory;
 import bio.terra.common.iam.SamUser;
 import bio.terra.common.iam.SamUserFactory;
-import bio.terra.pipelines.app.configuration.external.IngressConfiguration;
 import bio.terra.pipelines.app.configuration.external.SamConfiguration;
 import bio.terra.pipelines.app.controller.GlobalExceptionHandler;
 import bio.terra.pipelines.app.controller.JobsApiController;
@@ -51,7 +50,6 @@ class JobsApiControllerTest {
   @MockBean SamConfiguration samConfiguration;
   @MockBean SamService samService;
   @MockBean ImputationService imputationService;
-  @MockBean IngressConfiguration ingressConfiguration;
 
   @Autowired private MockMvc mockMvc;
   private final SamUser testUser = MockMvcUtils.TEST_SAM_USER;
@@ -59,7 +57,6 @@ class JobsApiControllerTest {
 
   @BeforeEach
   void beforeEach() {
-    when(ingressConfiguration.getDomainName()).thenReturn("localhost");
     when(samUserFactoryMock.from(any(HttpServletRequest.class), any())).thenReturn(testUser);
   }
 

--- a/service/src/test/java/bio/terra/pipelines/controller/JobsApiControllerTest.java
+++ b/service/src/test/java/bio/terra/pipelines/controller/JobsApiControllerTest.java
@@ -154,15 +154,10 @@ class JobsApiControllerTest {
   @Test
   void testGetMultipleJobs() throws Exception {
     EnumeratedJobs bothJobs = StairwayTestUtils.ENUMERATED_JOBS;
-    //    List<ApiJobReport> apiJobReports = bothJobs.getResults().stream().map().toList();
-    //    ApiGetJobsResponse expectedResult =
-    //        new
-    // ApiGetJobsResponse().results(apiJobReports).totalResults(bothJobs.getTotalResults());
 
     // the mocks
     when(jobServiceMock.enumerateJobs(testUser.getSubjectId(), 10, null, null))
         .thenReturn(bothJobs);
-    //    when(jobApiUtils.mapEnumeratedJobsToApi(bothJobs)).thenReturn(expectedResult);
 
     MvcResult result =
         mockMvc

--- a/service/src/test/java/bio/terra/pipelines/controller/JobsApiControllerTest.java
+++ b/service/src/test/java/bio/terra/pipelines/controller/JobsApiControllerTest.java
@@ -61,7 +61,7 @@ class JobsApiControllerTest {
   }
 
   @Test
-  void testGetJobOk() throws Exception {
+  void getJobOk() throws Exception {
     UUID jobId = TestUtils.TEST_NEW_UUID;
     FlightState flightState = StairwayTestUtils.FLIGHT_STATE_DONE_SUCCESS_1;
 
@@ -82,7 +82,7 @@ class JobsApiControllerTest {
   }
 
   @Test
-  void testGetErrorJobOk() throws Exception {
+  void getErrorJobOk() throws Exception {
     UUID jobId = TestUtils.TEST_NEW_UUID;
     FlightState flightState =
         StairwayTestUtils.constructFlightStateWithStatusAndId(
@@ -113,7 +113,7 @@ class JobsApiControllerTest {
   }
 
   @Test
-  void testGetJobNotFound() throws Exception {
+  void getJobNotFound() throws Exception {
     UUID badJobId = UUID.randomUUID();
     when(jobServiceMock.retrieveJob(badJobId, testUserId))
         .thenThrow(new ImputationJobNotFoundException("some message"));
@@ -124,7 +124,7 @@ class JobsApiControllerTest {
   }
 
   @Test
-  void testGetJobNoAccess() throws Exception {
+  void getJobNoAccess() throws Exception {
     UUID badJobId = UUID.randomUUID();
     when(jobServiceMock.retrieveJob(badJobId, testUserId))
         .thenThrow(new JobUnauthorizedException("some message"));
@@ -135,7 +135,7 @@ class JobsApiControllerTest {
   }
 
   @Test
-  void testGetJob_badId() throws Exception {
+  void getJobBadId() throws Exception {
     String badJobId = "not-a-uuid";
 
     mockMvc
@@ -144,7 +144,7 @@ class JobsApiControllerTest {
   }
 
   @Test
-  void testGetMultipleJobs() throws Exception {
+  void getMultipleJobs() throws Exception {
     EnumeratedJobs bothJobs = StairwayTestUtils.ENUMERATED_JOBS;
 
     // the mocks

--- a/service/src/test/java/bio/terra/pipelines/controller/JobsApiControllerTest.java
+++ b/service/src/test/java/bio/terra/pipelines/controller/JobsApiControllerTest.java
@@ -63,7 +63,7 @@ class JobsApiControllerTest {
   @Test
   void testGetJobOk() throws Exception {
     UUID jobIdOkDone = TestUtils.TEST_NEW_UUID;
-    when(jobServiceMock.retrieveJob(jobIdOkDone, testUserId))
+    when(jobServiceMock.retrieveJob(jobIdOkDone, testUserId, null))
         .thenReturn(StairwayTestUtils.FLIGHT_STATE_DONE_SUCCESS_1);
 
     MvcResult result =
@@ -93,7 +93,7 @@ class JobsApiControllerTest {
             StairwayTestUtils.TIME_COMPLETED_1);
     flightStateDoneError.setException(new Exception("Test exception"));
 
-    when(jobServiceMock.retrieveJob(jobId, testUserId)).thenReturn(flightStateDoneError);
+    when(jobServiceMock.retrieveJob(jobId, testUserId, null)).thenReturn(flightStateDoneError);
 
     // even though the job itself failed, it completed successfully so the status code should be 200
     // (ok)
@@ -114,7 +114,7 @@ class JobsApiControllerTest {
   @Test
   void testGetJobNotFound() throws Exception {
     UUID badJobId = UUID.randomUUID();
-    when(jobServiceMock.retrieveJob(badJobId, testUserId))
+    when(jobServiceMock.retrieveJob(badJobId, testUserId, null))
         .thenThrow(new ImputationJobNotFoundException("some message"));
 
     mockMvc
@@ -125,7 +125,7 @@ class JobsApiControllerTest {
   @Test
   void testGetJobNoAccess() throws Exception {
     UUID badJobId = UUID.randomUUID();
-    when(jobServiceMock.retrieveJob(badJobId, testUserId))
+    when(jobServiceMock.retrieveJob(badJobId, testUserId, null))
         .thenThrow(new JobUnauthorizedException("some message"));
 
     mockMvc

--- a/service/src/test/java/bio/terra/pipelines/controller/JobsApiControllerTest.java
+++ b/service/src/test/java/bio/terra/pipelines/controller/JobsApiControllerTest.java
@@ -2,7 +2,6 @@ package bio.terra.pipelines.controller;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -14,7 +13,6 @@ import bio.terra.common.iam.SamUserFactory;
 import bio.terra.pipelines.app.configuration.external.IngressConfiguration;
 import bio.terra.pipelines.app.configuration.external.SamConfiguration;
 import bio.terra.pipelines.app.controller.GlobalExceptionHandler;
-import bio.terra.pipelines.app.controller.JobApiUtils;
 import bio.terra.pipelines.app.controller.JobsApiController;
 import bio.terra.pipelines.db.exception.ImputationJobNotFoundException;
 import bio.terra.pipelines.dependencies.sam.SamService;
@@ -38,7 +36,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
@@ -54,7 +51,6 @@ class JobsApiControllerTest {
   @MockBean SamConfiguration samConfiguration;
   @MockBean SamService samService;
   @MockBean ImputationService imputationService;
-  @SpyBean JobApiUtils jobApiUtils;
   @MockBean IngressConfiguration ingressConfiguration;
 
   @Autowired private MockMvc mockMvc;
@@ -63,7 +59,6 @@ class JobsApiControllerTest {
 
   @BeforeEach
   void beforeEach() {
-    jobApiUtils = spy(new JobApiUtils(jobServiceMock, ingressConfiguration));
     when(ingressConfiguration.getDomainName()).thenReturn("localhost");
     when(samUserFactoryMock.from(any(HttpServletRequest.class), any())).thenReturn(testUser);
   }

--- a/service/src/test/java/bio/terra/pipelines/controller/PipelinesApiControllerTest.java
+++ b/service/src/test/java/bio/terra/pipelines/controller/PipelinesApiControllerTest.java
@@ -79,7 +79,7 @@ class PipelinesApiControllerTest {
 
   // we mock IngressConfiguration.getDomainName() to return "localhost", which maps to "http://"
   private final String fullResultURL =
-          String.format("http://localhost/%s", TestUtils.TEST_RESULT_PATH);
+      String.format("http://localhost/%s", TestUtils.TEST_RESULT_PATH);
 
   @BeforeEach
   void beforeEach() {

--- a/service/src/test/java/bio/terra/pipelines/controller/PipelinesApiControllerTest.java
+++ b/service/src/test/java/bio/terra/pipelines/controller/PipelinesApiControllerTest.java
@@ -580,7 +580,7 @@ class PipelinesApiControllerTest {
 
     // response should include the job report and pipeline output object
     assertEquals(newJobId.toString(), response.getJobReport().getId());
-    assertNotNull(response.getPipelineOutput());
+    assertEquals(jobResultValue, response.getPipelineOutput());
     assertNull(response.getErrorReport());
   }
 

--- a/service/src/test/java/bio/terra/pipelines/controller/PipelinesApiControllerTest.java
+++ b/service/src/test/java/bio/terra/pipelines/controller/PipelinesApiControllerTest.java
@@ -87,7 +87,7 @@ class PipelinesApiControllerTest {
   // getPipeline tests
 
   @Test
-  void testGetPipelines() throws Exception {
+  void getPipelinesOk() throws Exception {
     when(pipelinesServiceMock.getPipelines()).thenReturn(testPipelineList);
 
     MvcResult result =
@@ -105,7 +105,7 @@ class PipelinesApiControllerTest {
   }
 
   @Test
-  void getPipeline() throws Exception {
+  void getPipelineOk() throws Exception {
     String pipelineName = TestUtils.TEST_PIPELINE_1.getName();
     PipelinesEnum pipelineNameEnum = PipelinesEnum.IMPUTATION_MINIMAC4;
 
@@ -159,7 +159,7 @@ class PipelinesApiControllerTest {
   // createPipelineJob tests
 
   @Test
-  void testCreateJobImputationPipelineRunning() throws Exception {
+  void createJobImputationPipelineRunning() throws Exception {
     String pipelineName = PipelinesEnum.IMPUTATION_MINIMAC4.getValue();
     String description = "description for testCreateJobImputationPipelineRunning";
     UUID jobId = newJobId;
@@ -203,7 +203,7 @@ class PipelinesApiControllerTest {
   }
 
   @Test
-  void testCreateJobImputationPipelineNoDescriptionOk() throws Exception {
+  void createJobImputationPipelineNoDescriptionOk() throws Exception {
     String pipelineName = PipelinesEnum.IMPUTATION_MINIMAC4.getValue();
     UUID jobId = newJobId;
     String postBodyAsJson = createTestJobPostBody(jobId.toString(), "");
@@ -238,7 +238,7 @@ class PipelinesApiControllerTest {
   }
 
   @Test
-  void testCreateJobImputationPipelineCompletedSuccess() throws Exception {
+  void createJobImputationPipelineCompletedSuccess() throws Exception {
     String pipelineName = PipelinesEnum.IMPUTATION_MINIMAC4.getValue();
     String description = "description for testCreateJobImputationPipelineCompletedSuccess";
     UUID jobId = newJobId;
@@ -279,7 +279,7 @@ class PipelinesApiControllerTest {
   }
 
   @Test
-  void testCreateJobImputationPipelineCaseInsensitive() throws Exception {
+  void createJobImputationPipelineCaseInsensitive() throws Exception {
     String pipelineName = "iMpUtAtIoN_MINImac4";
     String description = "description for testCreateJobImputationPipelineCaseInsensitive";
     UUID jobId = newJobId;
@@ -319,7 +319,7 @@ class PipelinesApiControllerTest {
   }
 
   @Test
-  void testCreateJobBadPipeline() throws Exception {
+  void createJobBadPipeline() throws Exception {
     String pipelineName = "bad-pipeline-id";
     String description = "description for testCreateJobBadPipeline";
     UUID jobId = newJobId;
@@ -337,7 +337,7 @@ class PipelinesApiControllerTest {
   }
 
   @Test
-  void testCreateJobMissingJobControl() throws Exception {
+  void createJobMissingJobControl() throws Exception {
     String pipelineName = PipelinesEnum.IMPUTATION_MINIMAC4.getValue();
     ApiCreateJobRequestBody postBody =
         new ApiCreateJobRequestBody()
@@ -364,7 +364,7 @@ class PipelinesApiControllerTest {
   }
 
   @Test
-  void testCreateJobMissingJobId() throws Exception {
+  void createJobMissingJobId() throws Exception {
     String pipelineName = PipelinesEnum.IMPUTATION_MINIMAC4.getValue();
     ApiJobControl apiJobControl = new ApiJobControl();
     ApiCreateJobRequestBody postBody =
@@ -394,7 +394,7 @@ class PipelinesApiControllerTest {
   }
 
   @Test
-  void testCreateJobMissingMultipleRequiredFields() throws Exception {
+  void createJobMissingMultipleRequiredFields() throws Exception {
     String pipelineName = PipelinesEnum.IMPUTATION_MINIMAC4.getValue();
     String stringifiedInputs = MockMvcUtils.convertToJsonString(testPipelineInputs);
     String postBodyAsJson =
@@ -422,7 +422,7 @@ class PipelinesApiControllerTest {
   }
 
   @Test
-  void testCreateJobBadJobId() throws Exception {
+  void createJobBadJobId() throws Exception {
     String pipelineName = PipelinesEnum.IMPUTATION_MINIMAC4.getValue();
     String postBodyAsJson =
         createTestJobPostBody("this-is-not-a-uuid", "description for testCreateJobMissingJobId");
@@ -446,7 +446,7 @@ class PipelinesApiControllerTest {
   }
 
   @Test
-  void testCreateImputationJobStairwayError() throws Exception {
+  void createImputationJobStairwayError() throws Exception {
     String pipelineName = PipelinesEnum.IMPUTATION_MINIMAC4.getValue();
     String description = "description for testCreateImputationJobStairwayError";
     UUID jobId = newJobId;
@@ -477,7 +477,7 @@ class PipelinesApiControllerTest {
   // getPipelineJobs tests
 
   @Test
-  void testGetPipelineJobs() throws Exception {
+  void getPipelineJobsOk() throws Exception {
     String pipelineName = "imputation_minimac4";
     PipelinesEnum pipelineNameEnum = PipelinesEnum.IMPUTATION_MINIMAC4;
 
@@ -531,7 +531,7 @@ class PipelinesApiControllerTest {
   }
 
   @Test
-  void testGetPipelineJobsBadPipeline() throws Exception {
+  void getPipelineJobsBadPipeline() throws Exception {
     String badPipelineName = "bad-pipeline-id";
 
     mockMvc
@@ -545,7 +545,7 @@ class PipelinesApiControllerTest {
   // getPipelineJobResult tests
 
   @Test
-  void testGetPipelineJobResultDoneSuccess() throws Exception {
+  void getPipelineJobResultDoneSuccess() throws Exception {
     String pipelineName = PipelinesEnum.IMPUTATION_MINIMAC4.getValue();
     String jobIdString = newJobId.toString();
     String jobResultValue = "job result value";
@@ -588,7 +588,7 @@ class PipelinesApiControllerTest {
   }
 
   @Test
-  void testGetPipelineJobResultDoneFailed() throws Exception {
+  void getPipelineJobResultDoneFailed() throws Exception {
     String pipelineName = PipelinesEnum.IMPUTATION_MINIMAC4.getValue();
     String jobIdString = newJobId.toString();
     String errorMessage = "test exception message";
@@ -636,7 +636,7 @@ class PipelinesApiControllerTest {
   }
 
   @Test
-  void testGetPipelineJobResultRunning() throws Exception {
+  void getPipelineJobResultRunning() throws Exception {
     String pipelineName = PipelinesEnum.IMPUTATION_MINIMAC4.getValue();
     String jobIdString = newJobId.toString();
     Integer statusCode = 202;
@@ -679,7 +679,7 @@ class PipelinesApiControllerTest {
   }
 
   @Test
-  void testGetAsyncResultEndpointHttps() {
+  void getAsyncResultEndpointHttps() {
     String testServletPath = "test/path";
 
     MockHttpServletRequest request = new MockHttpServletRequest();
@@ -696,7 +696,7 @@ class PipelinesApiControllerTest {
   }
 
   @Test
-  void testGetAsyncResultEndpointHttp() {
+  void getAsyncResultEndpointHttp() {
     String testServletPath = "test/path";
 
     MockHttpServletRequest request = new MockHttpServletRequest();

--- a/service/src/test/java/bio/terra/pipelines/controller/PipelinesApiControllerTest.java
+++ b/service/src/test/java/bio/terra/pipelines/controller/PipelinesApiControllerTest.java
@@ -532,7 +532,7 @@ class PipelinesApiControllerTest {
             newJobId, testUser.getSubjectId(), PipelinesEnum.IMPUTATION_MINIMAC4))
         .thenReturn(
             StairwayTestUtils.constructFlightStateWithStatusAndId(FlightStatus.SUCCESS, newJobId));
-    when(jobApiUtils.retrieveAsyncJobResult(
+    when(jobServiceMock.retrieveAsyncJobResult(
             newJobId,
             testUser.getSubjectId(),
             PipelinesEnum.IMPUTATION_MINIMAC4,
@@ -579,7 +579,7 @@ class PipelinesApiControllerTest {
             newJobId, testUser.getSubjectId(), PipelinesEnum.IMPUTATION_MINIMAC4))
         .thenReturn(
             StairwayTestUtils.constructFlightStateWithStatusAndId(FlightStatus.ERROR, newJobId));
-    when(jobApiUtils.retrieveAsyncJobResult(
+    when(jobServiceMock.retrieveAsyncJobResult(
             newJobId,
             testUser.getSubjectId(),
             PipelinesEnum.IMPUTATION_MINIMAC4,
@@ -628,7 +628,7 @@ class PipelinesApiControllerTest {
             newJobId, testUser.getSubjectId(), PipelinesEnum.IMPUTATION_MINIMAC4))
         .thenReturn(
             StairwayTestUtils.constructFlightStateWithStatusAndId(FlightStatus.RUNNING, newJobId));
-    when(jobApiUtils.retrieveAsyncJobResult(
+    when(jobServiceMock.retrieveAsyncJobResult(
             newJobId,
             testUser.getSubjectId(),
             PipelinesEnum.IMPUTATION_MINIMAC4,

--- a/service/src/test/java/bio/terra/pipelines/controller/PipelinesApiControllerTest.java
+++ b/service/src/test/java/bio/terra/pipelines/controller/PipelinesApiControllerTest.java
@@ -76,7 +76,10 @@ class PipelinesApiControllerTest {
   private final Object testPipelineInputs = TestUtils.TEST_PIPELINE_INPUTS;
   private final UUID newJobId = TestUtils.TEST_NEW_UUID;
   private final String testResultPath = TestUtils.TEST_RESULT_PATH;
-  private final String testResultPathURL = String.format("http://localhost/%s", testResultPath);
+
+  // we mock IngressConfiguration.getDomainName() to return "localhost", which maps to "http://"
+  private final String fullResultURL =
+          String.format("http://localhost/%s", TestUtils.TEST_RESULT_PATH);
 
   @BeforeEach
   void beforeEach() {
@@ -200,7 +203,7 @@ class PipelinesApiControllerTest {
         new ObjectMapper()
             .readValue(result.getResponse().getContentAsString(), ApiCreateJobResponse.class);
     assertEquals(jobId.toString(), response.getJobReport().getId());
-    assertEquals(testResultPathURL, response.getJobReport().getResultURL());
+    assertEquals(fullResultURL, response.getJobReport().getResultURL());
     assertEquals(ApiJobReport.StatusEnum.RUNNING, response.getJobReport().getStatus());
   }
 
@@ -234,7 +237,7 @@ class PipelinesApiControllerTest {
         new ObjectMapper()
             .readValue(result.getResponse().getContentAsString(), ApiCreateJobResponse.class);
     assertEquals(jobId.toString(), response.getJobReport().getId());
-    assertEquals(testResultPathURL, response.getJobReport().getResultURL());
+    assertEquals(fullResultURL, response.getJobReport().getResultURL());
     assertEquals(ApiJobReport.StatusEnum.RUNNING, response.getJobReport().getStatus());
   }
 
@@ -274,7 +277,7 @@ class PipelinesApiControllerTest {
         new ObjectMapper()
             .readValue(result.getResponse().getContentAsString(), ApiCreateJobResponse.class);
     assertEquals(jobId.toString(), response.getJobReport().getId());
-    assertEquals(testResultPathURL, response.getJobReport().getResultURL());
+    assertEquals(fullResultURL, response.getJobReport().getResultURL());
     assertEquals(ApiJobReport.StatusEnum.SUCCEEDED, response.getJobReport().getStatus());
   }
 
@@ -314,7 +317,7 @@ class PipelinesApiControllerTest {
         new ObjectMapper()
             .readValue(result.getResponse().getContentAsString(), ApiCreateJobResponse.class);
     assertEquals(jobId.toString(), response.getJobReport().getId());
-    assertEquals(testResultPathURL, response.getJobReport().getResultURL());
+    assertEquals(fullResultURL, response.getJobReport().getResultURL());
   }
 
   @Test

--- a/service/src/test/java/bio/terra/pipelines/dependencies/cbas/CbasClientTest.java
+++ b/service/src/test/java/bio/terra/pipelines/dependencies/cbas/CbasClientTest.java
@@ -17,7 +17,7 @@ class CbasClientTest extends BaseEmbeddedDbTest {
   String authToken = "authToken";
 
   @Test
-  void TestWdsClientApis() {
+  void testWdsClientApis() {
 
     PublicApi publicApi = cbasClient.publicApi(cbasBaseUri, authToken);
 

--- a/service/src/test/java/bio/terra/pipelines/dependencies/leonardo/LeonardoClientTest.java
+++ b/service/src/test/java/bio/terra/pipelines/dependencies/leonardo/LeonardoClientTest.java
@@ -21,7 +21,7 @@ class LeonardoClientTest {
           expectedBaseUri, List.of(), List.of(), Duration.ofMinutes(10), true);
 
   @Test
-  void TestLeonardoAuthorizedClient() {
+  void testLeonardoAuthorizedClient() {
     leonardoClient = new LeonardoClient(leonardoServerConfiguration);
 
     ApiClient apiClient = leonardoClient.getUnauthorizedApiClient();

--- a/service/src/test/java/bio/terra/pipelines/dependencies/sam/SamClientTest.java
+++ b/service/src/test/java/bio/terra/pipelines/dependencies/sam/SamClientTest.java
@@ -16,7 +16,7 @@ class SamClientTest {
   SamConfiguration samConfiguration = new SamConfiguration(expectedBaseUri);
 
   @Test
-  void TestSamAuthorizedClient() {
+  void testSamAuthorizedClient() {
     samClient = new SamClient(samConfiguration);
 
     StatusApi statusApi = samClient.statusApi();

--- a/service/src/test/java/bio/terra/pipelines/dependencies/stairway/JobServiceMockTest.java
+++ b/service/src/test/java/bio/terra/pipelines/dependencies/stairway/JobServiceMockTest.java
@@ -12,7 +12,7 @@ import bio.terra.pipelines.testutils.BaseEmbeddedDbTest;
 import bio.terra.pipelines.testutils.StairwayTestUtils;
 import bio.terra.pipelines.testutils.TestUtils;
 import bio.terra.stairway.*;
-import bio.terra.stairway.exception.RetryException;
+import bio.terra.stairway.exception.MakeFlightException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import java.util.Optional;
 import java.util.UUID;
@@ -45,8 +45,8 @@ class JobServiceMockTest extends BaseEmbeddedDbTest {
 
   @Test
   void submit_StairwayException() throws InterruptedException {
-    // a RetryException is an instance of StairwayException
-    doThrow(new RetryException("test exception"))
+    // a MakeFlightException( is an instance of StairwayException
+    doThrow(new MakeFlightException("test exception"))
         .when(mockStairway)
         .submitWithDebugInfo(any(), any(), any(), ArgumentMatchers.eq(false), any());
 
@@ -153,8 +153,8 @@ class JobServiceMockTest extends BaseEmbeddedDbTest {
   @Test
   void retrieveJobResult_StairwayException() throws InterruptedException {
     UUID flightId = TestUtils.TEST_NEW_UUID;
-    // a RetryException is an instance of StairwayException
-    when(mockStairway.getFlightState(any())).thenThrow(new RetryException("test exception"));
+    // a MakeFlightException( is an instance of StairwayException
+    when(mockStairway.getFlightState(any())).thenThrow(new MakeFlightException("test exception"));
 
     assertThrows(
         InternalStairwayException.class,
@@ -188,8 +188,8 @@ class JobServiceMockTest extends BaseEmbeddedDbTest {
   void retrieveJob_stairwayException() throws InterruptedException {
     UUID flightId = TestUtils.TEST_NEW_UUID;
     String userId = "testUserId";
-    // a RetryException is an instance of StairwayException
-    when(mockStairway.getFlightState(any())).thenThrow(new RetryException("test exception"));
+    // a MakeFlightException( is an instance of StairwayException
+    when(mockStairway.getFlightState(any())).thenThrow(new MakeFlightException("test exception"));
 
     assertThrows(
         InternalStairwayException.class, () -> jobService.retrieveJob(flightId, userId, null));
@@ -277,11 +277,28 @@ class JobServiceMockTest extends BaseEmbeddedDbTest {
   }
 
   @Test
+  void retrieveAsyncJobResultStairwayException() throws InterruptedException {
+    UUID flightId = TestUtils.TEST_NEW_UUID;
+    // a MakeFlightException is an instance of StairwayException
+    when(mockStairway.getFlightState(any())).thenThrow(new MakeFlightException("test exception"));
+
+    assertThrows(
+        InternalStairwayException.class,
+        () ->
+            jobService.retrieveAsyncJobResult(
+                flightId,
+                TestUtils.TEST_USER_ID_1,
+                TestUtils.TEST_PIPELINE_1_ENUM,
+                String.class,
+                null));
+  }
+
+  @Test
   void enumerateJobs_stairwayException() throws InterruptedException {
     String userId = "testUserId";
-    // a RetryException is an instance of StairwayException
+    // a MakeFlightException( is an instance of StairwayException
     when(mockStairway.getFlights(any(), any(), any()))
-        .thenThrow(new RetryException("test exception"));
+        .thenThrow(new MakeFlightException("test exception"));
 
     assertThrows(
         InternalStairwayException.class, () -> jobService.enumerateJobs(userId, 10, null, null));

--- a/service/src/test/java/bio/terra/pipelines/dependencies/stairway/JobServiceMockTest.java
+++ b/service/src/test/java/bio/terra/pipelines/dependencies/stairway/JobServiceMockTest.java
@@ -5,7 +5,6 @@ import static org.mockito.Mockito.*;
 
 import bio.terra.common.exception.InternalServerErrorException;
 import bio.terra.common.stairway.StairwayComponent;
-import bio.terra.pipelines.app.configuration.external.IngressConfiguration;
 import bio.terra.pipelines.app.controller.JobApiUtils;
 import bio.terra.pipelines.common.utils.PipelinesEnum;
 import bio.terra.pipelines.dependencies.stairway.exception.*;
@@ -29,11 +28,9 @@ class JobServiceMockTest extends BaseEmbeddedDbTest {
   @InjectMocks JobService jobService;
   @Mock private Stairway mockStairway;
   @Mock private StairwayComponent mockStairwayComponent;
-  @Mock private IngressConfiguration ingressConfiguration;
 
   @BeforeEach
   void setup() {
-    when(ingressConfiguration.getDomainName()).thenReturn("localhost");
     when(mockStairwayComponent.get()).thenReturn(mockStairway);
   }
 
@@ -244,12 +241,7 @@ class JobServiceMockTest extends BaseEmbeddedDbTest {
 
     JobApiUtils.AsyncJobResult<String> result =
         jobService.retrieveAsyncJobResult(
-            ingressConfiguration,
-            jobId,
-            TestUtils.TEST_USER_ID_1,
-            PipelinesEnum.IMPUTATION_MINIMAC4,
-            String.class,
-            null);
+            jobId, TestUtils.TEST_USER_ID_1, PipelinesEnum.IMPUTATION_MINIMAC4, String.class, null);
 
     assertEquals(jobId.toString(), result.getJobReport().getId());
     assertEquals(202, result.getJobReport().getStatusCode());
@@ -272,12 +264,7 @@ class JobServiceMockTest extends BaseEmbeddedDbTest {
 
     JobApiUtils.AsyncJobResult<String> result =
         jobService.retrieveAsyncJobResult(
-            ingressConfiguration,
-            jobId,
-            TestUtils.TEST_USER_ID_1,
-            PipelinesEnum.IMPUTATION_MINIMAC4,
-            String.class,
-            null);
+            jobId, TestUtils.TEST_USER_ID_1, PipelinesEnum.IMPUTATION_MINIMAC4, String.class, null);
 
     assertEquals(jobId.toString(), result.getJobReport().getId());
     assertEquals(200, result.getJobReport().getStatusCode());
@@ -305,12 +292,7 @@ class JobServiceMockTest extends BaseEmbeddedDbTest {
 
     JobApiUtils.AsyncJobResult<String> result =
         jobService.retrieveAsyncJobResult(
-            ingressConfiguration,
-            jobId,
-            TestUtils.TEST_USER_ID_1,
-            PipelinesEnum.IMPUTATION_MINIMAC4,
-            String.class,
-            null);
+            jobId, TestUtils.TEST_USER_ID_1, PipelinesEnum.IMPUTATION_MINIMAC4, String.class, null);
 
     assertEquals(jobId.toString(), result.getJobReport().getId());
     assertEquals(500, result.getJobReport().getStatusCode());
@@ -328,7 +310,6 @@ class JobServiceMockTest extends BaseEmbeddedDbTest {
         InternalStairwayException.class,
         () ->
             jobService.retrieveAsyncJobResult(
-                ingressConfiguration,
                 flightId,
                 TestUtils.TEST_USER_ID_1,
                 TestUtils.TEST_PIPELINE_1_ENUM,

--- a/service/src/test/java/bio/terra/pipelines/dependencies/stairway/JobServiceMockTest.java
+++ b/service/src/test/java/bio/terra/pipelines/dependencies/stairway/JobServiceMockTest.java
@@ -44,7 +44,7 @@ class JobServiceMockTest extends BaseEmbeddedDbTest {
   }
 
   @Test
-  void submit_StairwayException() throws InterruptedException {
+  void submitStairwayException() throws InterruptedException {
     // a MakeFlightException is an instance of StairwayException
     doThrow(new MakeFlightException("test exception"))
         .when(mockStairway)
@@ -55,7 +55,7 @@ class JobServiceMockTest extends BaseEmbeddedDbTest {
   }
 
   @Test
-  void retrieveJobResult_successWithResultClass() throws InterruptedException {
+  void retrieveJobResultSuccessWithResultClass() throws InterruptedException {
     FlightMap inputParams = new FlightMap();
     FlightMap flightMap = new FlightMap();
     String expectedResponse = "foo";
@@ -73,7 +73,7 @@ class JobServiceMockTest extends BaseEmbeddedDbTest {
   }
 
   @Test
-  void retrieveJobResult_successWithResultTypeRef() throws InterruptedException {
+  void retrieveJobResultSuccessWithResultTypeRef() throws InterruptedException {
     FlightMap inputParams = new FlightMap();
     FlightMap flightMap = new FlightMap();
     String expectedResponse = "foo";
@@ -91,7 +91,7 @@ class JobServiceMockTest extends BaseEmbeddedDbTest {
   }
 
   @Test
-  void retrieveJobResult_noResultClassOrTypeThrows() throws InterruptedException {
+  void retrieveJobResultNoResultClassOrTypeThrows() throws InterruptedException {
     FlightMap inputParams = new FlightMap();
     FlightMap flightMap = new FlightMap();
     flightMap.put(JobMapKeys.RESPONSE.getKeyName(), null);
@@ -108,7 +108,7 @@ class JobServiceMockTest extends BaseEmbeddedDbTest {
   }
 
   @Test
-  void retrieveJobResult_fatal() throws InterruptedException {
+  void retrieveJobResultFatal() throws InterruptedException {
     UUID flightId = TestUtils.TEST_NEW_UUID;
     FlightState fatalFlightState =
         StairwayTestUtils.constructFlightStateWithStatusAndId(FlightStatus.FATAL, flightId);
@@ -122,7 +122,7 @@ class JobServiceMockTest extends BaseEmbeddedDbTest {
   }
 
   @Test
-  void retrieveJobResult_fatalNonRuntime() throws InterruptedException {
+  void retrieveJobResultFatalNonRuntime() throws InterruptedException {
     UUID flightId = TestUtils.TEST_NEW_UUID;
     FlightState fatalFlightState =
         StairwayTestUtils.constructFlightStateWithStatusAndId(FlightStatus.FATAL, flightId);
@@ -137,7 +137,7 @@ class JobServiceMockTest extends BaseEmbeddedDbTest {
   }
 
   @Test
-  void retrieveJobResult_errorFlightState() throws InterruptedException {
+  void retrieveJobResultErrorFlightState() throws InterruptedException {
     UUID flightId = TestUtils.TEST_NEW_UUID;
     FlightState errorFlightState =
         StairwayTestUtils.constructFlightStateWithStatusAndId(FlightStatus.ERROR, flightId);
@@ -151,7 +151,7 @@ class JobServiceMockTest extends BaseEmbeddedDbTest {
   }
 
   @Test
-  void retrieveJobResult_StairwayException() throws InterruptedException {
+  void retrieveJobResultStairwayException() throws InterruptedException {
     UUID flightId = TestUtils.TEST_NEW_UUID;
     // a MakeFlightException is an instance of StairwayException
     when(mockStairway.getFlightState(any())).thenThrow(new MakeFlightException("test exception"));
@@ -162,7 +162,7 @@ class JobServiceMockTest extends BaseEmbeddedDbTest {
   }
 
   @Test
-  void retrieveJobResult_running() throws InterruptedException {
+  void retrieveJobResultRunning() throws InterruptedException {
     UUID flightId = TestUtils.TEST_NEW_UUID;
     FlightState runningFlightState =
         StairwayTestUtils.constructFlightStateWithStatusAndId(FlightStatus.RUNNING, flightId);
@@ -175,7 +175,7 @@ class JobServiceMockTest extends BaseEmbeddedDbTest {
   }
 
   @Test
-  void retrieveJobResult_interrupted() throws InterruptedException {
+  void retrieveJobResultInterrupted() throws InterruptedException {
     UUID flightId = TestUtils.TEST_NEW_UUID;
     when(mockStairway.getFlightState(any())).thenThrow(new InterruptedException("test exception"));
 
@@ -185,7 +185,7 @@ class JobServiceMockTest extends BaseEmbeddedDbTest {
   }
 
   @Test
-  void retrieveJob_stairwayException() throws InterruptedException {
+  void retrieveJobStairwayException() throws InterruptedException {
     UUID flightId = TestUtils.TEST_NEW_UUID;
     String userId = "testUserId";
     // a MakeFlightException is an instance of StairwayException
@@ -196,7 +196,7 @@ class JobServiceMockTest extends BaseEmbeddedDbTest {
   }
 
   @Test
-  void retrieveJob_interruptedException() throws InterruptedException {
+  void retrieveJobInterruptedException() throws InterruptedException {
     UUID flightId = TestUtils.TEST_NEW_UUID;
     String userId = "testUserId";
 
@@ -208,7 +208,7 @@ class JobServiceMockTest extends BaseEmbeddedDbTest {
   }
 
   @Test
-  void enumerateJobs_stairwayException() throws InterruptedException {
+  void enumerateJobsStairwayException() throws InterruptedException {
     String userId = "testUserId";
     // a MakeFlightException is an instance of StairwayException
     when(mockStairway.getFlights(any(), any(), any()))
@@ -219,7 +219,7 @@ class JobServiceMockTest extends BaseEmbeddedDbTest {
   }
 
   @Test
-  void enumerateJobs_interruptedException() throws InterruptedException {
+  void enumerateJobsInterruptedException() throws InterruptedException {
     String userId = "testUserId";
 
     when(mockStairway.getFlights(any(), any(), any())).thenThrow(new InterruptedException());
@@ -230,7 +230,7 @@ class JobServiceMockTest extends BaseEmbeddedDbTest {
   }
 
   @Test
-  void testRetrieveAsyncJobResultRunning() throws InterruptedException {
+  void retrieveAsyncJobResultRunning() throws InterruptedException {
     UUID jobId = TestUtils.TEST_NEW_UUID;
     FlightMap inputParameters = StairwayTestUtils.CREATE_JOB_INPUT_PARAMS;
     FlightState flightState =
@@ -250,7 +250,7 @@ class JobServiceMockTest extends BaseEmbeddedDbTest {
   }
 
   @Test
-  void testRetrieveAsyncJobResultSucceeded() throws InterruptedException {
+  void retrieveAsyncJobResultSucceeded() throws InterruptedException {
     UUID jobId = TestUtils.TEST_NEW_UUID;
     FlightMap inputParameters = StairwayTestUtils.CREATE_JOB_INPUT_PARAMS;
     FlightMap workingMap = new FlightMap();
@@ -273,7 +273,7 @@ class JobServiceMockTest extends BaseEmbeddedDbTest {
   }
 
   @Test
-  void testRetrieveAsyncJobResultFailed() throws InterruptedException {
+  void retrieveAsyncJobResultFailed() throws InterruptedException {
     UUID jobId = TestUtils.TEST_NEW_UUID;
     FlightMap inputParameters = StairwayTestUtils.CREATE_JOB_INPUT_PARAMS;
     // even on a fatal failure the response might have been written to the working map

--- a/service/src/test/java/bio/terra/pipelines/dependencies/stairway/JobServiceMockTest.java
+++ b/service/src/test/java/bio/terra/pipelines/dependencies/stairway/JobServiceMockTest.java
@@ -189,7 +189,8 @@ class JobServiceMockTest extends BaseEmbeddedDbTest {
     // a RetryException is an instance of StairwayException
     when(mockStairway.getFlightState(any())).thenThrow(new RetryException("test exception"));
 
-    assertThrows(InternalStairwayException.class, () -> jobService.retrieveJob(flightId, userId));
+    assertThrows(
+        InternalStairwayException.class, () -> jobService.retrieveJob(flightId, userId, null));
   }
 
   @Test
@@ -200,7 +201,8 @@ class JobServiceMockTest extends BaseEmbeddedDbTest {
     when(mockStairway.getFlightState(any())).thenThrow(new InterruptedException());
 
     // InterruptedException should be caught and re-thrown as an InternalStairwayException
-    assertThrows(InternalStairwayException.class, () -> jobService.retrieveJob(flightId, userId));
+    assertThrows(
+        InternalStairwayException.class, () -> jobService.retrieveJob(flightId, userId, null));
   }
 
   @Test

--- a/service/src/test/java/bio/terra/pipelines/dependencies/stairway/JobServiceMockTest.java
+++ b/service/src/test/java/bio/terra/pipelines/dependencies/stairway/JobServiceMockTest.java
@@ -5,8 +5,6 @@ import static org.mockito.Mockito.*;
 
 import bio.terra.common.exception.InternalServerErrorException;
 import bio.terra.common.stairway.StairwayComponent;
-import bio.terra.pipelines.app.controller.JobApiUtils;
-import bio.terra.pipelines.common.utils.PipelinesEnum;
 import bio.terra.pipelines.dependencies.stairway.exception.*;
 import bio.terra.pipelines.testutils.BaseEmbeddedDbTest;
 import bio.terra.pipelines.testutils.StairwayTestUtils;
@@ -45,7 +43,7 @@ class JobServiceMockTest extends BaseEmbeddedDbTest {
 
   @Test
   void submit_StairwayException() throws InterruptedException {
-    // a MakeFlightException( is an instance of StairwayException
+    // a MakeFlightException is an instance of StairwayException
     doThrow(new MakeFlightException("test exception"))
         .when(mockStairway)
         .submitWithDebugInfo(any(), any(), any(), ArgumentMatchers.eq(false), any());
@@ -153,7 +151,7 @@ class JobServiceMockTest extends BaseEmbeddedDbTest {
   @Test
   void retrieveJobResult_StairwayException() throws InterruptedException {
     UUID flightId = TestUtils.TEST_NEW_UUID;
-    // a MakeFlightException( is an instance of StairwayException
+    // a MakeFlightException is an instance of StairwayException
     when(mockStairway.getFlightState(any())).thenThrow(new MakeFlightException("test exception"));
 
     assertThrows(
@@ -188,7 +186,7 @@ class JobServiceMockTest extends BaseEmbeddedDbTest {
   void retrieveJob_stairwayException() throws InterruptedException {
     UUID flightId = TestUtils.TEST_NEW_UUID;
     String userId = "testUserId";
-    // a MakeFlightException( is an instance of StairwayException
+    // a MakeFlightException is an instance of StairwayException
     when(mockStairway.getFlightState(any())).thenThrow(new MakeFlightException("test exception"));
 
     assertThrows(
@@ -208,95 +206,9 @@ class JobServiceMockTest extends BaseEmbeddedDbTest {
   }
 
   @Test
-  void testRetrieveAsyncJobResultRunning() throws InterruptedException {
-    UUID jobId = TestUtils.TEST_NEW_UUID;
-    FlightMap inputParameters = StairwayTestUtils.CREATE_JOB_INPUT_PARAMS;
-    FlightState flightState =
-        StairwayTestUtils.constructFlightStateWithStatusAndId(
-            FlightStatus.RUNNING, jobId, inputParameters, new FlightMap());
-
-    when(mockStairway.getFlightState(any())).thenReturn(flightState);
-
-    JobApiUtils.AsyncJobResult<String> result =
-        jobService.retrieveAsyncJobResult(
-            jobId, TestUtils.TEST_USER_ID_1, PipelinesEnum.IMPUTATION_MINIMAC4, String.class, null);
-
-    assertEquals(jobId.toString(), result.getJobReport().getId());
-    assertEquals(202, result.getJobReport().getStatusCode());
-    assertNull(result.getResult());
-    assertNull(result.getApiErrorReport());
-  }
-
-  @Test
-  void testRetrieveAsyncJobResultSucceeded() throws InterruptedException {
-    UUID jobId = TestUtils.TEST_NEW_UUID;
-    FlightMap inputParameters = StairwayTestUtils.CREATE_JOB_INPUT_PARAMS;
-    FlightMap workingMap = new FlightMap();
-    String testResponse = "test response";
-    workingMap.put(JobMapKeys.RESPONSE.getKeyName(), testResponse);
-    FlightState flightState =
-        StairwayTestUtils.constructFlightStateWithStatusAndId(
-            FlightStatus.SUCCESS, jobId, inputParameters, workingMap);
-
-    when(mockStairway.getFlightState(any())).thenReturn(flightState);
-
-    JobApiUtils.AsyncJobResult<String> result =
-        jobService.retrieveAsyncJobResult(
-            jobId, TestUtils.TEST_USER_ID_1, PipelinesEnum.IMPUTATION_MINIMAC4, String.class, null);
-
-    assertEquals(jobId.toString(), result.getJobReport().getId());
-    assertEquals(200, result.getJobReport().getStatusCode());
-    assertEquals(testResponse, result.getResult());
-    assertNull(result.getApiErrorReport());
-  }
-
-  @Test
-  void testRetrieveAsyncJobResultFailed() throws InterruptedException {
-    UUID jobId = TestUtils.TEST_NEW_UUID;
-    FlightMap inputParameters = StairwayTestUtils.CREATE_JOB_INPUT_PARAMS;
-    // even on a fatal failure the response might have been written to the working map
-    FlightMap workingMap = new FlightMap();
-    String testResponse = "test response";
-    workingMap.put(JobMapKeys.RESPONSE.getKeyName(), testResponse);
-    FlightState flightState =
-        StairwayTestUtils.constructFlightStateWithStatusAndId(
-            FlightStatus.ERROR, jobId, inputParameters, workingMap);
-    String testErrorMsg = "test exception";
-    flightState.setException(new RuntimeException(testErrorMsg));
-
-    when(mockStairway.getFlightState(any())).thenReturn(flightState);
-
-    JobApiUtils.AsyncJobResult<String> result =
-        jobService.retrieveAsyncJobResult(
-            jobId, TestUtils.TEST_USER_ID_1, PipelinesEnum.IMPUTATION_MINIMAC4, String.class, null);
-
-    assertEquals(jobId.toString(), result.getJobReport().getId());
-    assertEquals(500, result.getJobReport().getStatusCode());
-    assertNull(result.getResult());
-    assertEquals(testErrorMsg, result.getApiErrorReport().getMessage());
-  }
-
-  @Test
-  void retrieveAsyncJobResultStairwayException() throws InterruptedException {
-    UUID flightId = TestUtils.TEST_NEW_UUID;
-    // a MakeFlightException is an instance of StairwayException
-    when(mockStairway.getFlightState(any())).thenThrow(new MakeFlightException("test exception"));
-
-    assertThrows(
-        InternalStairwayException.class,
-        () ->
-            jobService.retrieveAsyncJobResult(
-                flightId,
-                TestUtils.TEST_USER_ID_1,
-                TestUtils.TEST_PIPELINE_1_ENUM,
-                String.class,
-                null));
-  }
-
-  @Test
   void enumerateJobs_stairwayException() throws InterruptedException {
     String userId = "testUserId";
-    // a MakeFlightException( is an instance of StairwayException
+    // a MakeFlightException is an instance of StairwayException
     when(mockStairway.getFlights(any(), any(), any()))
         .thenThrow(new MakeFlightException("test exception"));
 

--- a/service/src/test/java/bio/terra/pipelines/dependencies/stairway/JobServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/dependencies/stairway/JobServiceTest.java
@@ -35,7 +35,7 @@ class JobServiceTest extends BaseEmbeddedDbTest {
   }
 
   @Test
-  void submit_duplicateFlightId() throws InterruptedException {
+  void submitDuplicateFlightId() throws InterruptedException {
     UUID jobId = newJobId;
 
     JobBuilder jobToSubmit =
@@ -67,7 +67,7 @@ class JobServiceTest extends BaseEmbeddedDbTest {
   }
 
   @Test
-  void submit_success() {
+  void submitSuccess() {
     // this tests the setters in JobBuilder
     JobBuilder jobToSubmit =
         jobService
@@ -83,7 +83,7 @@ class JobServiceTest extends BaseEmbeddedDbTest {
   }
 
   @Test
-  void submit_missingFlightClass() {
+  void submitMissingFlightClass() {
     JobBuilder jobToSubmit =
         jobService
             .newJob()
@@ -101,7 +101,7 @@ class JobServiceTest extends BaseEmbeddedDbTest {
   }
 
   @Test
-  void submit_missingUserId() {
+  void submitMissingUserId() {
     JobBuilder jobToSubmit =
         jobService
             .newJob()
@@ -118,7 +118,7 @@ class JobServiceTest extends BaseEmbeddedDbTest {
   }
 
   @Test
-  void submit_nullRequiredField() {
+  void submitNullRequiredField() {
     JobBuilder jobToSubmit =
         jobService
             .newJob()
@@ -137,7 +137,7 @@ class JobServiceTest extends BaseEmbeddedDbTest {
   }
 
   @Test
-  void submit_blankRequiredField() {
+  void submitBlankRequiredField() {
     JobBuilder jobToSubmit =
         jobService
             .newJob()
@@ -156,7 +156,7 @@ class JobServiceTest extends BaseEmbeddedDbTest {
   }
 
   @Test
-  void submit_missingPipelineId() {
+  void submitMissingPipelineId() {
     JobBuilder jobToSubmit =
         jobService
             .newJob()
@@ -174,7 +174,7 @@ class JobServiceTest extends BaseEmbeddedDbTest {
   }
 
   @Test
-  void submit_missingJobId() {
+  void submitMissingJobId() {
     JobBuilder jobToSubmit =
         jobService
             .newJob()
@@ -192,7 +192,7 @@ class JobServiceTest extends BaseEmbeddedDbTest {
   }
 
   @Test
-  void submit_missingMultipleFields() {
+  void submitMissingMultipleFields() {
     JobBuilder jobToSubmit =
         jobService
             .newJob()
@@ -209,7 +209,7 @@ class JobServiceTest extends BaseEmbeddedDbTest {
   }
 
   @Test
-  void submit_missingDescriptionOk() {
+  void submitMissingDescriptionOk() {
     UUID jobId = newJobId;
     JobBuilder jobToSubmit =
         jobService
@@ -224,13 +224,13 @@ class JobServiceTest extends BaseEmbeddedDbTest {
   }
 
   @Test
-  void retrieveJob_badId() {
+  void retrieveJobBadId() {
     UUID jobId = newJobId;
     assertThrows(JobNotFoundException.class, () -> jobService.retrieveJob(jobId, testUserId, null));
   }
 
   @Test
-  void retrieveJobResult_badId() {
+  void retrieveJobResultBadId() {
     UUID jobId = newJobId;
     assertThrows(
         JobNotFoundException.class, () -> jobService.retrieveJobResult(jobId, Object.class));
@@ -239,7 +239,7 @@ class JobServiceTest extends BaseEmbeddedDbTest {
   /* Note: we currently only have one pipeline: Imputation. when we add the next pipeline,
   we should update this test with some instances of that pipeline as well. */
   @Test
-  void testEnumerateJobsPipelineIdImputation() throws InterruptedException {
+  void enumerateJobsPipelineIdImputation() throws InterruptedException {
     // create two Imputation jobs
     UUID firstJobId = UUID.randomUUID();
     UUID secondJobId = UUID.randomUUID();
@@ -252,7 +252,7 @@ class JobServiceTest extends BaseEmbeddedDbTest {
   }
 
   @Test
-  void testEnumerateJobsCorrectUserIsolation() throws InterruptedException {
+  void enumerateJobsCorrectUserIsolation() throws InterruptedException {
     // create a job for the first user and verify that it shows up
     runFlight(newJobId, testUserId, imputationPipelineName, "first user's flight");
     EnumeratedJobs jobsUserOne = jobService.enumerateJobs(testUserId, 10, null, null);
@@ -273,7 +273,7 @@ class JobServiceTest extends BaseEmbeddedDbTest {
   }
 
   @Test
-  void testRetrieveJobCorrectUserIsolation() throws InterruptedException {
+  void retrieveJobCorrectUserIsolation() throws InterruptedException {
     // create a job for the first user and verify that it shows up
     UUID jobIdUser1 = newJobId;
     runFlight(jobIdUser1, testUserId, imputationPipelineName, "first user's flight");
@@ -287,7 +287,7 @@ class JobServiceTest extends BaseEmbeddedDbTest {
   }
 
   @Test
-  void testRetrieveJobWithPipelineName() throws InterruptedException {
+  void retrieveJobWithPipelineName() throws InterruptedException {
     // create an imputation job for the first user and verify that it shows up
     UUID jobIdUser1 = newJobId;
     runFlight(jobIdUser1, testUserId, imputationPipelineName, "first user's flight");

--- a/service/src/test/java/bio/terra/pipelines/dependencies/stairway/JobServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/dependencies/stairway/JobServiceTest.java
@@ -226,7 +226,7 @@ class JobServiceTest extends BaseEmbeddedDbTest {
   @Test
   void retrieveJob_badId() {
     UUID jobId = newJobId;
-    assertThrows(JobNotFoundException.class, () -> jobService.retrieveJob(jobId, testUserId));
+    assertThrows(JobNotFoundException.class, () -> jobService.retrieveJob(jobId, testUserId, null));
   }
 
   @Test
@@ -277,13 +277,13 @@ class JobServiceTest extends BaseEmbeddedDbTest {
     // create a job for the first user and verify that it shows up
     UUID jobIdUser1 = newJobId;
     runFlight(jobIdUser1, testUserId, imputationPipelineName, "first user's flight");
-    FlightState user1job = jobService.retrieveJob(jobIdUser1, testUserId);
+    FlightState user1job = jobService.retrieveJob(jobIdUser1, testUserId, null);
     assertEquals(jobIdUser1.toString(), user1job.getFlightId());
 
     // make sure that user 2 doesn't have access to user 1's job
     assertThrows(
         JobUnauthorizedException.class,
-        () -> jobService.retrieveJob(jobIdUser1, TestUtils.TEST_USER_ID_2));
+        () -> jobService.retrieveJob(jobIdUser1, TestUtils.TEST_USER_ID_2, null));
   }
 
   @Test

--- a/service/src/test/java/bio/terra/pipelines/dependencies/stairway/JobServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/dependencies/stairway/JobServiceTest.java
@@ -287,6 +287,15 @@ class JobServiceTest extends BaseEmbeddedDbTest {
   }
 
   @Test
+  void testRetrieveJobWithPipelineName() throws InterruptedException {
+    // create an imputation job for the first user and verify that it shows up
+    UUID jobIdUser1 = newJobId;
+    runFlight(jobIdUser1, testUserId, imputationPipelineName, "first user's flight");
+    FlightState user1job = jobService.retrieveJob(jobIdUser1, testUserId, imputationPipelineName);
+    assertEquals(jobIdUser1.toString(), user1job.getFlightId());
+  }
+
+  @Test
   void setFlightDebugInfoForTest() throws InterruptedException {
     // Set a FlightDebugInfo so that any job submission should fail on the last step.
     jobService.setFlightDebugInfoForTest(

--- a/service/src/test/java/bio/terra/pipelines/dependencies/wds/WdsClientTest.java
+++ b/service/src/test/java/bio/terra/pipelines/dependencies/wds/WdsClientTest.java
@@ -17,7 +17,7 @@ class WdsClientTest extends BaseEmbeddedDbTest {
   String authToken = "authToken";
 
   @Test
-  void TestWdsClientApis() {
+  void testWdsClientApis() {
 
     RecordsApi recordsApi = wdsClient.recordsApi(wdsBaseUri, authToken);
 

--- a/service/src/test/java/bio/terra/pipelines/service/ImputationServiceMockTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/ImputationServiceMockTest.java
@@ -111,7 +111,7 @@ class ImputationServiceMockTest extends BaseEmbeddedDbTest {
             "test description",
             TestUtils.TEST_PIPELINE_1,
             testPipelineInputs,
-            TestUtils.TEST_RESULT_PATH);
+            TestUtils.TEST_RESULT_URL);
     assertEquals(testUUID, writtenUUID);
   }
 }

--- a/service/src/test/java/bio/terra/pipelines/service/ImputationServiceMockTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/ImputationServiceMockTest.java
@@ -43,7 +43,6 @@ class ImputationServiceMockTest extends BaseEmbeddedDbTest {
   // parameters used repeatedly by various tests, and things we'll want mocks to respond to
   // universally
   private final String testUserId = TestUtils.TEST_USER_ID_1;
-  private final Long testPipelineId = TestUtils.TEST_PIPELINE_ID_1;
 
   private final Object testPipelineInputs = TestUtils.TEST_PIPELINE_INPUTS;
   private final UUID testUUID = TestUtils.TEST_NEW_UUID;
@@ -111,7 +110,8 @@ class ImputationServiceMockTest extends BaseEmbeddedDbTest {
             testUserId,
             "test description",
             TestUtils.TEST_PIPELINE_1,
-            testPipelineInputs);
+            testPipelineInputs,
+            "test/result/path");
     assertEquals(testUUID, writtenUUID);
   }
 }

--- a/service/src/test/java/bio/terra/pipelines/service/ImputationServiceMockTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/ImputationServiceMockTest.java
@@ -102,7 +102,7 @@ class ImputationServiceMockTest extends BaseEmbeddedDbTest {
   }
 
   @Test
-  void testCreateJob_success() {
+  void createJobSuccess() {
     // note this doesn't actually kick off a job
     UUID writtenUUID =
         imputationService.createImputationJob(

--- a/service/src/test/java/bio/terra/pipelines/service/ImputationServiceMockTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/ImputationServiceMockTest.java
@@ -111,7 +111,7 @@ class ImputationServiceMockTest extends BaseEmbeddedDbTest {
             "test description",
             TestUtils.TEST_PIPELINE_1,
             testPipelineInputs,
-            "test/result/path");
+            TestUtils.TEST_RESULT_PATH);
     assertEquals(testUUID, writtenUUID);
   }
 }

--- a/service/src/test/java/bio/terra/pipelines/service/ImputationServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/ImputationServiceTest.java
@@ -37,7 +37,7 @@ class ImputationServiceTest extends BaseEmbeddedDbTest {
   }
 
   @Test
-  void testWriteJobToDb() {
+  void writeJobToDbOk() {
     List<ImputationJob> jobsDefault = imputationJobsRepository.findAllByUserId(testUserId);
 
     // test data migration inserts one row by default
@@ -63,7 +63,7 @@ class ImputationServiceTest extends BaseEmbeddedDbTest {
   }
 
   @Test
-  void testWriteDuplicateJob() {
+  void writeJobToDbDuplicateJob() {
     // try to save a job with the same job id two times, the second time it should throw duplicate
     // exception error
     ImputationJob newJob = createTestJobWithJobId(testJobId);

--- a/service/src/test/java/bio/terra/pipelines/service/PipelinesServiceMockTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/PipelinesServiceMockTest.java
@@ -17,7 +17,7 @@ class PipelinesServiceMockTest extends BaseEmbeddedDbTest {
   @MockBean private PipelinesRepository pipelinesRepository;
 
   @Test
-  void testGetPipelines() {
+  void getPipelinesOk() {
     // getPipelines should return a list of Pipelines
     List<Pipeline> pipelinesList = List.of(TestUtils.TEST_PIPELINE_1, TestUtils.TEST_PIPELINE_2);
     when(pipelinesRepository.findAll()).thenReturn(pipelinesList);

--- a/service/src/test/java/bio/terra/pipelines/service/PipelinesServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/PipelinesServiceTest.java
@@ -16,7 +16,7 @@ class PipelinesServiceTest extends BaseEmbeddedDbTest {
   @Autowired PipelinesRepository pipelinesRepository;
 
   @Test
-  void testGetCorrectNumberOfPipelines() {
+  void getCorrectNumberOfPipelines() {
     // migrations insert one pipeline (imputation) so make sure we find it
     List<Pipeline> pipelineList = pipelinesService.getPipelines();
     assertEquals(1, pipelineList.size());
@@ -44,7 +44,7 @@ class PipelinesServiceTest extends BaseEmbeddedDbTest {
   }
 
   @Test
-  void testAllPipelineEnumsExist() {
+  void allPipelineEnumsExist() {
     // make sure all the pipelines in the enum exist in the table
     for (PipelinesEnum p : PipelinesEnum.values()) {
       assertTrue(pipelinesRepository.existsByName(p.getValue()));

--- a/service/src/test/java/bio/terra/pipelines/stairway/RunImputationJobFlightTest.java
+++ b/service/src/test/java/bio/terra/pipelines/stairway/RunImputationJobFlightTest.java
@@ -32,12 +32,13 @@ class RunImputationJobFlightTest extends BaseEmbeddedDbTest {
   private static final UUID testJobId = TestUtils.TEST_NEW_UUID;
 
   private final Object testPipelineInputs = TestUtils.TEST_PIPELINE_INPUTS;
+  private final String testResultPath = TestUtils.TEST_RESULT_PATH;
 
   @Test
   void createJobFlight_success() throws Exception {
     FlightMap inputParameters =
         StairwayTestUtils.constructCreateJobInputs(
-            imputationPipelineName, testPipelineId, testUserId, testPipelineInputs);
+            imputationPipelineName, testPipelineId, testUserId, testPipelineInputs, testResultPath);
 
     FlightState flightState =
         StairwayTestUtils.blockUntilFlightCompletes(

--- a/service/src/test/java/bio/terra/pipelines/stairway/RunImputationJobFlightTest.java
+++ b/service/src/test/java/bio/terra/pipelines/stairway/RunImputationJobFlightTest.java
@@ -32,7 +32,7 @@ class RunImputationJobFlightTest extends BaseEmbeddedDbTest {
   private static final UUID testJobId = TestUtils.TEST_NEW_UUID;
 
   private final Object testPipelineInputs = TestUtils.TEST_PIPELINE_INPUTS;
-  private final String testResultPath = TestUtils.TEST_RESULT_PATH;
+  private final String testResultPath = TestUtils.TEST_RESULT_URL;
 
   @Test
   void createJobFlight_success() throws Exception {

--- a/service/src/test/java/bio/terra/pipelines/testutils/StairwayTestUtils.java
+++ b/service/src/test/java/bio/terra/pipelines/testutils/StairwayTestUtils.java
@@ -35,7 +35,8 @@ public class StairwayTestUtils {
           TestUtils.TEST_PIPELINE_1_ENUM,
           TestUtils.TEST_PIPELINE_ID_1,
           TestUtils.TEST_USER_ID_1,
-          TestUtils.TEST_PIPELINE_INPUTS);
+          TestUtils.TEST_PIPELINE_INPUTS,
+          TestUtils.TEST_RESULT_PATH);
   public static final FlightMap EMPTY_WORKING_MAP = new FlightMap();
   public static final String TEST_DESCRIPTION = "Test Job Description";
 
@@ -123,10 +124,14 @@ public class StairwayTestUtils {
   }
 
   public static FlightMap constructCreateJobInputs(
-      PipelinesEnum pipelineName, Long pipelineId, String userId, Object pipelineInputs) {
+      PipelinesEnum pipelineName,
+      Long pipelineId,
+      String userId,
+      Object pipelineInputs,
+      String resultPath) {
     FlightMap inputParameters = new FlightMap();
     return constructCreateJobInputs(
-        inputParameters, pipelineName, pipelineId, userId, pipelineInputs);
+        inputParameters, pipelineName, pipelineId, userId, pipelineInputs, resultPath);
   }
 
   public static FlightMap constructCreateJobInputs(
@@ -134,10 +139,12 @@ public class StairwayTestUtils {
       PipelinesEnum pipelineName,
       Long pipelineId,
       String userId,
-      Object pipelineInputs) {
+      Object pipelineInputs,
+      String resultPath) {
     inputParameters.put(JobMapKeys.USER_ID.getKeyName(), userId);
     inputParameters.put(JobMapKeys.PIPELINE_NAME.getKeyName(), pipelineName);
     inputParameters.put(JobMapKeys.DESCRIPTION.getKeyName(), TEST_DESCRIPTION);
+    inputParameters.put(JobMapKeys.RESULT_PATH.getKeyName(), resultPath);
     inputParameters.put(RunImputationJobFlightMapKeys.PIPELINE_ID, pipelineId);
     inputParameters.put(RunImputationJobFlightMapKeys.PIPELINE_INPUTS, pipelineInputs);
 
@@ -150,7 +157,8 @@ public class StairwayTestUtils {
         PipelinesEnum.IMPUTATION_MINIMAC4,
         TestUtils.TEST_PIPELINE_ID_1,
         TestUtils.TEST_USER_ID_1,
-        new HashMap<>());
+        new HashMap<>(),
+        TestUtils.TEST_RESULT_PATH);
   }
 
   /* Construct a FlightState with the given status and id. resultMap and inputParameters will be empty, and timeSubmitted and timeCompleted will be ~now. */

--- a/service/src/test/java/bio/terra/pipelines/testutils/StairwayTestUtils.java
+++ b/service/src/test/java/bio/terra/pipelines/testutils/StairwayTestUtils.java
@@ -36,7 +36,7 @@ public class StairwayTestUtils {
           TestUtils.TEST_PIPELINE_ID_1,
           TestUtils.TEST_USER_ID_1,
           TestUtils.TEST_PIPELINE_INPUTS,
-          TestUtils.TEST_RESULT_PATH);
+          TestUtils.TEST_RESULT_URL);
   public static final FlightMap EMPTY_WORKING_MAP = new FlightMap();
   public static final String TEST_DESCRIPTION = "Test Job Description";
 
@@ -158,7 +158,7 @@ public class StairwayTestUtils {
         TestUtils.TEST_PIPELINE_ID_1,
         TestUtils.TEST_USER_ID_1,
         new HashMap<>(),
-        TestUtils.TEST_RESULT_PATH);
+        TestUtils.TEST_RESULT_URL);
   }
 
   /* Construct a FlightState with the given status and id. resultMap and inputParameters will be empty, and timeSubmitted and timeCompleted will be ~now. */

--- a/service/src/test/java/bio/terra/pipelines/testutils/TestUtils.java
+++ b/service/src/test/java/bio/terra/pipelines/testutils/TestUtils.java
@@ -67,4 +67,5 @@ public class TestUtils {
 
   public static final Object TEST_PIPELINE_INPUTS =
       new LinkedHashMap<>(Map.of("first_key", "first_value"));
+  public static final String TEST_RESULT_PATH = "test/result/path";
 }

--- a/service/src/test/java/bio/terra/pipelines/testutils/TestUtils.java
+++ b/service/src/test/java/bio/terra/pipelines/testutils/TestUtils.java
@@ -63,9 +63,9 @@ public class TestUtils {
 
   public static final UUID TEST_NEW_UUID_2 =
       UUID.fromString("deadbeef-dead-beef-bbbb-beefdeadbeef");
-  public static final String TEST_STATUS = "TEST STATUS";
 
   public static final Object TEST_PIPELINE_INPUTS =
       new LinkedHashMap<>(Map.of("first_key", "first_value"));
-  public static final String TEST_RESULT_PATH = "test/result/path";
+  public static final String TEST_RESULT_URL = "https://some-tsps-domain.com/test/result/path";
+  public static final String TEST_DOMAIN = "some-tsps-domain.com";
 }

--- a/service/src/test/resources/application-test.yml
+++ b/service/src/test/resources/application-test.yml
@@ -46,4 +46,4 @@ cbas:
 
 pipelines:
   ingress:
-    domainName: "testDomainName"
+    domainName: "some-tsps-domain.com"

--- a/service/src/test/resources/application-test.yml
+++ b/service/src/test/resources/application-test.yml
@@ -43,3 +43,7 @@ wds:
 
 cbas:
   debugApiLogging: true
+
+pipelines:
+  ingress:
+    domainName: "testDomainName"


### PR DESCRIPTION
### Description 

- Add GET {pipelineName}/result/{jobId} endpoint
- This endpoint returns a CreatedJobResponse object that always includes a JobReport and depending on status returns an ErrorReport (if the job failed) or a PipelineOutput (if the job succeeded)
- changed the PipelineOutput format to String (this will likely be the path to the result workspace, but TBD)
- Add functionality to generate and return the ResultURL in the JobReport; the GET jobs/{jobid} endpoint now returns a JobReport that includes this URL

e.g. response to a createJob request is now
```
{
  "jobReport": {
    "id": "faf85f64-5717-4562-b3fc-2c963f66afa6",
    "description": "string",
    "status": "RUNNING",
    "statusCode": 202,
    "submitted": "2024-02-12T17:08:32.537386Z",
    "resultURL": "http://localhost:8080/api/pipelines/v1alpha1/imputation_minimac4/result/faf85f64-5717-4562-b3fc-2c963f66afa6"
  }
}
```

GET job/{jobid} response in a BEE: (note the resultURL)
```
{
  "id": "aaaabbbb-5717-4562-b3fc-2c963f66afa6",
  "description": "string",
  "status": "SUCCEEDED",
  "statusCode": 200,
  "submitted": "2024-02-13T15:28:43.782580Z",
  "completed": "2024-02-13T15:28:44.469910Z",
  "resultURL": "https://tsps.morgan.bee.envs-terra.bio/api/pipelines/v1alpha1/imputation_minimac4/result/aaaabbbb-5717-4562-b3fc-2c963f66afa6"
}
```

NOTE that currently our steps do not set the RESPONSE parameter, so the result endpoint if you run this doesn't return a PipelineOutput. but we do test that, when we do set a RESPONSE value in the working map, that value is returned as the PipelineOutput.



### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-135