### PR TITLE
[TSPS-23] Third party dependency security updates

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
     implementation 'io.spring.dependency-management:io.spring.dependency-management.gradle.plugin:1.1.4'
-    implementation 'org.springframework.boot:spring-boot-gradle-plugin:3.1.2'
+    implementation 'org.springframework.boot:spring-boot-gradle-plugin:3.2.3'
     implementation 'com.diffplug.spotless:spotless-plugin-gradle:6.7.1'
     implementation 'com.felipefzdz.gradle.shellcheck:shellcheck:1.4.6'
     implementation 'com.google.cloud.tools.jib:com.google.cloud.tools.jib.gradle.plugin:3.3.0'

--- a/buildSrc/src/main/groovy/bio.terra.pipelines.java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/bio.terra.pipelines.java-common-conventions.gradle
@@ -42,11 +42,15 @@ dependencies {
     compileOnly "com.google.code.findbugs:annotations:3.0.1"
     implementation 'org.slf4j:slf4j-api:2.0.12'
 
-    implementation 'ch.qos.logback:logback-classic:1.5.0'
-    implementation 'ch.qos.logback:logback-core:1.5.0' // see https://github.com/TNG/ArchUnit/issues/1212
     testImplementation 'org.hamcrest:hamcrest:2.2'
 
     implementation 'bio.terra:terra-common-lib:0.1.9-SNAPSHOT'
+    // transitive dependencies brought in by terra-common-lib that need to be explicitly declared to prevent security vulnerabilities
+    implementation 'ch.qos.logback:logback-classic:1.5.0'
+    implementation 'ch.qos.logback:logback-core:1.5.0' // see https://github.com/TNG/ArchUnit/issues/1212
+    implementation 'org.yaml:snakeyaml:2.0'
+    implementation 'org.apache.commons:commons-compress:1.26.0'
+    implementation 'org.bouncycastle:bcprov-jdk18on:1.74'
 
     implementation 'io.swagger.core.v3:swagger-annotations:2.2.12'
 

--- a/buildSrc/src/main/groovy/bio.terra.pipelines.java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/bio.terra.pipelines.java-common-conventions.gradle
@@ -42,8 +42,8 @@ dependencies {
     compileOnly "com.google.code.findbugs:annotations:3.0.1"
     implementation 'org.slf4j:slf4j-api:2.0.12'
 
-    testImplementation 'ch.qos.logback:logback-classic:1.5.0'
-    testImplementation 'ch.qos.logback:logback-core:1.5.0' // see https://github.com/TNG/ArchUnit/issues/1212
+    implementation 'ch.qos.logback:logback-classic:1.5.0'
+    implementation 'ch.qos.logback:logback-core:1.5.0' // see https://github.com/TNG/ArchUnit/issues/1212
     testImplementation 'org.hamcrest:hamcrest:2.2'
 
     implementation 'bio.terra:terra-common-lib:0.1.9-SNAPSHOT'

--- a/buildSrc/src/main/groovy/bio.terra.pipelines.java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/bio.terra.pipelines.java-common-conventions.gradle
@@ -44,13 +44,7 @@ dependencies {
 
     testImplementation 'org.hamcrest:hamcrest:2.2'
 
-    implementation 'bio.terra:terra-common-lib:0.1.9-SNAPSHOT'
-    // transitive dependencies brought in by terra-common-lib that need to be explicitly declared to prevent security vulnerabilities
-    implementation 'ch.qos.logback:logback-classic:1.5.0'
-    implementation 'ch.qos.logback:logback-core:1.5.0' // see https://github.com/TNG/ArchUnit/issues/1212
-    implementation 'org.yaml:snakeyaml:2.0'
-    implementation 'org.apache.commons:commons-compress:1.26.0'
-    implementation 'org.bouncycastle:bcprov-jdk18on:1.74'
+    implementation 'bio.terra:terra-common-lib:1.0.9-SNAPSHOT'
 
     implementation 'io.swagger.core.v3:swagger-annotations:2.2.12'
 

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -68,7 +68,6 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
-    implementation 'org.yaml:snakeyaml:2.0'
 
     // OpenTelemetry utilities for various HTTP clients - copied from WSM
     var openTelemetryVersion = '1.32.0'
@@ -110,7 +109,8 @@ dependencies {
     testImplementation 'org.awaitility:awaitility'
     testImplementation 'org.testcontainers:postgresql:1.17.3'
 
-    // security-related dependency upgrades
+    // security-related dependency upgrades of transitive dependencies
+    implementation 'org.yaml:snakeyaml:2.0'
     implementation 'org.apache.commons:commons-compress:1.26.0'
     implementation 'org.bouncycastle:bcprov-jdk18on:1.74'
 }

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -50,7 +50,7 @@ dependencies {
     implementation "bio.terra:cbas-client:0.0.199"
 
     implementation'org.apache.commons:commons-dbcp2'
-    implementation 'org.postgresql:postgresql'
+    implementation 'org.postgresql:postgresql:42.6.1'
 
     implementation platform('com.google.cloud:libraries-bom:26.28.0')
 
@@ -68,6 +68,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'org.yaml:snakeyaml:2.0'
 
     // OpenTelemetry utilities for various HTTP clients - copied from WSM
     var openTelemetryVersion = '1.32.0'
@@ -86,7 +87,7 @@ dependencies {
     implementation "com.google.cloud.opentelemetry:exporter-metrics:${gcpOpenTelemetryExporterVersion}"
 
     liquibaseRuntime 'info.picocli:picocli:4.6.1'
-    liquibaseRuntime 'org.postgresql:postgresql:42.3.9'
+    liquibaseRuntime 'org.postgresql:postgresql:42.6.1'
 
     annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -41,7 +41,7 @@ dependencies {
     implementation group: "com.google.guava", name:"guava"
 
     // Get stairway via TCL
-    implementation "bio.terra:terra-common-lib" // 0.1.9-SNAPSHOT is defined in java-common-conventions
+    implementation "bio.terra:terra-common-lib" // 1.0.9-SNAPSHOT is defined in java-common-conventions
 
     // terra clients
     implementation "org.broadinstitute.dsde.workbench:sam-client_2.13:0.1-5a5bf28"

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -108,11 +108,6 @@ dependencies {
     testImplementation 'io.zonky.test:embedded-database-spring-test:2.5.0'
     testImplementation 'org.awaitility:awaitility'
     testImplementation 'org.testcontainers:postgresql:1.17.3'
-
-    // security-related dependency upgrades of transitive dependencies
-    implementation 'org.yaml:snakeyaml:2.0'
-    implementation 'org.apache.commons:commons-compress:1.26.0'
-    implementation 'org.bouncycastle:bcprov-jdk18on:1.74'
 }
 // workaround for local development
 // set GOOGLE_APPLICATION_CREDENTIALS if this file exists - should only exist when

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -110,6 +110,9 @@ dependencies {
     testImplementation 'org.awaitility:awaitility'
     testImplementation 'org.testcontainers:postgresql:1.17.3'
 
+    // security-related dependency upgrades
+    implementation 'org.apache.commons:commons-compress:1.26.0'
+    implementation 'org.bouncycastle:bcprov-jdk18on:1.74'
 }
 // workaround for local development
 // set GOOGLE_APPLICATION_CREDENTIALS if this file exists - should only exist when


### PR DESCRIPTION
### Description 

Per latest sourceclear scan (screenshot in Jira ticket), the following updates:
- logback-classic -> now 1.4.14 (via spring boot -> 3.2.3)
- logback-core -> now 1.4.14 (via spring boot -> 3.2.3)
- postgresql -> now 42.6.1 (direct dependency)
- snakeyaml -> now 2.2 (via terra-common-lib -> 1.0.9)

The following are supposedly brought in by terra-common-lib but don't show up on insightDependency. 
- commons-compress* - [TCL updated this to 1.26.0](https://github.com/DataBiosphere/terra-common-lib/blob/develop/build.gradle#L134)

Unclear whether these changes will also upgrade bouncycastle, since this also doesn't show up on insightDependency.

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-23