### PR TITLE
TSPS-23 Third party dependency security upgrades: logback-classic, logback-core, snakeyaml, postgresql, commons-compress

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
     implementation 'io.spring.dependency-management:io.spring.dependency-management.gradle.plugin:1.1.4'
-    implementation 'org.springframework.boot:spring-boot-gradle-plugin:3.1.2'
+    implementation 'org.springframework.boot:spring-boot-gradle-plugin:3.2.3'
     implementation 'com.diffplug.spotless:spotless-plugin-gradle:6.7.1'
     implementation 'com.felipefzdz.gradle.shellcheck:shellcheck:1.4.6'
     implementation 'com.google.cloud.tools.jib:com.google.cloud.tools.jib.gradle.plugin:3.3.0'

--- a/buildSrc/src/main/groovy/bio.terra.pipelines.java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/bio.terra.pipelines.java-common-conventions.gradle
@@ -42,11 +42,10 @@ dependencies {
     compileOnly "com.google.code.findbugs:annotations:3.0.1"
     implementation 'org.slf4j:slf4j-api:2.0.12'
 
-    testImplementation 'ch.qos.logback:logback-classic:1.5.0'
-    testImplementation 'ch.qos.logback:logback-core:1.5.0' // see https://github.com/TNG/ArchUnit/issues/1212
     testImplementation 'org.hamcrest:hamcrest:2.2'
 
-    implementation 'bio.terra:terra-common-lib:0.1.9-SNAPSHOT'
+    implementation 'bio.terra:terra-common-lib:1.0.9-SNAPSHOT'
+    implementation platform('com.google.cloud:libraries-bom:26.33.0') // required for TCL
 
     implementation 'io.swagger.core.v3:swagger-annotations:2.2.12'
 

--- a/client/swagger.gradle
+++ b/client/swagger.gradle
@@ -10,8 +10,6 @@ dependencies {
 
     implementation 'io.swagger.core.v3:swagger-annotations'
     swaggerCodegen 'io.swagger.codegen.v3:swagger-codegen-cli'
-
-    implementation platform('com.google.cloud:libraries-bom:26.28.0') // required for TCL
 }
 
 def artifactGroup = "${group}.pipelines"

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -41,7 +41,7 @@ dependencies {
     implementation group: "com.google.guava", name:"guava"
 
     // Get stairway via TCL
-    implementation "bio.terra:terra-common-lib" // 0.1.9-SNAPSHOT is defined in java-common-conventions
+    implementation "bio.terra:terra-common-lib" // 1.0.9-SNAPSHOT is defined in java-common-conventions
 
     // terra clients
     implementation "org.broadinstitute.dsde.workbench:sam-client_2.13:0.1-5a5bf28"
@@ -50,9 +50,7 @@ dependencies {
     implementation "bio.terra:cbas-client:0.0.199"
 
     implementation'org.apache.commons:commons-dbcp2'
-    implementation 'org.postgresql:postgresql'
-
-    implementation platform('com.google.cloud:libraries-bom:26.28.0')
+    implementation 'org.postgresql:postgresql:42.6.1'
 
     implementation 'com.google.auth:google-auth-library-oauth2-http'
 
@@ -70,23 +68,24 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
     // OpenTelemetry utilities for various HTTP clients - copied from WSM
-    var openTelemetryVersion = '1.32.0'
+    var openTelemetryVersion = '1.34.1'
+    var openTelemetryInstrumentationVersion = '2.0.0'
     implementation "io.opentelemetry:opentelemetry-api:${openTelemetryVersion}"
     implementation "io.opentelemetry:opentelemetry-sdk:${openTelemetryVersion}"
     implementation "io.opentelemetry:opentelemetry-sdk-common:${openTelemetryVersion}"
     implementation "io.opentelemetry:opentelemetry-sdk-metrics:${openTelemetryVersion}"
     implementation "io.opentelemetry:opentelemetry-exporter-logging:${openTelemetryVersion}"
-    implementation "io.opentelemetry.semconv:opentelemetry-semconv:1.21.0-alpha"
-    implementation "io.opentelemetry.instrumentation:opentelemetry-spring-webmvc-6.0:${openTelemetryVersion}-alpha"
-    implementation "io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations:${openTelemetryVersion}"
-    implementation "io.opentelemetry.instrumentation:opentelemetry-spring-boot:${openTelemetryVersion}-alpha"
+    implementation "io.opentelemetry.instrumentation:opentelemetry-spring-webmvc-6.0:${openTelemetryInstrumentationVersion}-alpha"
+    implementation "io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations:${openTelemetryInstrumentationVersion}"
+    implementation "io.opentelemetry.instrumentation:opentelemetry-spring-boot:${openTelemetryInstrumentationVersion}-alpha"
 
-    var gcpOpenTelemetryExporterVersion = '0.25.2'
+    // Google cloud open telemetry exporters
+    var gcpOpenTelemetryExporterVersion = '0.27.0'
     implementation "com.google.cloud.opentelemetry:exporter-trace:${gcpOpenTelemetryExporterVersion}"
     implementation "com.google.cloud.opentelemetry:exporter-metrics:${gcpOpenTelemetryExporterVersion}"
 
     liquibaseRuntime 'info.picocli:picocli:4.6.1'
-    liquibaseRuntime 'org.postgresql:postgresql:42.3.9'
+    liquibaseRuntime 'org.postgresql:postgresql:42.6.1'
 
     annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 

--- a/service/src/test/java/bio/terra/pipelines/dependencies/sam/SamServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/dependencies/sam/SamServiceTest.java
@@ -80,10 +80,11 @@ class SamServiceTest {
 
   @Test
   void getServiceAccountToken() throws IOException {
+    GoogleCredentials mockCredentials = GoogleCredentials.create(new AccessToken("hi", null));
+
     try (MockedStatic<GoogleCredentials> utilities = Mockito.mockStatic(GoogleCredentials.class)) {
       SamClient samClient = mock(SamClient.class);
-      GoogleCredentials googleCredentials = new GoogleCredentials(new AccessToken("hi", null));
-      utilities.when(GoogleCredentials::getApplicationDefault).thenReturn(googleCredentials);
+      utilities.when(GoogleCredentials::getApplicationDefault).thenReturn(mockCredentials);
       SamService samService = new SamService(samClient);
       String token = samService.getTspsServiceAccountToken();
       assertEquals("hi", token);


### PR DESCRIPTION
### Description 

Retrying with the addition of [some fixes courtesy Olivia/WSM](https://github.com/DataBiosphere/terra-workspace-manager/pull/1666/files)

Per latest sourceclear scan (screenshot in Jira ticket), the following updates:
- logback-classic -> now 1.4.14 (via spring boot -> 3.2.3)
- logback-core -> now 1.4.14 (via spring boot -> 3.2.3)
- postgresql -> now 42.6.1 (direct dependency)
- snakeyaml -> now 2.2 (via terra-common-lib -> 1.0.9)

The following are supposedly brought in by terra-common-lib but don't show up on insightDependency. 
- commons-compress* - [TCL updated this to 1.26.0](https://github.com/DataBiosphere/terra-common-lib/blob/develop/build.gradle#L134)

Unclear whether these changes will also upgrade bouncycastle, since this also doesn't show up on insightDependency.

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-23