### PR TITLE
TSPS-234 upgrade TCL to get bouncycastle upgrade to v1.78

### DIFF
--- a/buildSrc/src/main/groovy/bio.terra.pipelines.java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/bio.terra.pipelines.java-common-conventions.gradle
@@ -44,7 +44,7 @@ dependencies {
 
     testImplementation 'org.hamcrest:hamcrest:2.2'
 
-    implementation 'bio.terra:terra-common-lib:1.1.4-SNAPSHOT'
+    implementation 'bio.terra:terra-common-lib:1.1.11-SNAPSHOT'
     implementation platform('com.google.cloud:libraries-bom:26.33.0') // required for TCL
 
     implementation 'io.swagger.core.v3:swagger-annotations:2.2.12'

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -41,7 +41,7 @@ dependencies {
     implementation group: "com.google.guava", name:"guava"
 
     // Get stairway via TCL
-    implementation "bio.terra:terra-common-lib" // 1.1.4-SNAPSHOT is defined in java-common-conventions
+    implementation "bio.terra:terra-common-lib" // 1.1.11-SNAPSHOT is defined in java-common-conventions
 
     // terra clients
     implementation "org.broadinstitute.dsde.workbench:sam-client_2.13:0.1-5a5bf28"


### PR DESCRIPTION
### Description 

Upgrade TCL to version 1.1.11-SNAPSHOT, which brings in bouncycastle 1.78 to resolve the high security finding

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-234