### PR TITLE
TSPS-231 update exceptions thrown in flight to be deserializable

### DIFF
--- a/service/src/main/java/bio/terra/pipelines/dependencies/cbas/CbasServiceApiException.java
+++ b/service/src/main/java/bio/terra/pipelines/dependencies/cbas/CbasServiceApiException.java
@@ -7,4 +7,8 @@ public class CbasServiceApiException extends CbasServiceException {
   public CbasServiceApiException(ApiException exception) {
     super("Cbas returned an unsuccessful status code", exception);
   }
+
+  public CbasServiceApiException(String message) {
+    super(message);
+  }
 }

--- a/service/src/main/java/bio/terra/pipelines/dependencies/cbas/CbasServiceException.java
+++ b/service/src/main/java/bio/terra/pipelines/dependencies/cbas/CbasServiceException.java
@@ -8,4 +8,8 @@ public class CbasServiceException extends ErrorReportException {
   protected CbasServiceException(String message, Throwable cause) {
     super(message, cause, new ArrayList<>(), HttpStatus.INTERNAL_SERVER_ERROR);
   }
+
+  protected CbasServiceException(String message) {
+    super(message, new ArrayList<>(), HttpStatus.INTERNAL_SERVER_ERROR);
+  }
 }

--- a/service/src/main/java/bio/terra/pipelines/dependencies/common/DependencyNotAvailableException.java
+++ b/service/src/main/java/bio/terra/pipelines/dependencies/common/DependencyNotAvailableException.java
@@ -3,11 +3,13 @@ package bio.terra.pipelines.dependencies.common;
 import bio.terra.common.exception.ErrorReportException;
 
 public class DependencyNotAvailableException extends ErrorReportException {
-  public DependencyNotAvailableException(String dependency, String context) {
-    super("Dependency not available: %s. %s".formatted(dependency, context));
+  public DependencyNotAvailableException(String errorMessage) {
+    super(errorMessage);
   }
 
-  public DependencyNotAvailableException(String dependency, String context, Throwable reason) {
-    super("Dependency not available: %s. %s".formatted(dependency, context), reason);
+  public static DependencyNotAvailableException formatDependencyNotAvailableExceptionHelper(
+      String dependency, String context) {
+    return new DependencyNotAvailableException(
+        "Dependency not available: %s. %s".formatted(dependency, context));
   }
 }

--- a/service/src/main/java/bio/terra/pipelines/dependencies/leonardo/AppUtils.java
+++ b/service/src/main/java/bio/terra/pipelines/dependencies/leonardo/AppUtils.java
@@ -104,7 +104,7 @@ public class AppUtils {
                 this.appComparisonFunction(appToCompareA, appToCompareB, appTypeList, workspaceId))
         .orElseThrow(
             () ->
-                new DependencyNotAvailableException(
+                DependencyNotAvailableException.formatDependencyNotAvailableExceptionHelper(
                     "%s".formatted(appType.toString()),
                     "No suitable, healthy app found for %s (out of %s total apps in this workspace)"
                         .formatted(appType.toString(), apps.size())));
@@ -156,7 +156,7 @@ public class AppUtils {
       return Optional.ofNullable(proxyUrls.get("wds"))
           .orElseThrow(
               () ->
-                  new DependencyNotAvailableException(
+                  DependencyNotAvailableException.formatDependencyNotAvailableExceptionHelper(
                       "WDS",
                       "WDS proxy URL not found in %s app (available proxy URLs: %s)"
                           .formatted(
@@ -166,7 +166,7 @@ public class AppUtils {
                                   .collect(Collectors.joining(", ")))));
     }
 
-    throw new DependencyNotAvailableException(
+    throw DependencyNotAvailableException.formatDependencyNotAvailableExceptionHelper(
         "WDS",
         "WDS in %s app not ready (%s)".formatted(foundApp.getAppName(), foundApp.getStatus()));
   }
@@ -183,7 +183,7 @@ public class AppUtils {
       return Optional.ofNullable(proxyUrls.get(proxyUrl))
           .orElseThrow(
               () ->
-                  new DependencyNotAvailableException(
+                  DependencyNotAvailableException.formatDependencyNotAvailableExceptionHelper(
                       "CBAS",
                       "CBAS proxy URL not found in %s app (available proxy URLs: %s)"
                           .formatted(
@@ -193,7 +193,7 @@ public class AppUtils {
                                   .collect(Collectors.joining(", ")))));
     }
 
-    throw new DependencyNotAvailableException(
+    throw DependencyNotAvailableException.formatDependencyNotAvailableExceptionHelper(
         "CBAS",
         "CBAS in %s app not ready (%s)".formatted(foundApp.getAppName(), foundApp.getStatus()));
   }

--- a/service/src/main/java/bio/terra/pipelines/dependencies/leonardo/LeonardoServiceApiException.java
+++ b/service/src/main/java/bio/terra/pipelines/dependencies/leonardo/LeonardoServiceApiException.java
@@ -7,4 +7,8 @@ public class LeonardoServiceApiException extends LeonardoServiceException {
   public LeonardoServiceApiException(ApiException exception) {
     super("Leonardo returned an unsuccessful status code", exception);
   }
+
+  public LeonardoServiceApiException(String message) {
+    super("Leonardo returned an unsuccessful status code");
+  }
 }

--- a/service/src/main/java/bio/terra/pipelines/dependencies/leonardo/LeonardoServiceException.java
+++ b/service/src/main/java/bio/terra/pipelines/dependencies/leonardo/LeonardoServiceException.java
@@ -8,4 +8,8 @@ public abstract class LeonardoServiceException extends ErrorReportException {
   protected LeonardoServiceException(String message, Throwable cause) {
     super(message, cause, new ArrayList<>(), HttpStatus.INTERNAL_SERVER_ERROR);
   }
+
+  protected LeonardoServiceException(String message) {
+    super(message, new ArrayList<>(), HttpStatus.INTERNAL_SERVER_ERROR);
+  }
 }

--- a/service/src/main/java/bio/terra/pipelines/stairway/imputation/CheckCbasHealthStep.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/imputation/CheckCbasHealthStep.java
@@ -1,6 +1,5 @@
 package bio.terra.pipelines.stairway.imputation;
 
-import bio.terra.cbas.client.ApiException;
 import bio.terra.pipelines.common.utils.FlightUtils;
 import bio.terra.pipelines.dependencies.cbas.CbasService;
 import bio.terra.pipelines.dependencies.cbas.CbasServiceApiException;
@@ -36,8 +35,7 @@ public class CheckCbasHealthStep implements Step {
         cbasService.checkHealth(cbasUri, samService.getTspsServiceAccountToken());
     if (!healthResult.isOk()) {
       return new StepResult(
-          StepStatus.STEP_RESULT_FAILURE_RETRY,
-          new CbasServiceApiException(new ApiException("CBAS is not healthy")));
+          StepStatus.STEP_RESULT_FAILURE_RETRY, new CbasServiceApiException("CBAS is not healthy"));
     }
     return StepResult.getStepResultSuccess();
   }

--- a/service/src/main/java/bio/terra/pipelines/stairway/imputation/CheckLeonardoHealthStep.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/imputation/CheckLeonardoHealthStep.java
@@ -5,7 +5,6 @@ import bio.terra.pipelines.dependencies.leonardo.LeonardoService;
 import bio.terra.pipelines.dependencies.leonardo.LeonardoServiceApiException;
 import bio.terra.stairway.*;
 import bio.terra.stairway.exception.RetryException;
-import org.broadinstitute.dsde.workbench.client.leonardo.ApiException;
 
 /** This step queries the Leonardo status endpoint to check if it is healthy */
 public class CheckLeonardoHealthStep implements Step {
@@ -21,7 +20,7 @@ public class CheckLeonardoHealthStep implements Step {
     if (!healthResult.isOk()) {
       return new StepResult(
           StepStatus.STEP_RESULT_FAILURE_RETRY,
-          new LeonardoServiceApiException(new ApiException("Leonardo is not healthy")));
+          new LeonardoServiceApiException("Leonardo is not healthy"));
     }
     return StepResult.getStepResultSuccess();
   }

--- a/service/src/test/java/bio/terra/pipelines/dependencies/wds/WdsServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/dependencies/wds/WdsServiceTest.java
@@ -39,7 +39,8 @@ class WdsServiceTest {
 
   final Answer<Object> errorAnswerDependencyException =
       invocation -> {
-        throw new DependencyNotAvailableException("WDS", "down");
+        throw DependencyNotAvailableException.formatDependencyNotAvailableExceptionHelper(
+            "WDS", "down");
       };
 
   @BeforeEach
@@ -120,7 +121,8 @@ class WdsServiceTest {
     RecordResponse expectedResponse = new RecordResponse().id("idTest").type("typeTest");
 
     DependencyNotAvailableException expectedException =
-        new DependencyNotAvailableException("WDS", "Bad Wds");
+        DependencyNotAvailableException.formatDependencyNotAvailableExceptionHelper(
+            "WDS", "Bad Wds");
 
     WdsClient wdsClient = mock(WdsClient.class);
     RecordsApi recordsApi = mock(RecordsApi.class);

--- a/service/src/test/java/bio/terra/pipelines/stairway/imputation/StairwayExceptionSerializerTest.java
+++ b/service/src/test/java/bio/terra/pipelines/stairway/imputation/StairwayExceptionSerializerTest.java
@@ -34,7 +34,8 @@ class StairwayExceptionSerializerTest extends BaseTest {
   @Test
   void serialize_errorReportException() {
     RuntimeException exception =
-        new DependencyNotAvailableException("test dependency name", "test context");
+        DependencyNotAvailableException.formatDependencyNotAvailableExceptionHelper(
+            "test dependency name", "test context");
     String serializedException = stairwayExceptionSerializer.serialize(exception);
     String expected =
         "{\"className\":\"bio.terra.pipelines.dependencies.common.DependencyNotAvailableException\",\"message\":\"Dependency not available: test dependency name. test context\",\"errorDetails\":[],\"errorCode\":500,\"apiErrorReportException\":true}";
@@ -83,15 +84,16 @@ class StairwayExceptionSerializerTest extends BaseTest {
 
   @Test
   void deserialize_failToConstruct() {
-    // this is marked as an ApiErrorReportException, but no matching constructor can be found
+    // this is marked as an ApiErrorReportException, but no matching constructor can be found.  We
+    // dont throw this in our stairway flgiht code so it doesnt need to be deserializable
     String serializedException =
-        "{\"className\":\"bio.terra.pipelines.dependencies.common.DependencyNotAvailableException\",\"message\":\"test message\",\"errorDetails\":[],\"errorCode\":500,\"apiErrorReportException\":true}";
+        "{\"className\":\"bio.terra.pipelines.dependencies.leonardo.LeonardoServiceException\",\"message\":\"test message\",\"errorDetails\":[],\"errorCode\":500,\"apiErrorReportException\":true}";
 
     Exception deserializedException = stairwayExceptionSerializer.deserialize(serializedException);
 
     assertEquals(ExceptionSerializerException.class, deserializedException.getClass());
     assertEquals(
-        "Failed to construct exception: bio.terra.pipelines.dependencies.common.DependencyNotAvailableException; Exception message: test message",
+        "Failed to construct exception: bio.terra.pipelines.dependencies.leonardo.LeonardoServiceException; Exception message: test message",
         deserializedException.getMessage());
   }
 }

--- a/service/src/test/java/bio/terra/pipelines/stairway/imputation/StairwayExceptionSerializerTest.java
+++ b/service/src/test/java/bio/terra/pipelines/stairway/imputation/StairwayExceptionSerializerTest.java
@@ -84,8 +84,10 @@ class StairwayExceptionSerializerTest extends BaseTest {
 
   @Test
   void deserialize_failToConstruct() {
-    // this is marked as an ApiErrorReportException, but no matching constructor can be found.  We
-    // dont throw this in our stairway flgiht code so it doesnt need to be deserializable
+    // LeonardoServiceException an ApiErrorReportException but it's not something that can actually
+    // be thrown as it is abstract (LeonardoServiceApiException is the exception that is thrown in
+    // our code and is deserializable).  Using this to demonstrate what an un-deserializable
+    // exception would look like.
     String serializedException =
         "{\"className\":\"bio.terra.pipelines.dependencies.leonardo.LeonardoServiceException\",\"message\":\"test message\",\"errorDetails\":[],\"errorCode\":500,\"apiErrorReportException\":true}";
 


### PR DESCRIPTION


### Description 

These 3 exceptions are now deserializable when they are thrown in a flight (you can see in the test I changed that the exception we were expecting to fail now succeeds so I changed it to an exception that isnt thrown at all)

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-231