### PR TITLE
[TSPS-130] enable pubsub for stairway in live envs

### DIFF
--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -25,6 +25,8 @@ env:
     # https://bvdp-saturn-dev.appspot.com/#workspaces/tsps_dev_bp_02_01_2024_v1/tsps_imputation_service_v1
     # this should be updated when trying to run on a bee.
     workspaceId: ${IMPUTATION_WORKSPACE_ID:b1d915cb-c1c8-40e4-bc85-8e7ba38f808e}
+  kubernetes:
+    in-kubernetes: ${TERRA_COMMON_KUBERNETES_IN_KUBERNETES:false}
 
 
 # Below here is non-deployment-specific
@@ -109,7 +111,7 @@ pipelines:
 
 terra.common:
   kubernetes:
-    in-kubernetes: false
+    in-kubernetes: ${env.kubernetes.in-kubernetes}
 
   # these values are used by TCL
   stairway:

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -111,7 +111,7 @@ pipelines:
 
 terra.common:
   kubernetes:
-    in-kubernetes: ${env.kubernetes.in-kubernetes}
+    in-kubernetes: ${env.kubernetes.in-kubernetes} # whether to use a pubsub queue for Stairway; if false, use a local queue
 
   # these values are used by TCL
   stairway:


### PR DESCRIPTION
### Description 

read the in-Kubernetes environment variable, which (thanks to the terra-helmfile PR below) is set to true for live envs and false for bees, so that we use a pubsub queue for Stairway in live envs. local defaults to false (no pubsub queue when running locally).

goes with this terra-helmfile PR: https://github.com/broadinstitute/terra-helmfile/pull/5100

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-130