### PR TITLE
[TSPS-23] third party dependency security finding: postgresql:42.3.3 -> 42.3.9

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -37,7 +37,7 @@ dependencies {
 
     implementation 'org.apache.commons:commons-dbcp2:2.9.0'
     implementation 'javax.ws.rs:javax.ws.rs-api:2.1.1'
-    implementation 'org.postgresql:postgresql:42.3.8'
+    implementation 'org.postgresql:postgresql:42.3.9'
     implementation 'javax.servlet:jstl:1.2'
     implementation 'com.google.auth:google-auth-library-oauth2-http:1.6.0'
     // https://projectlombok.org
@@ -61,7 +61,7 @@ dependencies {
 
     liquibaseRuntime 'org.liquibase:liquibase-core:3.10.0'
     liquibaseRuntime 'info.picocli:picocli:4.6.1'
-    liquibaseRuntime 'org.postgresql:postgresql:42.3.8'
+    liquibaseRuntime 'org.postgresql:postgresql:42.3.9'
     liquibaseRuntime 'ch.qos.logback:logback-classic:1.2.3'
 
     annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -37,7 +37,7 @@ dependencies {
 
     implementation 'org.apache.commons:commons-dbcp2:2.9.0'
     implementation 'javax.ws.rs:javax.ws.rs-api:2.1.1'
-    implementation 'org.postgresql:postgresql:42.3.3'
+    implementation 'org.postgresql:postgresql:42.3.8'
     implementation 'javax.servlet:jstl:1.2'
     implementation 'com.google.auth:google-auth-library-oauth2-http:1.6.0'
     // https://projectlombok.org
@@ -61,7 +61,7 @@ dependencies {
 
     liquibaseRuntime 'org.liquibase:liquibase-core:3.10.0'
     liquibaseRuntime 'info.picocli:picocli:4.6.1'
-    liquibaseRuntime 'org.postgresql:postgresql:42.3.3'
+    liquibaseRuntime 'org.postgresql:postgresql:42.3.8'
     liquibaseRuntime 'ch.qos.logback:logback-classic:1.2.3'
 
     annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"


### PR DESCRIPTION
### Description 

We have several security alerts for postgresql 42.3.3. This ticket upgrades that package to 42.3.9, which is the safe version per defectdojo, e.g. (note you need to be on VPN to see these pages)
- critical: https://defectdojo.dsp-appsec.broadinstitute.org/finding/188673
- high: https://defectdojo.dsp-appsec.broadinstitute.org/finding/188689 

Did manual integration test in my bee, everything apparently working fine.

### Jira Ticket
This PR only partially addresses the work in this ticket: https://broadworkbench.atlassian.net/browse/TSPS-23