### PR TITLE
update params step in e2e workflow to get bee-destroy step to always run

### DIFF
--- a/.github/workflows/run-e2e-tests.yaml
+++ b/.github/workflows/run-e2e-tests.yaml
@@ -1,8 +1,8 @@
 name: Run TSPS e2e tests with BEE
 on:
   schedule:
-    # run once a day at 23:00 UTC every day of the work week
-    - cron: "0 23 * * 1-5"
+    # run once a day at 23:25 UTC every day of the work week
+    - cron: "25 23 * * 1-5"
   workflow_dispatch:
 env:
   BEE_NAME: 'tsps-${{ github.run_id }}-${{ github.run_attempt}}-dev'

--- a/.github/workflows/run-e2e-tests.yaml
+++ b/.github/workflows/run-e2e-tests.yaml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Get inputs or use defaults
         id: extract-inputs
-        run: >
+        run: |
           echo "branch=${{ inputs.branch || 'develop' }}" >> "$GITHUB_OUTPUT"
           echo "delete-bee=${{ inputs.delete-bee || true }}" >> "$GITHUB_OUTPUT"
   params-gen:


### PR DESCRIPTION
### Description 
I think we're separating the commands of the init-params step incorrectly.  I think it should be a `|` instead of a `>` https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun

### Jira Ticket
No ticket explicitly but related to https://broadworkbench.atlassian.net/browse/TSPS-124