### PR TITLE
TSPS-224 add admin endpoint to be able to update workspace id for a pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ To run locally:
 4. Run `scripts/write-config.sh`
 5. Run `./gradlew bootRun` to spin up the server.
 6. Navigate to [http://localhost:8080/#](http://localhost:8080/#)
-7. If this is your first time deploying to any environment, be sure to use the use the admin endpoint `/api/admin/v1/updatePipelineWorkspaceId/{pipelineName}/{workspaceId}` to set your pipeline's workspace id
+7. If this is your first time deploying to any environment, be sure to use the admin endpoint `/api/admin/v1/updatePipelineWorkspaceId/{pipelineName}/{workspaceId}` to set your pipeline's workspace id. Workspace id can be found through the terra ui workspace dashboard or through the Rawls GET workspace endpoint.
 
 
 #### Local development with debugging

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ To run locally:
 4. Run `scripts/write-config.sh`
 5. Run `./gradlew bootRun` to spin up the server.
 6. Navigate to [http://localhost:8080/#](http://localhost:8080/#)
+7. If this is your first time deploying to any environment, be sure to use the use the admin endpoint `/api/admin/v1/updatePipelineWorkspaceId/{pipelineName}/{workspaceId}` to set your pipeline's workspace id
+
 
 #### Local development with debugging
 If using Intellij (only IDE we use on the team), you can run the server with a debugger. Follow

--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -4,11 +4,32 @@ info:
   version: 1.0.0
 paths:
   # Admin APIs
+  /api/admin/v1/getAdminPipeline/{pipelineName}:
+    parameters:
+      - $ref: '#/components/parameters/PipelineName'
+    get:
+      summary: Get description for a given pipeline.
+      tags: [ admin ]
+      operationId: getAdminPipeline
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdminPipeline'
+        400:
+          $ref: '#/components/responses/BadRequest'
+        403:
+          $ref: '#/components/responses/PermissionDenied'
+        500:
+          $ref: '#/components/responses/ServerError'
+
   /api/admin/v1/updatePipelineWorkspaceId/{pipelineName}/{workspaceId}:
     parameters:
       - $ref: '#/components/parameters/PipelineName'
       - $ref: '#/components/parameters/WorkspaceId'
-    get:
+    patch:
       summary: Update the workspace id for a given pipeline.
       tags: [ admin ]
       operationId: updatePipelineWorkspaceId

--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -4,13 +4,13 @@ info:
   version: 1.0.0
 paths:
   # Admin APIs
-  /api/admin/v1/getAdminPipeline/{pipelineName}:
+  /api/admin/v1/pipeline/{pipelineName}:
     parameters:
       - $ref: '#/components/parameters/PipelineName'
     get:
       summary: Get description for a given pipeline.
       tags: [ admin ]
-      operationId: getAdminPipeline
+      operationId: getPipeline
       responses:
         200:
           description: Success
@@ -24,15 +24,16 @@ paths:
           $ref: '#/components/responses/PermissionDenied'
         500:
           $ref: '#/components/responses/ServerError'
-
-  /api/admin/v1/updatePipelineWorkspaceId/{pipelineName}/{workspaceId}:
-    parameters:
-      - $ref: '#/components/parameters/PipelineName'
-      - $ref: '#/components/parameters/WorkspaceId'
     patch:
-      summary: Update the workspace id for a given pipeline.
+      summary: Update attributes for a given pipeline.
       tags: [ admin ]
-      operationId: updatePipelineWorkspaceId
+      operationId: updatePipeline
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdatePipelineRequestBody'
       responses:
         200:
           description: Success
@@ -455,7 +456,7 @@ components:
       description: |
         Object containing the pipeline identifier, display name, description, and workspace UUID of a Pipeline.
       type: object
-      required: [ pipelineName, displayName, description ]
+      required: [ pipelineName, displayName, description, workspaceId ]
       properties:
         pipelineName:
           $ref: "#/components/schemas/PipelineName"
@@ -589,6 +590,16 @@ components:
         The uuid for the workspace to run the pipeline in.
       type: string
       format: uuid
+
+    UpdatePipelineRequestBody:
+      description: |
+        json object containing the admin provided information to update a pipeline with
+      type: object
+      required: [ workspaceId ]
+      properties:
+        description:
+        workspaceId:
+          $ref: "#/components/schemas/PipelineWorkspaceId"
 
     UserId:
       description: |

--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -3,40 +3,30 @@ info:
   title: Terra Scientific Pipelines Service
   version: 1.0.0
 paths:
-  /status:
+  # Admin APIs
+  /api/admin/v1/updatePipelineWorkspaceId/{pipelineName}/{workspaceId}:
+    parameters:
+      - $ref: '#/components/parameters/PipelineName'
+      - $ref: '#/components/parameters/WorkspaceId'
     get:
-      summary: Check status of the service.
-      tags: [ public ]
-      operationId: getStatus
-      security: [ ]
+      summary: Update the workspace id for a given pipeline.
+      tags: [ admin ]
+      operationId: updatePipelineWorkspaceId
       responses:
         200:
-          description: OK
-        500:
-          $ref: '#/components/responses/ServerError'
-        503:
-          $ref: '#/components/responses/SystemStatusResponse'
-  /version:
-    get:
-      summary: Get version info of the deployed service.
-      tags: [ public ]
-      operationId: getVersion
-      security: [ ]
-      responses:
-        200:
-          description: Version information
+          description: Success
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/VersionProperties'
-        404:
-          description: "Version not configured"
+                $ref: '#/components/schemas/AdminPipeline'
+        400:
+          $ref: '#/components/responses/BadRequest'
+        403:
+          $ref: '#/components/responses/PermissionDenied'
         500:
           $ref: '#/components/responses/ServerError'
 
-
-  # Specific terra scientific pipelines service queries will go here
-
+  # Pipeline related APIs
   /api/pipelines/v1:
     get:
       summary: Return all available Pipelines
@@ -51,7 +41,6 @@ paths:
                 $ref: '#/components/schemas/GetPipelinesResult'
         500:
           $ref: '#/components/responses/ServerError'
-
 
   /api/pipelines/v1/{pipelineName}:
     parameters:
@@ -172,6 +161,7 @@ paths:
         500:
           $ref: '#/components/responses/ServerError'
 
+  # Job related APIs go here
   /api/job/v1/jobs:
     get:
       tags: [ jobs ]
@@ -189,7 +179,6 @@ paths:
                 $ref: '#/components/schemas/GetJobsResponse'
         500:
           $ref: '#/components/responses/ServerError'
-
 
   /api/job/v1/jobs/{jobId}:
     parameters:
@@ -225,9 +214,40 @@ paths:
         404:
           $ref: '#/components/responses/NotFound'
 
+  # Public APIs
+  /status:
+    get:
+      summary: Check status of the service.
+      tags: [ public ]
+      operationId: getStatus
+      security: [ ]
+      responses:
+        200:
+          description: OK
+        500:
+          $ref: '#/components/responses/ServerError'
+        503:
+          $ref: '#/components/responses/SystemStatusResponse'
+
+  /version:
+    get:
+      summary: Get version info of the deployed service.
+      tags: [ public ]
+      operationId: getVersion
+      security: [ ]
+      responses:
+        200:
+          description: Version information
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VersionProperties'
+        404:
+          description: "Version not configured"
+        500:
+          $ref: '#/components/responses/ServerError'
 
 components:
-
   parameters:
     JobId:
       name: jobId
@@ -263,6 +283,15 @@ components:
       required: true
       schema:
         type: string
+
+    WorkspaceId:
+      name: workspaceId
+      in: path
+      description: A UUID identifier for a workspace job
+      required: true
+      schema:
+        type: string
+        format: uuid
 
   responses:
     # Error Responses
@@ -401,6 +430,21 @@ components:
           $ref: '#/components/schemas/ErrorReport'
 
     # TSPS schemas; please keep alphabetized
+    AdminPipeline:
+      description: |
+        Object containing the pipeline identifier, display name, description, and workspace UUID of a Pipeline.
+      type: object
+      required: [ pipelineName, displayName, description ]
+      properties:
+        pipelineName:
+          $ref: "#/components/schemas/PipelineName"
+        displayName:
+          $ref: "#/components/schemas/PipelineDisplayName"
+        description:
+          $ref: "#/components/schemas/PipelineDescription"
+        workspaceId:
+          $ref: "#/components/schemas/PipelineWorkspaceId"
+
     CreateJobRequestBody:
       description: |
         Object containing the user-provided information about a job request.
@@ -518,6 +562,12 @@ components:
         An identifier string for the Pipeline Version.
       type: string
       format: string
+
+    PipelineWorkspaceId:
+      description: |
+        The uuid for the workspace to run the pipeline in.
+      type: string
+      format: uuid
 
     UserId:
       description: |

--- a/service/src/main/java/bio/terra/pipelines/app/configuration/internal/ImputationConfiguration.java
+++ b/service/src/main/java/bio/terra/pipelines/app/configuration/internal/ImputationConfiguration.java
@@ -5,16 +5,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 /** configuration for all properties related to imputation */
 @ConfigurationProperties(prefix = "imputation")
 public class ImputationConfiguration {
-  private String workspaceId;
   private Long cromwellSubmissionPollingIntervalInSeconds;
-
-  public String getWorkspaceId() {
-    return workspaceId;
-  }
-
-  public void setWorkspaceId(String workspaceId) {
-    this.workspaceId = workspaceId;
-  }
 
   public Long getCromwellSubmissionPollingIntervalInSeconds() {
     return cromwellSubmissionPollingIntervalInSeconds;

--- a/service/src/main/java/bio/terra/pipelines/app/controller/AdminApiController.java
+++ b/service/src/main/java/bio/terra/pipelines/app/controller/AdminApiController.java
@@ -50,24 +50,25 @@ public class AdminApiController implements AdminApi {
   }
 
   @Override
-  public ResponseEntity<ApiAdminPipeline> updatePipelineWorkspaceId(
-      String pipelineName, UUID workspaceId) {
-    final SamUser authedUser = getAuthenticatedInfo();
-    samService.checkAdminAuthz(authedUser);
-    PipelinesEnum validatedPipelineName =
-        PipelineApiUtils.validatePipelineName(pipelineName, logger);
-    Pipeline updatedPipeline =
-        pipelinesService.updatePipelineWorkspaceId(validatedPipelineName, workspaceId);
-    return new ResponseEntity<>(pipelineToApiAdminPipeline(updatedPipeline), HttpStatus.OK);
-  }
-
-  @Override
-  public ResponseEntity<ApiAdminPipeline> getAdminPipeline(String pipelineName) {
+  public ResponseEntity<ApiAdminPipeline> getPipeline(String pipelineName) {
     final SamUser authedUser = getAuthenticatedInfo();
     samService.checkAdminAuthz(authedUser);
     PipelinesEnum validatedPipelineName =
         PipelineApiUtils.validatePipelineName(pipelineName, logger);
     Pipeline updatedPipeline = pipelinesService.getPipeline(validatedPipelineName);
+    return new ResponseEntity<>(pipelineToApiAdminPipeline(updatedPipeline), HttpStatus.OK);
+  }
+
+  @Override
+  public ResponseEntity<ApiAdminPipeline> updatePipeline(
+      String pipelineName, ApiUpdatePipelineRequestBody body) {
+    final SamUser authedUser = getAuthenticatedInfo();
+    samService.checkAdminAuthz(authedUser);
+    PipelinesEnum validatedPipelineName =
+        PipelineApiUtils.validatePipelineName(pipelineName, logger);
+    UUID workspaceId = body.getWorkspaceId();
+    Pipeline updatedPipeline =
+        pipelinesService.updatePipelineWorkspaceId(validatedPipelineName, workspaceId);
     return new ResponseEntity<>(pipelineToApiAdminPipeline(updatedPipeline), HttpStatus.OK);
   }
 

--- a/service/src/main/java/bio/terra/pipelines/app/controller/AdminApiController.java
+++ b/service/src/main/java/bio/terra/pipelines/app/controller/AdminApiController.java
@@ -1,0 +1,71 @@
+package bio.terra.pipelines.app.controller;
+
+import bio.terra.common.iam.SamUser;
+import bio.terra.common.iam.SamUserFactory;
+import bio.terra.pipelines.app.configuration.external.SamConfiguration;
+import bio.terra.pipelines.common.utils.PipelinesEnum;
+import bio.terra.pipelines.db.entities.Pipeline;
+import bio.terra.pipelines.dependencies.sam.SamService;
+import bio.terra.pipelines.generated.api.AdminApi;
+import bio.terra.pipelines.generated.model.*;
+import bio.terra.pipelines.service.PipelinesService;
+import io.swagger.annotations.Api;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+
+/** Admin controller */
+@Controller
+@Api(tags = {"admin"})
+public class AdminApiController implements AdminApi {
+  private final SamConfiguration samConfiguration;
+  private final SamUserFactory samUserFactory;
+  private final HttpServletRequest request;
+  private final PipelinesService pipelinesService;
+  private final SamService samService;
+
+  @Autowired
+  public AdminApiController(
+      SamConfiguration samConfiguration,
+      SamUserFactory samUserFactory,
+      HttpServletRequest request,
+      PipelinesService pipelinesService,
+      SamService samService) {
+    this.samConfiguration = samConfiguration;
+    this.samUserFactory = samUserFactory;
+    this.request = request;
+    this.pipelinesService = pipelinesService;
+    this.samService = samService;
+  }
+
+  private static final Logger logger = LoggerFactory.getLogger(AdminApiController.class);
+
+  private SamUser getAuthenticatedInfo() {
+    return samUserFactory.from(request, samConfiguration.baseUri());
+  }
+
+  @Override
+  public ResponseEntity<ApiAdminPipeline> updatePipelineWorkspaceId(
+      String pipelineName, UUID workspaceId) {
+    final SamUser authedUser = getAuthenticatedInfo();
+    samService.checkAdminAuthz(authedUser);
+    PipelinesEnum validatedPipelineName =
+        PipelineApiUtils.validatePipelineName(pipelineName, logger);
+    Pipeline updatedPipeline =
+        pipelinesService.updatePipelineWorkspaceId(validatedPipelineName, workspaceId);
+    return new ResponseEntity<>(pipelineToApiAdminPipeline(updatedPipeline), HttpStatus.OK);
+  }
+
+  public ApiAdminPipeline pipelineToApiAdminPipeline(Pipeline pipeline) {
+    return new ApiAdminPipeline()
+        .pipelineName(pipeline.getName())
+        .displayName(pipeline.getDisplayName())
+        .description(pipeline.getDescription())
+        .workspaceId(pipeline.getWorkspaceId());
+  }
+}

--- a/service/src/main/java/bio/terra/pipelines/app/controller/AdminApiController.java
+++ b/service/src/main/java/bio/terra/pipelines/app/controller/AdminApiController.java
@@ -61,6 +61,16 @@ public class AdminApiController implements AdminApi {
     return new ResponseEntity<>(pipelineToApiAdminPipeline(updatedPipeline), HttpStatus.OK);
   }
 
+  @Override
+  public ResponseEntity<ApiAdminPipeline> getAdminPipeline(String pipelineName) {
+    final SamUser authedUser = getAuthenticatedInfo();
+    samService.checkAdminAuthz(authedUser);
+    PipelinesEnum validatedPipelineName =
+        PipelineApiUtils.validatePipelineName(pipelineName, logger);
+    Pipeline updatedPipeline = pipelinesService.getPipeline(validatedPipelineName);
+    return new ResponseEntity<>(pipelineToApiAdminPipeline(updatedPipeline), HttpStatus.OK);
+  }
+
   public ApiAdminPipeline pipelineToApiAdminPipeline(Pipeline pipeline) {
     return new ApiAdminPipeline()
         .pipelineName(pipeline.getName())

--- a/service/src/main/java/bio/terra/pipelines/app/controller/PipelineApiUtils.java
+++ b/service/src/main/java/bio/terra/pipelines/app/controller/PipelineApiUtils.java
@@ -6,6 +6,8 @@ import org.slf4j.Logger;
 
 public class PipelineApiUtils {
 
+  private PipelineApiUtils() {}
+
   /**
    * Validates that the pipelineName is a valid pipelineName and returns the Enum value for the
    * pipelineName

--- a/service/src/main/java/bio/terra/pipelines/app/controller/PipelineApiUtils.java
+++ b/service/src/main/java/bio/terra/pipelines/app/controller/PipelineApiUtils.java
@@ -1,0 +1,30 @@
+package bio.terra.pipelines.app.controller;
+
+import bio.terra.pipelines.common.utils.PipelinesEnum;
+import bio.terra.pipelines.db.exception.InvalidPipelineException;
+import org.slf4j.Logger;
+
+public class PipelineApiUtils {
+
+  /**
+   * Validates that the pipelineName is a valid pipelineName and returns the Enum value for the
+   * pipelineName
+   *
+   * <p>Note that in PipelinesServiceTest, we check that all the pipelines in the enum exist in the
+   * pipelines table
+   *
+   * @param pipelineName the pipelineName to validate
+   * @param logger logger to log messages to
+   * @return the Enum value for the pipelineName
+   * @throws InvalidPipelineException if the pipelineName is not valid
+   */
+  public static PipelinesEnum validatePipelineName(String pipelineName, Logger logger) {
+    try {
+      return PipelinesEnum.valueOf(pipelineName.toUpperCase());
+    } catch (IllegalArgumentException e) {
+      logger.error("Unknown pipeline name {}", pipelineName);
+      throw new InvalidPipelineException(
+          String.format("%s is not a valid pipelineName", pipelineName));
+    }
+  }
+}

--- a/service/src/main/java/bio/terra/pipelines/app/controller/PipelinesApiController.java
+++ b/service/src/main/java/bio/terra/pipelines/app/controller/PipelinesApiController.java
@@ -73,6 +73,7 @@ public class PipelinesApiController implements PipelinesApi {
 
   @Override
   public ResponseEntity<ApiGetPipelinesResult> getPipelines() {
+    getAuthenticatedInfo();
     List<Pipeline> pipelineList = pipelinesService.getPipelines();
     ApiGetPipelinesResult result = pipelinesToApi(pipelineList);
 
@@ -82,6 +83,7 @@ public class PipelinesApiController implements PipelinesApi {
   @Override
   public ResponseEntity<ApiPipeline> getPipeline(
       @PathVariable("pipelineName") String pipelineName) {
+    getAuthenticatedInfo();
     PipelinesEnum validatedPipelineName = validatePipelineName(pipelineName);
     Pipeline pipelineInfo = pipelinesService.getPipeline(validatedPipelineName);
     ApiPipeline result = pipelineToApi(pipelineInfo);

--- a/service/src/main/java/bio/terra/pipelines/app/controller/PipelinesApiController.java
+++ b/service/src/main/java/bio/terra/pipelines/app/controller/PipelinesApiController.java
@@ -11,7 +11,6 @@ import bio.terra.pipelines.app.configuration.external.IngressConfiguration;
 import bio.terra.pipelines.app.configuration.external.SamConfiguration;
 import bio.terra.pipelines.common.utils.PipelinesEnum;
 import bio.terra.pipelines.db.entities.Pipeline;
-import bio.terra.pipelines.db.exception.InvalidPipelineException;
 import bio.terra.pipelines.dependencies.stairway.JobService;
 import bio.terra.pipelines.dependencies.stairway.model.EnumeratedJobs;
 import bio.terra.pipelines.generated.api.PipelinesApi;
@@ -84,7 +83,8 @@ public class PipelinesApiController implements PipelinesApi {
   public ResponseEntity<ApiPipeline> getPipeline(
       @PathVariable("pipelineName") String pipelineName) {
     getAuthenticatedInfo();
-    PipelinesEnum validatedPipelineName = validatePipelineName(pipelineName);
+    PipelinesEnum validatedPipelineName =
+        PipelineApiUtils.validatePipelineName(pipelineName, logger);
     Pipeline pipelineInfo = pipelinesService.getPipeline(validatedPipelineName);
     ApiPipeline result = pipelineToApi(pipelineInfo);
 
@@ -135,7 +135,8 @@ public class PipelinesApiController implements PipelinesApi {
     String pipelineVersion = body.getPipelineVersion();
     Object pipelineInputs = body.getPipelineInputs();
 
-    PipelinesEnum validatedPipelineName = validatePipelineName(pipelineName);
+    PipelinesEnum validatedPipelineName =
+        PipelineApiUtils.validatePipelineName(pipelineName, logger);
 
     logger.info(
         "Creating {} pipeline (version {}) job (id {}) for user {} with inputs {}",
@@ -172,7 +173,8 @@ public class PipelinesApiController implements PipelinesApi {
       @PathVariable("pipelineName") String pipelineName, Integer limit, String pageToken) {
     final SamUser userRequest = getAuthenticatedInfo();
     String userId = userRequest.getSubjectId();
-    PipelinesEnum validatedPipelineName = validatePipelineName(pipelineName);
+    PipelinesEnum validatedPipelineName =
+        PipelineApiUtils.validatePipelineName(pipelineName, logger);
     EnumeratedJobs enumeratedJobs =
         jobService.enumerateJobs(userId, limit, pageToken, validatedPipelineName);
 
@@ -186,7 +188,7 @@ public class PipelinesApiController implements PipelinesApi {
       @PathVariable("pipelineName") String pipelineName, @PathVariable("jobId") UUID jobId) {
     final SamUser userRequest = getAuthenticatedInfo();
     String userId = userRequest.getSubjectId();
-    PipelinesEnum validatedPipelineId = validatePipelineName(pipelineName);
+    PipelinesEnum validatedPipelineId = PipelineApiUtils.validatePipelineName(pipelineName, logger);
 
     JobApiUtils.AsyncJobResult<String> jobResult =
         jobService.retrieveAsyncJobResult(jobId, userId, validatedPipelineId, String.class, null);
@@ -198,27 +200,6 @@ public class PipelinesApiController implements PipelinesApi {
             .pipelineOutput(jobResult.getResult()); // this is null unless the job succeeded
 
     return new ResponseEntity<>(response, getAsyncResponseCode(response.getJobReport()));
-  }
-
-  /**
-   * Validates that the pipelineName is a valid pipelineName and returns the Enum value for the
-   * pipelineName
-   *
-   * <p>Note that in PipelinesServiceTest, we check that all the pipelines in the enum exist in the
-   * pipelines table
-   *
-   * @param pipelineName the pipelineName to validate
-   * @return the Enum value for the pipelineName
-   * @throws InvalidPipelineException if the pipelineName is not valid
-   */
-  public PipelinesEnum validatePipelineName(String pipelineName) {
-    try {
-      return PipelinesEnum.valueOf(pipelineName.toUpperCase());
-    } catch (IllegalArgumentException e) {
-      logger.error("Unknown pipeline name {}", pipelineName);
-      throw new InvalidPipelineException(
-          String.format("%s is not a valid pipelineName", pipelineName));
-    }
   }
 
   /**

--- a/service/src/main/java/bio/terra/pipelines/db/entities/Pipeline.java
+++ b/service/src/main/java/bio/terra/pipelines/db/entities/Pipeline.java
@@ -2,6 +2,7 @@ package bio.terra.pipelines.db.entities;
 
 import jakarta.persistence.*;
 import java.util.StringJoiner;
+import java.util.UUID;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -42,6 +43,9 @@ public class Pipeline {
   @Column(name = "wdl_method_name")
   private String wdlMethodName;
 
+  @Column(name = "workspace_id")
+  private UUID workspaceId;
+
   public Pipeline(
       String name,
       String version,
@@ -49,7 +53,8 @@ public class Pipeline {
       String description,
       String pipelineType,
       String wdlUrl,
-      String wdlMethodName) {
+      String wdlMethodName,
+      UUID workspaceId) {
     this.name = name;
     this.version = version;
     this.displayName = displayName;
@@ -57,6 +62,7 @@ public class Pipeline {
     this.pipelineType = pipelineType;
     this.wdlUrl = wdlUrl;
     this.wdlMethodName = wdlMethodName;
+    this.workspaceId = workspaceId;
   }
 
   @Override
@@ -69,6 +75,7 @@ public class Pipeline {
         .add("pipelineType=" + pipelineType)
         .add("wdlUrl=" + wdlUrl)
         .add("wdlMethodName=" + wdlMethodName)
+        .add("workspaceId=" + workspaceId)
         .toString();
   }
 
@@ -90,6 +97,7 @@ public class Pipeline {
         .append(pipelineType)
         .append(wdlUrl)
         .append(wdlMethodName)
+        .append(workspaceId)
         .toHashCode();
   }
 
@@ -108,6 +116,7 @@ public class Pipeline {
         .append(pipelineType, otherObject.pipelineType)
         .append(wdlUrl, otherObject.wdlUrl)
         .append(wdlMethodName, otherObject.wdlMethodName)
+        .append(workspaceId, otherObject.workspaceId)
         .isEquals();
   }
 }

--- a/service/src/main/java/bio/terra/pipelines/dependencies/sam/SamClient.java
+++ b/service/src/main/java/bio/terra/pipelines/dependencies/sam/SamClient.java
@@ -5,6 +5,7 @@ import bio.terra.pipelines.app.configuration.external.SamConfiguration;
 import io.opentelemetry.api.OpenTelemetry;
 import okhttp3.OkHttpClient;
 import org.broadinstitute.dsde.workbench.client.sam.ApiClient;
+import org.broadinstitute.dsde.workbench.client.sam.api.AdminApi;
 import org.broadinstitute.dsde.workbench.client.sam.api.ResourcesApi;
 import org.broadinstitute.dsde.workbench.client.sam.api.StatusApi;
 import org.broadinstitute.dsde.workbench.client.sam.api.UsersApi;
@@ -43,6 +44,10 @@ public class SamClient {
 
   ResourcesApi resourcesApi(String accessToken) {
     return new ResourcesApi(getApiClient(accessToken));
+  }
+
+  AdminApi adminApi(String accessToken) {
+    return new AdminApi(getApiClient(accessToken));
   }
 
   StatusApi statusApi() {

--- a/service/src/main/java/bio/terra/pipelines/service/ImputationService.java
+++ b/service/src/main/java/bio/terra/pipelines/service/ImputationService.java
@@ -29,7 +29,6 @@ public class ImputationService {
   private final ImputationJobsRepository imputationJobsRepository;
   private final PipelineInputsRepository pipelineInputsRepository;
   private final JobService jobService;
-  private ImputationConfiguration imputationConfiguration;
 
   @Autowired
   ImputationService(
@@ -40,7 +39,6 @@ public class ImputationService {
     this.imputationJobsRepository = imputationJobsRepository;
     this.pipelineInputsRepository = pipelineInputsRepository;
     this.jobService = jobService;
-    this.imputationConfiguration = imputationConfiguration;
   }
 
   /**
@@ -78,7 +76,7 @@ public class ImputationService {
             .addParameter(RunImputationJobFlightMapKeys.PIPELINE_INPUTS, pipelineInputs)
             .addParameter(
                 RunImputationJobFlightMapKeys.CONTROL_WORKSPACE_ID,
-                imputationConfiguration.getWorkspaceId())
+                imputationPipeline.getWorkspaceId().toString())
             .addParameter(
                 RunImputationJobFlightMapKeys.WDL_METHOD_NAME,
                 imputationPipeline.getWdlMethodName())

--- a/service/src/main/java/bio/terra/pipelines/service/PipelinesService.java
+++ b/service/src/main/java/bio/terra/pipelines/service/PipelinesService.java
@@ -37,6 +37,14 @@ public class PipelinesService {
     return dbResult;
   }
 
+  /**
+   * This method is meant to only be called by an admin endpoint to update the control workspace id
+   * for a pipeline
+   *
+   * @param pipelineName - nanme of pipeline to update
+   * @param workspaceId - UUID of workspace to update to
+   * @return
+   */
   public Pipeline updatePipelineWorkspaceId(PipelinesEnum pipelineName, UUID workspaceId) {
     Pipeline pipeline = getPipeline(pipelineName);
     pipeline.setWorkspaceId(workspaceId);

--- a/service/src/main/java/bio/terra/pipelines/service/PipelinesService.java
+++ b/service/src/main/java/bio/terra/pipelines/service/PipelinesService.java
@@ -4,6 +4,7 @@ import bio.terra.pipelines.common.utils.PipelinesEnum;
 import bio.terra.pipelines.db.entities.Pipeline;
 import bio.terra.pipelines.db.repositories.PipelinesRepository;
 import java.util.List;
+import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -34,5 +35,12 @@ public class PipelinesService {
           String.format("Pipeline not found for pipelineName %s", pipelineName));
     }
     return dbResult;
+  }
+
+  public Pipeline updatePipelineWorkspaceId(PipelinesEnum pipelineName, UUID workspaceId) {
+    Pipeline pipeline = getPipeline(pipelineName);
+    pipeline.setWorkspaceId(workspaceId);
+    pipelinesRepository.save(pipeline);
+    return pipeline;
   }
 }

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -20,11 +20,6 @@ env:
     leonardo: ${LEONARDO_ADDRESS:https://leonardo.dsde-dev.broadinstitute.org}
   ingress:
     domainName: ${TSPS_INGRESS_DOMAIN_NAME:localhost:8080}
-  imputation:
-    # default workspace id is for this workspace in the dev environment
-    # https://bvdp-saturn-dev.appspot.com/#workspaces/tsps_dev_bp_03_13_2024/tsps_imputation_service_protected_v1
-    # this should be updated when trying to run on a bee.
-    workspaceId: ${IMPUTATION_WORKSPACE_ID:94fd136b-4231-4e80-ab0c-76d8a2811066}
   kubernetes:
     in-kubernetes: ${TERRA_COMMON_KUBERNETES_IN_KUBERNETES:false}
     pod-name: ${TERRA_COMMON_KUBERNETES_POD_NAME:}
@@ -111,7 +106,6 @@ management:
       percentiles-histogram[http.server.requests]: true
 
 imputation:
-  workspaceId: ${env.imputation.workspaceId}
   cromwellSubmissionPollingIntervalInSeconds: 600 # poll every 10 minutes for a cromwell submission
 
 pipelines:

--- a/service/src/main/resources/db/changelog.xml
+++ b/service/src/main/resources/db/changelog.xml
@@ -8,5 +8,6 @@
   <include file="changesets/20230711.yaml" relativeToChangelogFile="true"/>
   <include file="changesets/20240104.yaml" relativeToChangelogFile="true"/>
   <include file="changesets/20240202.yaml" relativeToChangelogFile="true"/>
+  <include file="changesets/20240417_add_workspace_id_to_pipelines.yaml" relativeToChangelogFile="true"/>
   <include file="changesets/20230324-testdata.yaml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/service/src/main/resources/db/changesets/20240417_add_workspace_id_to_pipelines.yaml
+++ b/service/src/main/resources/db/changesets/20240417_add_workspace_id_to_pipelines.yaml
@@ -1,0 +1,13 @@
+# add workspace_id column to pipelines table to power the new admin endpoint
+databaseChangeLog:
+  - changeSet:
+      id: add workspace_id column to pipelines table
+      author: js
+      changes:
+        # add workspace_id column to pipelines table
+        - addColumn:
+            tableName: pipelines
+            columns:
+              - column:
+                  name: workspace_id
+                  type: uuid

--- a/service/src/test/java/bio/terra/pipelines/controller/AdminApiControllerTest.java
+++ b/service/src/test/java/bio/terra/pipelines/controller/AdminApiControllerTest.java
@@ -34,7 +34,7 @@ import org.springframework.test.web.servlet.MvcResult;
 
 @ContextConfiguration(classes = {AdminApiController.class, GlobalExceptionHandler.class})
 @WebMvcTest()
-public class AdminApiControllerTest {
+class AdminApiControllerTest {
   @MockBean PipelinesService pipelinesServiceMock;
   @MockBean SamUserFactory samUserFactoryMock;
   @MockBean BearerTokenFactory bearerTokenFactory;
@@ -87,101 +87,4 @@ public class AdminApiControllerTest {
                     PipelinesEnum.IMPUTATION_MINIMAC4.getValue(), TEST_WORKSPACE_UUID)))
         .andExpect(status().isForbidden());
   }
-  //    @Test
-  //    void getErrorJobOk() throws Exception {
-  //        UUID jobId = TestUtils.TEST_NEW_UUID;
-  //        FlightState flightState =
-  //                StairwayTestUtils.constructFlightStateWithStatusAndId(
-  //                        FlightStatus.ERROR,
-  //                        jobId,
-  //                        StairwayTestUtils.CREATE_JOB_INPUT_PARAMS,
-  //                        StairwayTestUtils.EMPTY_WORKING_MAP,
-  //                        StairwayTestUtils.TIME_SUBMITTED_1,
-  //                        StairwayTestUtils.TIME_COMPLETED_1);
-  //        flightState.setException(new Exception("Test exception"));
-  //
-  //        when(jobServiceMock.retrieveJob(jobId, testUserId)).thenReturn(flightState);
-  //
-  //        // even though the job itself failed, it completed successfully so the status code
-  // should be 200
-  //        // (ok)
-  //        MvcResult result =
-  //                mockMvc
-  //                        .perform(get(String.format("/api/job/v1/jobs/%s", jobId)))
-  //                        .andExpect(status().isOk())
-  //                        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-  //                        .andReturn();
-  //
-  //        ApiJobReport response =
-  //                new ObjectMapper().readValue(result.getResponse().getContentAsString(),
-  // ApiJobReport.class);
-  //
-  //        // you could compare other fields here too beyond the id, if wanted
-  //        assertEquals(jobId.toString(), response.getId());
-  //    }
-  //
-  //    @Test
-  //    void getJobNotFound() throws Exception {
-  //        UUID badJobId = UUID.randomUUID();
-  //        when(jobServiceMock.retrieveJob(badJobId, testUserId))
-  //                .thenThrow(new ImputationJobNotFoundException("some message"));
-  //
-  //        mockMvc
-  //                .perform(get(String.format("/api/job/v1/jobs/%s", badJobId)))
-  //                .andExpect(status().isNotFound());
-  //    }
-  //
-  //    @Test
-  //    void getJobNoAccess() throws Exception {
-  //        UUID badJobId = UUID.randomUUID();
-  //        when(jobServiceMock.retrieveJob(badJobId, testUserId))
-  //                .thenThrow(new JobUnauthorizedException("some message"));
-  //
-  //        mockMvc
-  //                .perform(get(String.format("/api/job/v1/jobs/%s", badJobId)))
-  //                .andExpect(status().isForbidden());
-  //    }
-  //
-  //    @Test
-  //    void getJobBadId() throws Exception {
-  //        String badJobId = "not-a-uuid";
-  //
-  //        mockMvc
-  //                .perform(get(String.format("/api/job/v1/jobs/%s", badJobId)))
-  //                .andExpect(status().isBadRequest());
-  //    }
-  //
-  //    @Test
-  //    void getMultipleJobs() throws Exception {
-  //        EnumeratedJobs bothJobs = StairwayTestUtils.ENUMERATED_JOBS;
-  //
-  //        // the mocks
-  //        when(jobServiceMock.enumerateJobs(testUser.getSubjectId(), 10, null, null))
-  //                .thenReturn(bothJobs);
-  //
-  //        MvcResult result =
-  //                mockMvc
-  //                        .perform(get("/api/job/v1/jobs"))
-  //                        .andExpect(status().isOk())
-  //                        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-  //                        .andReturn();
-  //
-  //        // Now that we have the result object, we should further validate the contents of the
-  // string
-  //        // by reconstituting the response object from the json
-  //        ApiGetJobsResponse response =
-  //                new ObjectMapper()
-  //                        .readValue(result.getResponse().getContentAsString(),
-  // ApiGetJobsResponse.class);
-  //
-  //        // should be the same number of items as what jobsServiceMock returns
-  //        assertEquals(bothJobs.getTotalResults(), response.getTotalResults());
-  //
-  //        // The ids should all match what was returned from jobsServiceMock
-  //        for (int i = 0; i < response.getTotalResults(); ++i) {
-  //            String rawJobId = bothJobs.getResults().get(i).getFlightState().getFlightId();
-  //            String responseJobId = response.getResults().get(i).getId();
-  //            assertEquals(rawJobId, responseJobId);
-  //        }
-  //    }
 }

--- a/service/src/test/java/bio/terra/pipelines/controller/PipelinesApiUtilsTest.java
+++ b/service/src/test/java/bio/terra/pipelines/controller/PipelinesApiUtilsTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class PipelinesApiUtilsTest {
+class PipelinesApiUtilsTest {
   private static final Logger logger = LoggerFactory.getLogger(PipelinesApiUtilsTest.class);
 
   @Test

--- a/service/src/test/java/bio/terra/pipelines/controller/PipelinesApiUtilsTest.java
+++ b/service/src/test/java/bio/terra/pipelines/controller/PipelinesApiUtilsTest.java
@@ -1,0 +1,28 @@
+package bio.terra.pipelines.controller;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import bio.terra.pipelines.app.controller.PipelineApiUtils;
+import bio.terra.pipelines.common.utils.PipelinesEnum;
+import bio.terra.pipelines.db.exception.InvalidPipelineException;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class PipelinesApiUtilsTest {
+  private static final Logger logger = LoggerFactory.getLogger(PipelinesApiUtilsTest.class);
+
+  @Test
+  void validatePipelineNameHappy() {
+    // give a valid enum and expect no errors
+    PipelineApiUtils.validatePipelineName(PipelinesEnum.IMPUTATION_MINIMAC4.getValue(), logger);
+  }
+
+  @Test
+  void validatePipelineNameBadPipelineName() {
+    // give a valid enum and expect no errors
+    assertThrows(
+        InvalidPipelineException.class,
+        () -> PipelineApiUtils.validatePipelineName("bad pipeline name", logger));
+  }
+}

--- a/service/src/test/java/bio/terra/pipelines/dependencies/sam/SamServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/dependencies/sam/SamServiceTest.java
@@ -131,10 +131,11 @@ class SamServiceTest {
 
     SamService samService = spy(new SamService(samClient));
 
+    BearerToken bearerToken = new BearerToken("blah");
     assertThrows(
         ForbiddenException.class,
         () -> {
-          samService.checkAdminAuthz(new SamUser("blah", "blah", new BearerToken("blah")));
+          samService.checkAdminAuthz(new SamUser("blah", "blah", bearerToken));
         });
   }
 }

--- a/service/src/test/java/bio/terra/pipelines/dependencies/sam/SamServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/dependencies/sam/SamServiceTest.java
@@ -7,7 +7,6 @@ import bio.terra.common.exception.ForbiddenException;
 import bio.terra.common.exception.InternalServerErrorException;
 import bio.terra.common.iam.BearerToken;
 import bio.terra.common.iam.SamUser;
-import bio.terra.common.sam.exception.SamInterruptedException;
 import bio.terra.pipelines.dependencies.common.HealthCheck;
 import bio.terra.pipelines.generated.model.ApiSystemStatusSystems;
 import com.google.auth.oauth2.AccessToken;

--- a/service/src/test/java/bio/terra/pipelines/dependencies/sam/SamServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/dependencies/sam/SamServiceTest.java
@@ -131,11 +131,11 @@ class SamServiceTest {
 
     SamService samService = spy(new SamService(samClient));
 
-    BearerToken bearerToken = new BearerToken("blah");
+    SamUser samUser = new SamUser("doesnt matter", "really doesnt matter", new BearerToken("blah"));
     assertThrows(
         ForbiddenException.class,
         () -> {
-          samService.checkAdminAuthz(new SamUser("blah", "blah", bearerToken));
+          samService.checkAdminAuthz(samUser);
         });
   }
 }

--- a/service/src/test/java/bio/terra/pipelines/service/ImputationServiceMockTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/ImputationServiceMockTest.java
@@ -37,7 +37,6 @@ class ImputationServiceMockTest extends BaseEmbeddedDbTest {
     when(mockJobBuilder.addParameter(any(), any())).thenReturn(mockJobBuilder);
     when(mockJobBuilder.submit()).thenReturn(testUUID);
 
-    imputationConfiguration.setWorkspaceId("workspaceId");
     imputationConfiguration.setCromwellSubmissionPollingIntervalInSeconds(1L);
   }
 

--- a/service/src/test/java/bio/terra/pipelines/service/PipelinesServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/PipelinesServiceTest.java
@@ -7,6 +7,7 @@ import bio.terra.pipelines.db.entities.Pipeline;
 import bio.terra.pipelines.db.repositories.PipelinesRepository;
 import bio.terra.pipelines.testutils.BaseEmbeddedDbTest;
 import java.util.List;
+import java.util.UUID;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,6 +21,7 @@ class PipelinesServiceTest extends BaseEmbeddedDbTest {
     // migrations insert one pipeline (imputation) so make sure we find it
     List<Pipeline> pipelineList = pipelinesService.getPipelines();
     assertEquals(1, pipelineList.size());
+    UUID workspaceId = UUID.randomUUID();
 
     pipelinesRepository.save(
         new Pipeline(
@@ -29,7 +31,8 @@ class PipelinesServiceTest extends BaseEmbeddedDbTest {
             "description",
             "pipelineType",
             "wdlUrl",
-            "wdlMethodName"));
+            "wdlMethodName",
+            workspaceId));
 
     pipelineList = pipelinesService.getPipelines();
     assertEquals(2, pipelineList.size());
@@ -41,6 +44,7 @@ class PipelinesServiceTest extends BaseEmbeddedDbTest {
     assertEquals("pipelineType", savedPipeline.getPipelineType());
     assertEquals("wdlUrl", savedPipeline.getWdlUrl());
     assertEquals("wdlMethodName", savedPipeline.getWdlMethodName());
+    assertEquals(workspaceId, savedPipeline.getWorkspaceId());
   }
 
   @Test
@@ -59,14 +63,15 @@ class PipelinesServiceTest extends BaseEmbeddedDbTest {
     for (Pipeline p : pipelineList) {
       assertEquals(
           String.format(
-              "Pipeline[pipelineName=%s, version=%s, displayName=%s, description=%s, pipelineType=%s, wdlUrl=%s, wdlMethodName=%s]",
+              "Pipeline[pipelineName=%s, version=%s, displayName=%s, description=%s, pipelineType=%s, wdlUrl=%s, wdlMethodName=%s, workspaceId=%s]",
               p.getName(),
               p.getVersion(),
               p.getDisplayName(),
               p.getDescription(),
               p.getPipelineType(),
               p.getWdlUrl(),
-              p.getWdlMethodName()),
+              p.getWdlMethodName(),
+              p.getWorkspaceId()),
           p.toString());
     }
   }
@@ -86,6 +91,7 @@ class PipelinesServiceTest extends BaseEmbeddedDbTest {
               .append(p.getPipelineType())
               .append(p.getWdlUrl())
               .append(p.getWdlMethodName())
+              .append(p.getWorkspaceId())
               .toHashCode(),
           p.hashCode());
     }

--- a/service/src/test/java/bio/terra/pipelines/service/PipelinesServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/PipelinesServiceTest.java
@@ -102,7 +102,7 @@ class PipelinesServiceTest extends BaseEmbeddedDbTest {
     PipelinesEnum pipelinesEnum = PipelinesEnum.IMPUTATION_MINIMAC4;
     Pipeline p = pipelinesService.getPipeline(pipelinesEnum);
     UUID savedWorkspaceId = UUID.randomUUID();
-    // make sure the current pipeline does not have the workedspace id we're trying to update with
+    // make sure the current pipeline does not have the workspace id we're trying to update with
     assertNotEquals(savedWorkspaceId, p.getWorkspaceId());
 
     // update pipeline workspace id

--- a/service/src/test/java/bio/terra/pipelines/service/PipelinesServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/PipelinesServiceTest.java
@@ -96,4 +96,20 @@ class PipelinesServiceTest extends BaseEmbeddedDbTest {
           p.hashCode());
     }
   }
+
+  @Test
+  void updatePipelineWorkspaceId() {
+    PipelinesEnum pipelinesEnum = PipelinesEnum.IMPUTATION_MINIMAC4;
+    Pipeline p = pipelinesService.getPipeline(pipelinesEnum);
+    UUID savedWorkspaceId = UUID.randomUUID();
+    // make sure the current pipeline does not have the workedspace id we're trying to update with
+    assertNotEquals(savedWorkspaceId, p.getWorkspaceId());
+
+    // update pipeline workspace id
+    pipelinesService.updatePipelineWorkspaceId(pipelinesEnum, savedWorkspaceId);
+    p = pipelinesService.getPipeline(pipelinesEnum);
+
+    // assert the workspace id has been updated
+    assertEquals(savedWorkspaceId, p.getWorkspaceId());
+  }
 }

--- a/service/src/test/java/bio/terra/pipelines/testutils/MockMvcUtils.java
+++ b/service/src/test/java/bio/terra/pipelines/testutils/MockMvcUtils.java
@@ -46,6 +46,8 @@ public class MockMvcUtils {
           UUID.randomUUID().toString(),
           new BearerToken(UUID.randomUUID().toString()));
 
+  public static final UUID TEST_WORKSPACE_UUID =
+      UUID.fromString("94fd136b-1234-1234-1234-76d8a2811066");
   // using this function to build a pipeline with a value set for the id field.  Normally this would
   // be populated
   // by calling `save()` from the repository but since these tests mock that out, we have to set the
@@ -60,7 +62,8 @@ public class MockMvcUtils {
             "description",
             "pipelineType",
             "wdlUrl",
-            "wdlMethodName");
+            "wdlMethodName",
+            TEST_WORKSPACE_UUID);
     testPipeline.setId(2L);
     return testPipeline;
   }

--- a/service/src/test/java/bio/terra/pipelines/testutils/TestUtils.java
+++ b/service/src/test/java/bio/terra/pipelines/testutils/TestUtils.java
@@ -24,6 +24,7 @@ public class TestUtils {
   public static final String TEST_PIPELINE_TYPE_1 = "imputation1";
   public static final String TEST_WDL_URL_1 = "http://nowhere1";
   public static final String TEST_WDL_METHOD_NAME_1 = "methodName1";
+  public static final UUID TEST_WORKSPACE_ID_1 = UUID.randomUUID();
   public static final String TEST_PIPELINE_ID_2 = "testPipeline2";
   public static final String TEST_PIPELINE_VERSION_2 = "testVersion2";
   public static final String TEST_PIPELINE_DISPLAY_NAME_2 = "Test Pipeline Name Two";
@@ -32,6 +33,8 @@ public class TestUtils {
   public static final String TEST_PIPELINE_TYPE_2 = "imputation2";
   public static final String TEST_WDL_URL_2 = "http://nowhere2";
   public static final String TEST_WDL_METHOD_NAME_2 = "methodName2";
+  public static final UUID TEST_WORKSPACE_ID_2 = UUID.randomUUID();
+
   public static final Pipeline TEST_PIPELINE_1 =
       new Pipeline(
           TEST_PIPELINE_NAME_1,
@@ -40,7 +43,8 @@ public class TestUtils {
           TEST_PIPELINE_DESCRIPTION_1,
           TEST_PIPELINE_TYPE_1,
           TEST_WDL_URL_1,
-          TEST_WDL_METHOD_NAME_1);
+          TEST_WDL_METHOD_NAME_1,
+          TEST_WORKSPACE_ID_1);
   public static final Pipeline TEST_PIPELINE_2 =
       new Pipeline(
           TEST_PIPELINE_ID_2,
@@ -49,7 +53,8 @@ public class TestUtils {
           TEST_PIPELINE_DESCRIPTION_2,
           TEST_PIPELINE_TYPE_2,
           TEST_WDL_URL_2,
-          TEST_WDL_METHOD_NAME_2);
+          TEST_WDL_METHOD_NAME_2,
+          TEST_WORKSPACE_ID_2);
 
   public static final String TEST_USER_ID_1 =
       "testUser"; // this matches the job pre-populated in the db for tests


### PR DESCRIPTION
### Description 

In order to make e2e testing easier (and for generally more flexibility in running tsps) we want to add an admin endpoint that allows an admin user to update the workspace id for a given pipeline.

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-224