### PR TITLE
TSPS-221 add checker wdl to test if two vcfs are the same

### DIFF
--- a/pipelines/testing/CompareVcfs.wdl
+++ b/pipelines/testing/CompareVcfs.wdl
@@ -1,6 +1,6 @@
 version 1.0
 
-workflow VerifyVcf {
+workflow CompareVcfs {
 
     input {
         File test_gvcf

--- a/wdls/imputation/VcfChecker.wdl
+++ b/wdls/imputation/VcfChecker.wdl
@@ -25,18 +25,15 @@ task CompareVcfs {
     command {
         set -eo pipefail
 
-        comm --nocheck-order <(gunzip -c -f ~{file1} | grep -v '~{patternForLinesToExcludeFromComparison}')  <(gunzip -c -f ~{file2} | grep -v '~{patternForLinesToExcludeFromComparison}') > comm_output.txt
+        gunzip -c -f ~{file1} | grep -v '~{patternForLinesToExcludeFromComparison}' > file_1.vcf
+        gunzip -c -f ~{file2} | grep -v '~{patternForLinesToExcludeFromComparison}' > file_2.vcf
 
-        if [ -s comm_output.txt ]; then
-        # file is not empty so that means comm found differences
-        cat comm_output.txt
-        exit 1
-        fi
+        diff -q file_1.vcf file_2.vcf
     }
 
     runtime {
         docker: "gcr.io/gcp-runtimes/ubuntu_16_0_4:latest"
         disks: "local-disk ${disk_size_gb} SSD"
-        memory: "8 GiB"
+        memory: "64 GiB"
     }
 }

--- a/wdls/imputation/VcfChecker.wdl
+++ b/wdls/imputation/VcfChecker.wdl
@@ -21,14 +21,11 @@ task CompareVcfs {
         File file2
         String patternForLinesToExcludeFromComparison
     }
-    Int disk_size_gb = ceil(6 * size(file1, "GiB")) + ceil(6 * size(file2, "GiB")) + 100
+    Int disk_size_gb = ceil(3 * size(file1, "GiB")) + ceil(3 * size(file2, "GiB")) + 50
     command {
         set -eo pipefail
 
-        gunzip -c -f ~{file1} | grep -v '~{patternForLinesToExcludeFromComparison}' > file_1.vcf
-        gunzip -c -f ~{file2} | grep -v '~{patternForLinesToExcludeFromComparison}' > file_2.vcf
-
-        comm --nocheck-order file_1.vcf file_2.vcf > comm_output.txt
+        comm --nocheck-order <(gunzip -c -f ~{file1} | grep -v '~{patternForLinesToExcludeFromComparison}')  <(gunzip -c -f ~{file2} | grep -v '~{patternForLinesToExcludeFromComparison}') > comm_output.txt
 
         if [ -s comm_output.txt ]; then
         # file is not empty so that means comm found differences

--- a/wdls/imputation/VcfChecker.wdl
+++ b/wdls/imputation/VcfChecker.wdl
@@ -31,7 +31,7 @@ task CompareVcfs {
         comm --nocheck-order file_1.vcf file_2.vcf > comm_output.txt
 
         if [ -s comm_output.txt ]; then
-        # The comm output is not empty so there are differences
+        cat comm_output.txt
         exit 1
         fi
     }

--- a/wdls/imputation/VcfChecker.wdl
+++ b/wdls/imputation/VcfChecker.wdl
@@ -23,21 +23,16 @@ task CompareVcfs {
     input {
         File file1
         File file2
-        String patternForLinesToExcludeFromComparison = ""
+        String patternForLinesToExcludeFromComparison
     }
     Int disk_size_gb = ceil(3 * size(file1, "GiB")) + ceil(3 * size(file2, "GiB")) + 50
     command {
         set -eo pipefail
 
-        gunzip -c -f > file_1.vcf
-        gunzip -c -f > file_2.vcf
+        gunzip -c -f ~{file1} | grep -v '~{patternForLinesToExcludeFromComparison}' > file_1.vcf
+        gunzip -c -f ~{file2} | grep -v '~{patternForLinesToExcludeFromComparison}' > file_2.vcf
 
-        if [ -z ~{patternForLinesToExcludeFromComparison} ]; then
         diff file_1.vcf file_2.vcf
-        else
-        echo "It's defined!"
-        diff <(cat file_1.vcf | grep -v '~{patternForLinesToExcludeFromComparison}') <(cat file_2.vcf | grep -v '~{patternForLinesToExcludeFromComparison}')
-        fi
     }
 
     runtime {

--- a/wdls/imputation/VcfChecker.wdl
+++ b/wdls/imputation/VcfChecker.wdl
@@ -41,8 +41,4 @@ task CompareVcfs {
         disks: "local-disk ${disk_size_gb} SSD"
         memory: "8 GiB"
     }
-
-    output{
-        File comm_output = "comm_output.txt"
-    }
 }

--- a/wdls/imputation/VcfChecker.wdl
+++ b/wdls/imputation/VcfChecker.wdl
@@ -1,0 +1,45 @@
+version 1.0
+
+workflow VerifyGvcf {
+
+    input {
+        File test_gvcf
+        File test_gvcf_index
+        File truth_gvcf
+        File truth_gvcf_index
+
+        Boolean? done
+    }
+
+    call CompareVcfs {
+        input:
+            file1 = test_gvcf,
+            file2 = truth_gvcf,
+            patternForLinesToExcludeFromComparison = "^##"
+    }
+}
+
+task CompareVcfs {
+    input {
+        File file1
+        File file2
+        String patternForLinesToExcludeFromComparison = ""
+    }
+    Int disk_size_gb = ceil(size(file1, "GiB")) + ceil(size(file2, "GiB")) + 20
+    command {
+        set -eo pipefail
+
+        if [ -z ~{patternForLinesToExcludeFromComparison} ]; then
+        diff <(gunzip -c -f ~{file1}) <(gunzip -c -f ~{file2})
+        else
+        echo "It's defined!"
+        diff <(gunzip -c -f ~{file1} | grep -v '~{patternForLinesToExcludeFromComparison}') <(gunzip -c -f ~{file2} | grep -v '~{patternForLinesToExcludeFromComparison}')
+        fi
+    }
+
+    runtime {
+        docker: "gcr.io/gcp-runtimes/ubuntu_16_0_4:latest"
+        disks: "local-disk ${disk_size_gb} SSD"
+        memory: "32 GiB"
+    }
+}

--- a/wdls/imputation/VcfChecker.wdl
+++ b/wdls/imputation/VcfChecker.wdl
@@ -1,6 +1,6 @@
 version 1.0
 
-workflow VerifyGvcf {
+workflow VerifyVcf {
 
     input {
         File test_gvcf

--- a/wdls/imputation/VcfChecker.wdl
+++ b/wdls/imputation/VcfChecker.wdl
@@ -21,7 +21,7 @@ task CompareVcfs {
         File file2
         String patternForLinesToExcludeFromComparison
     }
-    Int disk_size_gb = ceil(3 * size(file1, "GiB")) + ceil(3 * size(file2, "GiB")) + 50
+    Int disk_size_gb = ceil(6 * size(file1, "GiB")) + ceil(6 * size(file2, "GiB")) + 100
     command {
         set -eo pipefail
 
@@ -31,6 +31,7 @@ task CompareVcfs {
         comm --nocheck-order file_1.vcf file_2.vcf > comm_output.txt
 
         if [ -s comm_output.txt ]; then
+        # file is not empty so that means comm found differences
         cat comm_output.txt
         exit 1
         fi

--- a/wdls/imputation/VcfChecker.wdl
+++ b/wdls/imputation/VcfChecker.wdl
@@ -15,10 +15,6 @@ workflow VerifyGvcf {
             file2 = truth_gvcf,
             patternForLinesToExcludeFromComparison = "^##"
     }
-
-    output {
-        File vcf_differences = CompareVcfs.comm_output
-    }
 }
 
 task CompareVcfs {
@@ -34,21 +30,12 @@ task CompareVcfs {
         gunzip -c -f ~{file1} | grep -v '~{patternForLinesToExcludeFromComparison}' > file_1.vcf
         gunzip -c -f ~{file2} | grep -v '~{patternForLinesToExcludeFromComparison}' > file_2.vcf
 
-        comm file_1.vcf file_2.vcf > output.txt
-
-        if [ -s output.txt ]; then
-        # The output is not-empty so that means there was a diff
-        exit 1
-        fi
+        diff -q file_1.vcf file_2.vcf
     }
 
     runtime {
         docker: "gcr.io/gcp-runtimes/ubuntu_16_0_4:latest"
         disks: "local-disk ${disk_size_gb} SSD"
-        memory: "32 GiB"
-    }
-
-    output {
-        File comm_output = "output.txt"
+        memory: "64 GiB"
     }
 }

--- a/wdls/imputation/VcfChecker.wdl
+++ b/wdls/imputation/VcfChecker.wdl
@@ -33,7 +33,7 @@ task CompareVcfs {
         gunzip -c -f > file_2.vcf
 
         if [ -z ~{patternForLinesToExcludeFromComparison} ]; then
-        diff file_1.vcf file_2.vcf)
+        diff file_1.vcf file_2.vcf
         else
         echo "It's defined!"
         diff <(cat file_1.vcf | grep -v '~{patternForLinesToExcludeFromComparison}') <(cat file_2.vcf | grep -v '~{patternForLinesToExcludeFromComparison}')

--- a/wdls/imputation/VcfChecker.wdl
+++ b/wdls/imputation/VcfChecker.wdl
@@ -25,15 +25,18 @@ task CompareVcfs {
         File file2
         String patternForLinesToExcludeFromComparison = ""
     }
-    Int disk_size_gb = ceil(size(file1, "GiB")) + ceil(size(file2, "GiB")) + 20
+    Int disk_size_gb = ceil(3 * size(file1, "GiB")) + ceil(3 * size(file2, "GiB")) + 50
     command {
         set -eo pipefail
 
+        gunzip -c -f > file_1.vcf
+        gunzip -c -f > file_2.vcf
+
         if [ -z ~{patternForLinesToExcludeFromComparison} ]; then
-        diff <(gunzip -c -f ~{file1}) <(gunzip -c -f ~{file2})
+        diff file_1.vcf file_2.vcf)
         else
         echo "It's defined!"
-        diff <(gunzip -c -f ~{file1} | grep -v '~{patternForLinesToExcludeFromComparison}') <(gunzip -c -f ~{file2} | grep -v '~{patternForLinesToExcludeFromComparison}')
+        diff <(cat file_1.vcf | grep -v '~{patternForLinesToExcludeFromComparison}') <(cat file_2.vcf | grep -v '~{patternForLinesToExcludeFromComparison}')
         fi
     }
 


### PR DESCRIPTION
### Description 

As part of the work to making beagle determinstic (work done in https://github.com/broadinstitute/warp/pull/1285) we wanted to have wdl that we could pass in two vcfs to and verify that they are in fact the same.

This is the run of this wdl that verifies outputs from two different runs of the new beagle wdl were in fact the same - https://bvdp-saturn-dev.appspot.com/#workspaces/tsps_dev_bp_02_01_2024_v1/imputation-pipeline-testing-03-07-2024/workflows-app/submission-history/14873abd-23c3-4df9-81b8-00d813fd21fe

A run to make sure the workflow does fail when the two files are not the same - https://bvdp-saturn-dev.appspot.com/#workspaces/tsps_dev_bp_02_01_2024_v1/imputation-pipeline-testing-03-07-2024/workflows-app/submission-history/d96627a1-b0eb-4eb9-95ba-841ca19ff2c3


### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-221