### PR TITLE
don't call cache cbas submissions, remove outputs from empty WDL

### DIFF
--- a/pipelines/testing/ImputationBeagleEmpty.wdl
+++ b/pipelines/testing/ImputationBeagleEmpty.wdl
@@ -29,8 +29,6 @@ workflow ImputationBeagle {
         File imputed_multi_sample_vcf = WriteEmptyFile.empty_file
         File imputed_multi_sample_vcf_index = WriteEmptyFile.empty_file
         File chunks_info = WriteEmptyFile.empty_file
-        File failed_chunks = WriteEmptyFile.empty_file
-        Int n_failed_chunks = 0
     }
 }
 

--- a/service/src/main/java/bio/terra/pipelines/app/configuration/external/CbasConfiguration.java
+++ b/service/src/main/java/bio/terra/pipelines/app/configuration/external/CbasConfiguration.java
@@ -2,5 +2,25 @@ package bio.terra.pipelines.app.configuration.external;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+/** configuration for all properties related to cbas */
 @ConfigurationProperties(prefix = "cbas")
-public record CbasConfiguration(Boolean debugApiLogging) {}
+public class CbasConfiguration {
+  private Boolean callCache;
+  private Boolean debugApiLogging;
+
+  public Boolean getCallCache() {
+    return callCache;
+  }
+
+  public Boolean getDebugApiLogging() {
+    return debugApiLogging;
+  }
+
+  public void setCallCache(Boolean callCache) {
+    this.callCache = callCache;
+  }
+
+  public void setDebugApiLogging(Boolean debugApiLogging) {
+    this.debugApiLogging = debugApiLogging;
+  }
+}

--- a/service/src/main/java/bio/terra/pipelines/common/utils/FlightBeanBag.java
+++ b/service/src/main/java/bio/terra/pipelines/common/utils/FlightBeanBag.java
@@ -1,5 +1,6 @@
 package bio.terra.pipelines.common.utils;
 
+import bio.terra.pipelines.app.configuration.external.CbasConfiguration;
 import bio.terra.pipelines.app.configuration.internal.ImputationConfiguration;
 import bio.terra.pipelines.dependencies.cbas.CbasService;
 import bio.terra.pipelines.dependencies.leonardo.LeonardoService;
@@ -27,6 +28,7 @@ public class FlightBeanBag {
   private final WdsService wdsService;
   private final CbasService cbasService;
   private final ImputationConfiguration imputationConfiguration;
+  private final CbasConfiguration cbasConfiguration;
 
   @Lazy
   @Autowired
@@ -37,7 +39,8 @@ public class FlightBeanBag {
       LeonardoService leonardoService,
       WdsService wdsService,
       CbasService cbasService,
-      ImputationConfiguration imputationConfiguration) {
+      ImputationConfiguration imputationConfiguration,
+      CbasConfiguration cbasConfiguration) {
     this.pipelinesService = pipelinesService;
     this.pipelineRunsService = pipelineRunsService;
     this.samService = samService;
@@ -45,6 +48,7 @@ public class FlightBeanBag {
     this.wdsService = wdsService;
     this.cbasService = cbasService;
     this.imputationConfiguration = imputationConfiguration;
+    this.cbasConfiguration = cbasConfiguration;
   }
 
   public static FlightBeanBag getFromObject(Object object) {
@@ -77,5 +81,9 @@ public class FlightBeanBag {
 
   public ImputationConfiguration getImputationConfiguration() {
     return imputationConfiguration;
+  }
+
+  public CbasConfiguration getCbasConfiguration() {
+    return cbasConfiguration;
   }
 }

--- a/service/src/main/java/bio/terra/pipelines/dependencies/cbas/CbasClient.java
+++ b/service/src/main/java/bio/terra/pipelines/dependencies/cbas/CbasClient.java
@@ -23,7 +23,7 @@ public class CbasClient {
     // By closing the connection after each request, we avoid the problem of the open connection
     // being force-closed ungracefully by the Azure Relay/Listener infrastructure:
     apiClient.addDefaultHeader("Connection", "close");
-    apiClient.setDebugging(cbasConfiguration.debugApiLogging());
+    apiClient.setDebugging(cbasConfiguration.getDebugApiLogging());
     return apiClient;
   }
 

--- a/service/src/main/java/bio/terra/pipelines/stairway/imputation/RunImputationJobFlight.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/imputation/RunImputationJobFlight.java
@@ -67,7 +67,8 @@ public class RunImputationJobFlight extends Flight {
         new SubmitCromwellRunSetStep(
             flightBeanBag.getCbasService(),
             flightBeanBag.getSamService(),
-            flightBeanBag.getPipelinesService()),
+            flightBeanBag.getPipelinesService(),
+            flightBeanBag.getCbasConfiguration()),
         dataPlaneAppRetryRule);
 
     addStep(

--- a/service/src/main/java/bio/terra/pipelines/stairway/imputation/SubmitCromwellRunSetStep.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/imputation/SubmitCromwellRunSetStep.java
@@ -89,6 +89,7 @@ public class SubmitCromwellRunSetStep implements Step {
                         pipelineName, wdlMethodName, flightContext.getFlightId(), description))
             .runSetName("%s - flightId %s".formatted(wdlMethodName, flightContext.getFlightId()))
             .methodVersionId(methodVersionId)
+            .callCachingEnabled(false)
             // OUTPUTS
             // imputed_multi_sample_vcf output
             .addWorkflowOutputDefinitionsItem(

--- a/service/src/main/java/bio/terra/pipelines/stairway/imputation/SubmitCromwellRunSetStep.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/imputation/SubmitCromwellRunSetStep.java
@@ -127,30 +127,6 @@ public class SubmitCromwellRunSetStep implements Step {
                         new OutputDestinationRecordUpdate()
                             .recordAttribute("chunks_info")
                             .type(OutputDestination.TypeEnum.RECORD_UPDATE)))
-            // failed_chunks output
-            .addWorkflowOutputDefinitionsItem(
-                new WorkflowOutputDefinition()
-                    .outputName("%s.failed_chunks".formatted(wdlMethodName))
-                    .outputType(
-                        new ParameterTypeDefinitionPrimitive()
-                            .primitiveType(PrimitiveParameterValueType.FILE)
-                            .type(ParameterTypeDefinition.TypeEnum.PRIMITIVE))
-                    .destination(
-                        new OutputDestinationRecordUpdate()
-                            .recordAttribute("failed_chunks")
-                            .type(OutputDestination.TypeEnum.RECORD_UPDATE)))
-            // n_failed_chunks output
-            .addWorkflowOutputDefinitionsItem(
-                new WorkflowOutputDefinition()
-                    .outputName("%s.n_failed_chunks".formatted(wdlMethodName))
-                    .outputType(
-                        new ParameterTypeDefinitionPrimitive()
-                            .primitiveType(PrimitiveParameterValueType.INT)
-                            .type(ParameterTypeDefinition.TypeEnum.PRIMITIVE))
-                    .destination(
-                        new OutputDestinationRecordUpdate()
-                            .recordAttribute("n_failed_chunks")
-                            .type(OutputDestination.TypeEnum.RECORD_UPDATE)))
             // define the WDS record to link to for inputs and outputs
             .wdsRecords(
                 new WdsRecordSet()

--- a/service/src/main/java/bio/terra/pipelines/stairway/imputation/SubmitCromwellRunSetStep.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/imputation/SubmitCromwellRunSetStep.java
@@ -2,6 +2,7 @@ package bio.terra.pipelines.stairway.imputation;
 
 import bio.terra.cbas.model.*;
 import bio.terra.common.exception.InternalServerErrorException;
+import bio.terra.pipelines.app.configuration.external.CbasConfiguration;
 import bio.terra.pipelines.common.utils.FlightUtils;
 import bio.terra.pipelines.common.utils.PipelinesEnum;
 import bio.terra.pipelines.db.entities.PipelineInputDefinition;
@@ -29,12 +30,17 @@ public class SubmitCromwellRunSetStep implements Step {
   private final CbasService cbasService;
   private final SamService samService;
   private final PipelinesService pipelinesService;
+  private final CbasConfiguration cbasConfiguration;
 
   public SubmitCromwellRunSetStep(
-      CbasService cbasService, SamService samService, PipelinesService pipelinesService) {
+      CbasService cbasService,
+      SamService samService,
+      PipelinesService pipelinesService,
+      CbasConfiguration cbasConfiguration) {
     this.cbasService = cbasService;
     this.samService = samService;
     this.pipelinesService = pipelinesService;
+    this.cbasConfiguration = cbasConfiguration;
   }
 
   @Override
@@ -89,7 +95,7 @@ public class SubmitCromwellRunSetStep implements Step {
                         pipelineName, wdlMethodName, flightContext.getFlightId(), description))
             .runSetName("%s - flightId %s".formatted(wdlMethodName, flightContext.getFlightId()))
             .methodVersionId(methodVersionId)
-            .callCachingEnabled(false)
+            .callCachingEnabled(cbasConfiguration.getCallCache())
             // OUTPUTS
             // imputed_multi_sample_vcf output
             .addWorkflowOutputDefinitionsItem(

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -167,4 +167,5 @@ wds:
   debugApiLogging: false
 
 cbas:
+  callCache: false
   debugApiLogging: false

--- a/service/src/test/java/bio/terra/pipelines/common/utils/FlightBeanBagTest.java
+++ b/service/src/test/java/bio/terra/pipelines/common/utils/FlightBeanBagTest.java
@@ -2,6 +2,7 @@ package bio.terra.pipelines.common.utils;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import bio.terra.pipelines.app.configuration.external.CbasConfiguration;
 import bio.terra.pipelines.app.configuration.internal.ImputationConfiguration;
 import bio.terra.pipelines.dependencies.cbas.CbasService;
 import bio.terra.pipelines.dependencies.leonardo.LeonardoService;
@@ -22,6 +23,7 @@ class FlightBeanBagTest extends BaseEmbeddedDbTest {
   @Autowired private WdsService wdsService;
   @Autowired private CbasService cbasService;
   @Autowired private ImputationConfiguration imputationConfiguration;
+  @Autowired private CbasConfiguration cbasConfiguration;
 
   @Test
   void testFlightBeanBag() {
@@ -33,7 +35,8 @@ class FlightBeanBagTest extends BaseEmbeddedDbTest {
             leonardoService,
             wdsService,
             cbasService,
-            imputationConfiguration);
+            imputationConfiguration,
+            cbasConfiguration);
     assertEquals(pipelinesService, flightBeanBag.getPipelinesService());
     assertEquals(pipelineRunsService, flightBeanBag.getPipelineRunsService());
     assertEquals(samService, flightBeanBag.getSamService());
@@ -41,5 +44,6 @@ class FlightBeanBagTest extends BaseEmbeddedDbTest {
     assertEquals(wdsService, flightBeanBag.getWdsService());
     assertEquals(cbasService, flightBeanBag.getCbasService());
     assertEquals(imputationConfiguration, flightBeanBag.getImputationConfiguration());
+    assertEquals(cbasConfiguration, flightBeanBag.getCbasConfiguration());
   }
 }

--- a/service/src/test/java/bio/terra/pipelines/configuration/external/CbasConfigurationTest.java
+++ b/service/src/test/java/bio/terra/pipelines/configuration/external/CbasConfigurationTest.java
@@ -1,5 +1,6 @@
 package bio.terra.pipelines.configuration.external;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import bio.terra.pipelines.app.configuration.external.CbasConfiguration;
@@ -13,6 +14,9 @@ class CbasConfigurationTest extends BaseEmbeddedDbTest {
 
   @Test
   void verifyCbasServerConfig() {
-    assertTrue(cbasConfiguration.debugApiLogging());
+    assertFalse(cbasConfiguration.getCallCache());
+
+    // debugApiLogging is true in application-test.yml
+    assertTrue(cbasConfiguration.getDebugApiLogging());
   }
 }

--- a/service/src/test/java/bio/terra/pipelines/dependencies/cbas/CbasServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/dependencies/cbas/CbasServiceTest.java
@@ -29,7 +29,7 @@ class CbasServiceTest {
   final RetryConfiguration retryConfig = new RetryConfiguration();
   RetryTemplate template = retryConfig.listenerResetRetryTemplate();
 
-  final CbasConfiguration cbasConfiguration = new CbasConfiguration(false);
+  final CbasConfiguration cbasConfiguration = new CbasConfiguration();
 
   final Answer<Object> errorAnswer =
       invocation -> {

--- a/service/src/test/java/bio/terra/pipelines/stairway/imputation/SubmitCromwellRunSetStepTest.java
+++ b/service/src/test/java/bio/terra/pipelines/stairway/imputation/SubmitCromwellRunSetStepTest.java
@@ -11,6 +11,7 @@ import bio.terra.cbas.model.MethodVersionDetails;
 import bio.terra.cbas.model.RunSetRequest;
 import bio.terra.cbas.model.RunSetStateResponse;
 import bio.terra.cbas.model.WorkflowInputDefinition;
+import bio.terra.pipelines.app.configuration.external.CbasConfiguration;
 import bio.terra.pipelines.dependencies.cbas.CbasService;
 import bio.terra.pipelines.dependencies.sam.SamService;
 import bio.terra.pipelines.service.PipelinesService;
@@ -26,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
 
 class SubmitCromwellRunSetStepTest extends BaseEmbeddedDbTest {
   @Mock private CbasService cbasService;
@@ -33,6 +35,7 @@ class SubmitCromwellRunSetStepTest extends BaseEmbeddedDbTest {
   @Mock private SamService samService;
   @Mock private PipelinesService pipelinesService;
   @Mock private FlightContext flightContext;
+  @Autowired private CbasConfiguration cbasConfiguration;
 
   private final UUID testJobId = TestUtils.TEST_NEW_UUID;
 
@@ -84,7 +87,7 @@ class SubmitCromwellRunSetStepTest extends BaseEmbeddedDbTest {
 
     // do the step
     SubmitCromwellRunSetStep submitCromwellRunSetStep =
-        new SubmitCromwellRunSetStep(cbasService, samService, pipelinesService);
+        new SubmitCromwellRunSetStep(cbasService, samService, pipelinesService, cbasConfiguration);
     StepResult result = submitCromwellRunSetStep.doStep(flightContext);
 
     // extract the captured RunSetRequest
@@ -118,7 +121,7 @@ class SubmitCromwellRunSetStepTest extends BaseEmbeddedDbTest {
 
     // do the step
     SubmitCromwellRunSetStep submitCromwellRunSetStep =
-        new SubmitCromwellRunSetStep(cbasService, samService, pipelinesService);
+        new SubmitCromwellRunSetStep(cbasService, samService, pipelinesService, cbasConfiguration);
     StepResult result = submitCromwellRunSetStep.doStep(flightContext);
 
     // make sure the step was a fatal faiilure
@@ -128,7 +131,7 @@ class SubmitCromwellRunSetStepTest extends BaseEmbeddedDbTest {
   @Test
   void undoStepSuccess() throws InterruptedException {
     SubmitCromwellRunSetStep submitCromwellRunSetStep =
-        new SubmitCromwellRunSetStep(cbasService, samService, pipelinesService);
+        new SubmitCromwellRunSetStep(cbasService, samService, pipelinesService, cbasConfiguration);
     StepResult result = submitCromwellRunSetStep.undoStep(flightContext);
 
     assertEquals(StepStatus.STEP_RESULT_SUCCESS, result.getStepStatus());

--- a/service/src/test/java/bio/terra/pipelines/stairway/imputation/SubmitCromwellRunSetStepTest.java
+++ b/service/src/test/java/bio/terra/pipelines/stairway/imputation/SubmitCromwellRunSetStepTest.java
@@ -1,6 +1,7 @@
 package bio.terra.pipelines.stairway.imputation;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -88,6 +89,7 @@ class SubmitCromwellRunSetStepTest extends BaseEmbeddedDbTest {
 
     // extract the captured RunSetRequest
     RunSetRequest capturedRunSetRequest = runSetRequestCaptor.getValue();
+    assertFalse(capturedRunSetRequest.isCallCachingEnabled());
     List<WorkflowInputDefinition> capturedWorkflowInputDefinitions =
         capturedRunSetRequest.getWorkflowInputDefinitions();
     // make sure the workflow definitions are populated

--- a/service/src/test/resources/application-test.yml
+++ b/service/src/test/resources/application-test.yml
@@ -46,6 +46,7 @@ wds:
   debugApiLogging: true
 
 cbas:
+  callCache: false
   debugApiLogging: true
 
 pipelines:


### PR DESCRIPTION
### Description 

We don't want to use call caching for now. 
Also, remove outputs that are no longer in the real WDL now that https://github.com/broadinstitute/warp/pull/1288 is merged.

Tested locally:
<img width="1615" alt="image" src="https://github.com/DataBiosphere/terra-scientific-pipelines-service/assets/20929778/ece7434f-ffa4-4918-8b93-30e371b9f89f">


### Jira Ticket
