### PR TITLE
log 5** exceptions to sentry

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -73,6 +73,9 @@ dependencies {
     // prometheus metrics
     implementation 'io.micrometer:micrometer-registry-prometheus'
 
+    // sentry
+    implementation 'io.sentry:sentry:7.3.0'
+
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
     testImplementation('org.springframework.boot:spring-boot-starter-test:2.7.0') {
         // Fixes warning about multiple occurrences of JSONObject on the classpath

--- a/service/src/main/java/bio/terra/pipelines/app/StartupInitializer.java
+++ b/service/src/main/java/bio/terra/pipelines/app/StartupInitializer.java
@@ -1,12 +1,17 @@
 package bio.terra.pipelines.app;
 
 import bio.terra.common.migrate.LiquibaseMigrator;
+import bio.terra.pipelines.app.configuration.external.SentryConfiguration;
 import bio.terra.pipelines.app.configuration.internal.TspsDatabaseConfiguration;
 import bio.terra.pipelines.dependencies.stairway.JobService;
+import io.sentry.Sentry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationContext;
 
 public final class StartupInitializer {
   private static final String CHANGELOG_PATH = "db/changelog.xml";
+  private static final Logger logger = LoggerFactory.getLogger(StartupInitializer.class);
 
   public static void initialize(ApplicationContext applicationContext) {
     // Initialize the Terra Scientific Pipelines Service library
@@ -23,5 +28,18 @@ public final class StartupInitializer {
 
     // The JobService initialization also handles Stairway initialization.
     jobService.initialize();
+
+    // initialize sentry if sentry dsn env variable is available
+    SentryConfiguration sentryConfiguration = applicationContext.getBean(SentryConfiguration.class);
+    if (sentryConfiguration.dsn().isEmpty()) {
+      logger.info("No Sentry DSN found. Starting up without it.");
+    } else {
+      logger.info("Sentry DSN found. 5xx errors will be sent to Sentry.");
+      Sentry.init(
+          options -> {
+            options.setDsn(sentryConfiguration.dsn());
+            options.setEnvironment(sentryConfiguration.environment());
+          });
+    }
   }
 }

--- a/service/src/main/java/bio/terra/pipelines/app/configuration/external/SentryConfiguration.java
+++ b/service/src/main/java/bio/terra/pipelines/app/configuration/external/SentryConfiguration.java
@@ -1,0 +1,6 @@
+package bio.terra.pipelines.app.configuration.external;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "pipelines.sentry")
+public record SentryConfiguration(String dsn, String environment) {}

--- a/service/src/main/java/bio/terra/pipelines/app/controller/GlobalExceptionHandler.java
+++ b/service/src/main/java/bio/terra/pipelines/app/controller/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package bio.terra.pipelines.app.controller;
 
 import bio.terra.common.exception.ErrorReportException;
 import bio.terra.pipelines.generated.model.ApiErrorReport;
+import io.sentry.Sentry;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -128,9 +129,13 @@ public class GlobalExceptionHandler {
 
   private ResponseEntity<ApiErrorReport> buildApiErrorReport(
       @NotNull Throwable ex, HttpStatus statusCode, List<String> causes) {
+    // only logging 5** errors to sentry, should we log more/every error?  Other services seem to do 5** only
+    if (statusCode.is5xxServerError()) {
+      Sentry.captureException(ex);
+    }
     StringBuilder combinedCauseString = new StringBuilder();
     for (Throwable cause = ex; cause != null; cause = cause.getCause()) {
-      combinedCauseString.append("cause: ").append(cause.toString()).append(", ");
+      combinedCauseString.append("cause: ").append(cause).append(", ");
     }
     logger.error("Global exception handler: {}", combinedCauseString, ex);
 

--- a/service/src/main/java/bio/terra/pipelines/app/controller/GlobalExceptionHandler.java
+++ b/service/src/main/java/bio/terra/pipelines/app/controller/GlobalExceptionHandler.java
@@ -129,8 +129,7 @@ public class GlobalExceptionHandler {
 
   private ResponseEntity<ApiErrorReport> buildApiErrorReport(
       @NotNull Throwable ex, HttpStatus statusCode, List<String> causes) {
-    // only logging 5** errors to sentry, should we log more/every error?  Other services seem to do
-    // 5** only
+    // only logging 5** errors to sentry
     if (statusCode.is5xxServerError()) {
       Sentry.captureException(ex);
     }

--- a/service/src/main/java/bio/terra/pipelines/app/controller/GlobalExceptionHandler.java
+++ b/service/src/main/java/bio/terra/pipelines/app/controller/GlobalExceptionHandler.java
@@ -129,7 +129,8 @@ public class GlobalExceptionHandler {
 
   private ResponseEntity<ApiErrorReport> buildApiErrorReport(
       @NotNull Throwable ex, HttpStatus statusCode, List<String> causes) {
-    // only logging 5** errors to sentry, should we log more/every error?  Other services seem to do 5** only
+    // only logging 5** errors to sentry, should we log more/every error?  Other services seem to do
+    // 5** only
     if (statusCode.is5xxServerError()) {
       Sentry.captureException(ex);
     }

--- a/service/src/main/java/bio/terra/pipelines/app/controller/PipelinesApiController.java
+++ b/service/src/main/java/bio/terra/pipelines/app/controller/PipelinesApiController.java
@@ -5,7 +5,6 @@ import static bio.terra.pipelines.app.controller.JobApiUtils.mapFlightStateToApi
 import static bio.terra.pipelines.common.utils.PipelinesEnum.IMPUTATION_MINIMAC4;
 
 import bio.terra.common.exception.ApiException;
-import bio.terra.common.exception.InternalServerErrorException;
 import bio.terra.common.iam.SamUser;
 import bio.terra.common.iam.SamUserFactory;
 import bio.terra.pipelines.app.common.MetricsUtils;
@@ -172,15 +171,15 @@ public class PipelinesApiController implements PipelinesApi {
   @Override
   public ResponseEntity<ApiGetJobsResponse> getPipelineJobs(
       @PathVariable("pipelineName") String pipelineName, Integer limit, String pageToken) {
-        final SamUser userRequest = getAuthenticatedInfo();
-        String userId = userRequest.getSubjectId();
-        PipelinesEnum validatedPipelineName = validatePipelineName(pipelineName);
-        EnumeratedJobs enumeratedJobs =
-            jobService.enumerateJobs(userId, limit, pageToken, validatedPipelineName);
+    final SamUser userRequest = getAuthenticatedInfo();
+    String userId = userRequest.getSubjectId();
+    PipelinesEnum validatedPipelineName = validatePipelineName(pipelineName);
+    EnumeratedJobs enumeratedJobs =
+        jobService.enumerateJobs(userId, limit, pageToken, validatedPipelineName);
 
-        ApiGetJobsResponse result = mapEnumeratedJobsToApi(enumeratedJobs);
+    ApiGetJobsResponse result = mapEnumeratedJobsToApi(enumeratedJobs);
 
-        return new ResponseEntity<>(result, HttpStatus.OK);
+    return new ResponseEntity<>(result, HttpStatus.OK);
   }
 
   @Override

--- a/service/src/main/java/bio/terra/pipelines/app/controller/PipelinesApiController.java
+++ b/service/src/main/java/bio/terra/pipelines/app/controller/PipelinesApiController.java
@@ -5,6 +5,7 @@ import static bio.terra.pipelines.app.controller.JobApiUtils.mapFlightStateToApi
 import static bio.terra.pipelines.common.utils.PipelinesEnum.IMPUTATION_MINIMAC4;
 
 import bio.terra.common.exception.ApiException;
+import bio.terra.common.exception.InternalServerErrorException;
 import bio.terra.common.iam.SamUser;
 import bio.terra.common.iam.SamUserFactory;
 import bio.terra.pipelines.app.common.MetricsUtils;
@@ -171,15 +172,15 @@ public class PipelinesApiController implements PipelinesApi {
   @Override
   public ResponseEntity<ApiGetJobsResponse> getPipelineJobs(
       @PathVariable("pipelineName") String pipelineName, Integer limit, String pageToken) {
-    final SamUser userRequest = getAuthenticatedInfo();
-    String userId = userRequest.getSubjectId();
-    PipelinesEnum validatedPipelineName = validatePipelineName(pipelineName);
-    EnumeratedJobs enumeratedJobs =
-        jobService.enumerateJobs(userId, limit, pageToken, validatedPipelineName);
+        final SamUser userRequest = getAuthenticatedInfo();
+        String userId = userRequest.getSubjectId();
+        PipelinesEnum validatedPipelineName = validatePipelineName(pipelineName);
+        EnumeratedJobs enumeratedJobs =
+            jobService.enumerateJobs(userId, limit, pageToken, validatedPipelineName);
 
-    ApiGetJobsResponse result = mapEnumeratedJobsToApi(enumeratedJobs);
+        ApiGetJobsResponse result = mapEnumeratedJobsToApi(enumeratedJobs);
 
-    return new ResponseEntity<>(result, HttpStatus.OK);
+        return new ResponseEntity<>(result, HttpStatus.OK);
   }
 
   @Override

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -107,6 +107,10 @@ pipelines:
     startupWaitSeconds: 5
     stalenessThresholdSeconds: 125
 
+  sentry:
+    dsn: ${SENTRY_DSN:}
+    environment: ${DEPLOY_ENV:}
+
 terra.common:
   kubernetes:
     in-kubernetes: false

--- a/service/src/test/java/bio/terra/pipelines/configuration/internal/StairwayDatabaseConfigurationTest.java
+++ b/service/src/test/java/bio/terra/pipelines/configuration/internal/StairwayDatabaseConfigurationTest.java
@@ -11,7 +11,9 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest(
     properties = {
       "spring.main.lazy-initialization=true",
-      "datasource.testWithEmbeddedDatabase=false"
+      "datasource.testWithEmbeddedDatabase=false",
+      "pipelines.sentry.dsn=" // piggyback on this test which already supplies properties to test
+      // no sentry dsn configuration
     })
 class StairwayDatabaseConfigurationTest extends BaseEmbeddedDbTest {
 

--- a/service/src/test/resources/application-test.yml
+++ b/service/src/test/resources/application-test.yml
@@ -48,3 +48,6 @@ cbas:
 pipelines:
   ingress:
     domainName: "some-tsps-domain.com"
+  sentry:
+    dsn: notempty
+    env: doesntmatter

--- a/service/src/test/resources/application-test.yml
+++ b/service/src/test/resources/application-test.yml
@@ -49,5 +49,5 @@ pipelines:
   ingress:
     domainName: "some-tsps-domain.com"
   sentry:
-    dsn: notempty
+    dsn: https://public@sentry.example.com/1
     env: doesntmatter


### PR DESCRIPTION
### Description 

To satisy the requirement for Production Readiness section M8, we need to send our exceptions to sentry for monitoring puproses. The work was already done to set up our dashboard and make sentry available to us.  This PR introduces sentry to the service and logs all 5** exceptions we generate to sentry for monitoring

This change has to go along with https://github.com/broadinstitute/terra-helmfile/pull/5103

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-172
