### PR TITLE
Enable metrics sent to prometheus for api latency metrics

### DIFF
--- a/service/src/main/java/bio/terra/pipelines/app/common/MetricsUtils.java
+++ b/service/src/main/java/bio/terra/pipelines/app/common/MetricsUtils.java
@@ -29,4 +29,13 @@ public class MetricsUtils {
             pipelineName.getValue())
         .increment();
   }
+
+  public static void incrementPipelineRunFailed(PipelinesEnum pipelineName) {
+    Metrics.globalRegistry
+        .counter(
+            String.format("%s.pipeline.failed.count", NAMESPACE),
+            PIPELINE_TAG,
+            pipelineName.getValue())
+        .increment();
+  }
 }

--- a/service/src/main/java/bio/terra/pipelines/app/controller/PipelinesApiController.java
+++ b/service/src/main/java/bio/terra/pipelines/app/controller/PipelinesApiController.java
@@ -7,7 +7,6 @@ import static bio.terra.pipelines.common.utils.PipelinesEnum.IMPUTATION_MINIMAC4
 import bio.terra.common.exception.ApiException;
 import bio.terra.common.iam.SamUser;
 import bio.terra.common.iam.SamUserFactory;
-import bio.terra.pipelines.app.common.MetricsUtils;
 import bio.terra.pipelines.app.configuration.external.IngressConfiguration;
 import bio.terra.pipelines.app.configuration.external.SamConfiguration;
 import bio.terra.pipelines.common.utils.PipelinesEnum;
@@ -157,8 +156,6 @@ public class PipelinesApiController implements PipelinesApi {
     }
 
     logger.info("Created {} job {}", validatedPipelineName.getValue(), jobId);
-
-    MetricsUtils.incrementPipelineRun(validatedPipelineName);
 
     FlightState flightState = jobService.retrieveJob(jobId, userId, validatedPipelineName);
     ApiJobReport jobReport = mapFlightStateToApiJobReport(flightState);

--- a/service/src/main/java/bio/terra/pipelines/stairway/WriteJobToDbStep.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/WriteJobToDbStep.java
@@ -1,6 +1,8 @@
 package bio.terra.pipelines.stairway;
 
+import bio.terra.pipelines.app.common.MetricsUtils;
 import bio.terra.pipelines.common.utils.FlightUtils;
+import bio.terra.pipelines.common.utils.PipelinesEnum;
 import bio.terra.pipelines.dependencies.stairway.JobMapKeys;
 import bio.terra.pipelines.service.ImputationService;
 import bio.terra.pipelines.stairway.imputation.RunImputationJobFlightMapKeys;
@@ -47,7 +49,13 @@ public class WriteJobToDbStep implements Step {
 
   @Override
   public StepResult undoStep(FlightContext flightContext) throws InterruptedException {
-    // nothing to undo; keep the job in the database
+    // increment failed imputation flight counter if flight fails
+    PipelinesEnum pipelinesEnum =
+        PipelinesEnum.valueOf(
+            flightContext
+                .getInputParameters()
+                .get(JobMapKeys.PIPELINE_NAME.getKeyName(), String.class));
+    MetricsUtils.incrementPipelineRunFailed(pipelinesEnum);
     return StepResult.getStepResultSuccess();
   }
 }

--- a/service/src/main/java/bio/terra/pipelines/stairway/WriteJobToDbStep.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/WriteJobToDbStep.java
@@ -49,7 +49,8 @@ public class WriteJobToDbStep implements Step {
 
   @Override
   public StepResult undoStep(FlightContext flightContext) throws InterruptedException {
-    // increment failed imputation flight counter if flight fails
+    // increment pipeline failed counter if undoStep is called which means the flight failed
+    // to be moved to a StairwayHook in https://broadworkbench.atlassian.net/browse/TSPS-181
     PipelinesEnum pipelinesEnum =
         PipelinesEnum.valueOf(
             flightContext

--- a/service/src/main/java/bio/terra/pipelines/stairway/imputation/RunImputationJobFlight.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/imputation/RunImputationJobFlight.java
@@ -1,7 +1,9 @@
 package bio.terra.pipelines.stairway.imputation;
 
+import bio.terra.pipelines.app.common.MetricsUtils;
 import bio.terra.pipelines.common.utils.FlightBeanBag;
 import bio.terra.pipelines.common.utils.FlightUtils;
+import bio.terra.pipelines.common.utils.PipelinesEnum;
 import bio.terra.pipelines.dependencies.stairway.JobMapKeys;
 import bio.terra.pipelines.stairway.*;
 import bio.terra.stairway.*;
@@ -35,6 +37,11 @@ public class RunImputationJobFlight extends Flight {
         RunImputationJobFlightMapKeys.CONTROL_WORKSPACE_ID,
         RunImputationJobFlightMapKeys.WDL_METHOD_NAME,
         JobMapKeys.RESULT_PATH.getKeyName());
+
+    PipelinesEnum pipelinesEnum =
+        PipelinesEnum.valueOf(
+            inputParameters.get(JobMapKeys.PIPELINE_NAME.getKeyName(), String.class));
+    MetricsUtils.incrementPipelineRun(pipelinesEnum);
 
     // write the job metadata to the Jobs table
     addStep(new WriteJobToDbStep(flightBeanBag.getImputationService()), dbRetryRule);

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -89,7 +89,13 @@ management:
   endpoints:
     web:
       exposure:
-        include: "prometheus"
+        include: "*"
+  metrics:
+    distribution:
+      # Used to publish a histogram suitable for computing aggregates (across dimensions) percentile
+      # latency approximations in Prometheus (by using histogram_quantile)
+      # For more information: https://docs.micrometer.io/micrometer/reference/concepts/histogram-quantiles.html
+      percentiles-histogram[http.server.requests]: true
 
 imputation:
   workspaceId: ${env.imputation.workspaceId}

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -82,7 +82,8 @@ spring:
         use-last-modified: false
       static-locations: classpath:/static/
 
-# Used to expose prometheus metrics
+# Used to expose prometheus metrics using actuator
+# https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html#actuator.endpoints
 management:
   server:
     port: 9098

--- a/service/src/test/java/bio/terra/pipelines/common/MetricsUtilsTest.java
+++ b/service/src/test/java/bio/terra/pipelines/common/MetricsUtilsTest.java
@@ -30,7 +30,7 @@ class MetricsUtilsTest extends BaseTest {
   }
 
   @Test
-  void createGcpProfileMetrics() {
+  void incrementImputationPipelineRunMetrics() {
     PipelinesEnum pipelineName = PipelinesEnum.IMPUTATION_MINIMAC4;
 
     // increment counter once
@@ -44,6 +44,24 @@ class MetricsUtilsTest extends BaseTest {
     // increment counter again
     MetricsUtils.incrementPipelineRun(pipelineName);
     counter = meterRegistry.find("tsps.pipeline.run.count").counter();
+    assertEquals(2, counter.count());
+  }
+
+  @Test
+  void incrementInputationPipelineFailedMetrics() {
+    PipelinesEnum pipelineName = PipelinesEnum.IMPUTATION_MINIMAC4;
+
+    // increment counter once
+    MetricsUtils.incrementPipelineRunFailed(pipelineName);
+
+    Counter counter = meterRegistry.find("tsps.pipeline.failed.count").counter();
+    assertNotNull(counter);
+    assertEquals(1, counter.count());
+    assertEquals(pipelineName.getValue(), counter.getId().getTag("pipeline"));
+
+    // increment counter again
+    MetricsUtils.incrementPipelineRunFailed(pipelineName);
+    counter = meterRegistry.find("tsps.pipeline.failed.count").counter();
     assertEquals(2, counter.count());
   }
 }

--- a/service/src/test/java/bio/terra/pipelines/stairway/WriteJobToDbStepTest.java
+++ b/service/src/test/java/bio/terra/pipelines/stairway/WriteJobToDbStepTest.java
@@ -65,6 +65,7 @@ class WriteJobToDbStepTest extends BaseEmbeddedDbTest {
 
   @Test
   void undoStepSuccess() throws InterruptedException {
+    StairwayTestUtils.constructCreateJobInputs(flightContext.getInputParameters());
     var writeJobStep = new WriteJobToDbStep(imputationService);
     var result = writeJobStep.undoStep(flightContext);
 


### PR DESCRIPTION
### Description 
We want to be able to create a grafana dashboard that tracks API metrics and this should enable that to be possible.
Here is the dashboard - https://grafana.dsp-devops.broadinstitute.org/d/3VhQ1_0Sz/tsps?orgId=1

example of the failed imputation workflow count being recorded in our prometheus endpoint
![Screenshot 2024-03-12 at 10 25 15 AM](https://github.com/DataBiosphere/terra-scientific-pipelines-service/assets/13023616/6fe3bbfc-5eb8-46ab-ad3c-a9abfcf30f43)


### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-127