### PR TITLE
TSPS-257, TSPS-243 add Stairway retries to WDS and CBAS steps, also Don't alert Sentry for NoResourceFoundException

### DIFF
--- a/service/src/main/java/bio/terra/pipelines/stairway/imputation/AddWdsRowStep.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/imputation/AddWdsRowStep.java
@@ -5,6 +5,7 @@ import bio.terra.pipelines.common.utils.PipelinesEnum;
 import bio.terra.pipelines.dependencies.sam.SamService;
 import bio.terra.pipelines.dependencies.stairway.JobMapKeys;
 import bio.terra.pipelines.dependencies.wds.WdsService;
+import bio.terra.pipelines.dependencies.wds.WdsServiceException;
 import bio.terra.stairway.*;
 import bio.terra.stairway.exception.RetryException;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -78,7 +79,7 @@ public class AddWdsRowStep implements Step {
           pipelineName.getValue(),
           flightContext.getFlightId(), // this is the primary key for WDS
           "flight_id");
-    } catch (Exception e) {
+    } catch (WdsServiceException e) {
       throw new RetryException("Error creating record in WDS. Will retry.", e);
     }
 

--- a/service/src/main/java/bio/terra/pipelines/stairway/imputation/AddWdsRowStep.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/imputation/AddWdsRowStep.java
@@ -5,7 +5,6 @@ import bio.terra.pipelines.common.utils.PipelinesEnum;
 import bio.terra.pipelines.dependencies.sam.SamService;
 import bio.terra.pipelines.dependencies.stairway.JobMapKeys;
 import bio.terra.pipelines.dependencies.wds.WdsService;
-import bio.terra.pipelines.dependencies.wds.WdsServiceException;
 import bio.terra.stairway.*;
 import bio.terra.stairway.exception.RetryException;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -79,9 +78,8 @@ public class AddWdsRowStep implements Step {
           pipelineName.getValue(),
           flightContext.getFlightId(), // this is the primary key for WDS
           "flight_id");
-    } catch (WdsServiceException e) {
-      // not sure what exception makes sense to throw here
-      return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, e);
+    } catch (Exception e) {
+      throw new RetryException("Error creating record in WDS. Will retry.", e);
     }
 
     return StepResult.getStepResultSuccess();

--- a/service/src/main/java/bio/terra/pipelines/stairway/imputation/AddWdsRowStep.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/imputation/AddWdsRowStep.java
@@ -35,7 +35,7 @@ public class AddWdsRowStep implements Step {
   @SuppressWarnings(
       "java:S2259") // suppress warning for possible NPE when calling pipelineName.getValue(),
   //  since we do validate that pipelineName is not null in `validateRequiredEntries`
-  public StepResult doStep(FlightContext flightContext) throws InterruptedException {
+  public StepResult doStep(FlightContext flightContext) {
     // validate and extract parameters from input map
     FlightMap inputParameters = flightContext.getInputParameters();
     FlightUtils.validateRequiredEntries(
@@ -85,7 +85,7 @@ public class AddWdsRowStep implements Step {
   }
 
   @Override
-  public StepResult undoStep(FlightContext context) throws InterruptedException {
+  public StepResult undoStep(FlightContext context) {
     // nothing to undo; we don't need to remove the row that was added to WDS as it could be useful
     // for debugging. this may change in the future
     return StepResult.getStepResultSuccess();

--- a/service/src/main/java/bio/terra/pipelines/stairway/imputation/AddWdsRowStep.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/imputation/AddWdsRowStep.java
@@ -7,7 +7,6 @@ import bio.terra.pipelines.dependencies.stairway.JobMapKeys;
 import bio.terra.pipelines.dependencies.wds.WdsService;
 import bio.terra.pipelines.dependencies.wds.WdsServiceException;
 import bio.terra.stairway.*;
-import bio.terra.stairway.exception.RetryException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import java.util.Map;
 import org.databiosphere.workspacedata.model.RecordAttributes;
@@ -36,8 +35,7 @@ public class AddWdsRowStep implements Step {
   @SuppressWarnings(
       "java:S2259") // suppress warning for possible NPE when calling pipelineName.getValue(),
   //  since we do validate that pipelineName is not null in `validateRequiredEntries`
-  public StepResult doStep(FlightContext flightContext)
-      throws InterruptedException, RetryException {
+  public StepResult doStep(FlightContext flightContext) throws InterruptedException {
     // validate and extract parameters from input map
     FlightMap inputParameters = flightContext.getInputParameters();
     FlightUtils.validateRequiredEntries(
@@ -80,7 +78,7 @@ public class AddWdsRowStep implements Step {
           flightContext.getFlightId(), // this is the primary key for WDS
           "flight_id");
     } catch (WdsServiceException e) {
-      throw new RetryException("Error creating record in WDS. Will retry.", e);
+      return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, e);
     }
 
     return StepResult.getStepResultSuccess();

--- a/service/src/main/java/bio/terra/pipelines/stairway/imputation/CheckCbasHealthStep.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/imputation/CheckCbasHealthStep.java
@@ -22,7 +22,7 @@ public class CheckCbasHealthStep implements Step {
   }
 
   @Override
-  public StepResult doStep(FlightContext flightContext) throws InterruptedException {
+  public StepResult doStep(FlightContext flightContext) {
     // validate and extract parameters from working map
     FlightMap workingMap = flightContext.getWorkingMap();
     FlightUtils.validateRequiredEntries(workingMap, RunImputationJobFlightMapKeys.CBAS_URI);
@@ -41,7 +41,7 @@ public class CheckCbasHealthStep implements Step {
   }
 
   @Override
-  public StepResult undoStep(FlightContext context) throws InterruptedException {
+  public StepResult undoStep(FlightContext context) {
     // nothing to undo; this step just queries for the health of a cbas app
     return StepResult.getStepResultSuccess();
   }

--- a/service/src/main/java/bio/terra/pipelines/stairway/imputation/CheckCbasHealthStep.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/imputation/CheckCbasHealthStep.java
@@ -6,7 +6,6 @@ import bio.terra.pipelines.dependencies.cbas.CbasServiceApiException;
 import bio.terra.pipelines.dependencies.common.HealthCheckWorkspaceApps;
 import bio.terra.pipelines.dependencies.sam.SamService;
 import bio.terra.stairway.*;
-import bio.terra.stairway.exception.RetryException;
 
 /**
  * This step checks the health of the cbas app associated with the passed in workspace id
@@ -23,20 +22,15 @@ public class CheckCbasHealthStep implements Step {
   }
 
   @Override
-  public StepResult doStep(FlightContext flightContext)
-      throws InterruptedException {
+  public StepResult doStep(FlightContext flightContext) throws InterruptedException {
     // validate and extract parameters from working map
     FlightMap workingMap = flightContext.getWorkingMap();
     FlightUtils.validateRequiredEntries(workingMap, RunImputationJobFlightMapKeys.CBAS_URI);
 
     String cbasUri = workingMap.get(RunImputationJobFlightMapKeys.CBAS_URI, String.class);
 
-    HealthCheckWorkspaceApps.Result healthResult;
-    try {
-      healthResult = cbasService.checkHealth(cbasUri, samService.getTspsServiceAccountToken());
-    } catch (CbasServiceApiException e) {
-      return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, e);
-    }
+    HealthCheckWorkspaceApps.Result healthResult =
+        cbasService.checkHealth(cbasUri, samService.getTspsServiceAccountToken());
 
     if (!healthResult.isOk()) {
       return new StepResult(

--- a/service/src/main/java/bio/terra/pipelines/stairway/imputation/CheckLeonardoHealthStep.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/imputation/CheckLeonardoHealthStep.java
@@ -28,7 +28,7 @@ public class CheckLeonardoHealthStep implements Step {
   }
 
   @Override
-  public StepResult undoStep(FlightContext flightContext) throws InterruptedException {
+  public StepResult undoStep(FlightContext flightContext) {
     // this is the first step in RunImputationJobFlight.
     // increment pipeline failed counter if undoStep is called which means the flight failed
     // to be moved to a StairwayHook in https://broadworkbench.atlassian.net/browse/TSPS-181

--- a/service/src/main/java/bio/terra/pipelines/stairway/imputation/CheckLeonardoHealthStep.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/imputation/CheckLeonardoHealthStep.java
@@ -7,7 +7,6 @@ import bio.terra.pipelines.dependencies.leonardo.LeonardoService;
 import bio.terra.pipelines.dependencies.leonardo.LeonardoServiceApiException;
 import bio.terra.pipelines.dependencies.stairway.JobMapKeys;
 import bio.terra.stairway.*;
-import bio.terra.stairway.exception.RetryException;
 
 /** This step queries the Leonardo status endpoint to check if it is healthy */
 public class CheckLeonardoHealthStep implements Step {
@@ -18,7 +17,7 @@ public class CheckLeonardoHealthStep implements Step {
   }
 
   @Override
-  public StepResult doStep(FlightContext flightContext) throws RetryException {
+  public StepResult doStep(FlightContext flightContext) {
     HealthCheck.Result healthResult = leonardoService.checkHealth();
     if (!healthResult.isOk()) {
       return new StepResult(

--- a/service/src/main/java/bio/terra/pipelines/stairway/imputation/CheckWdsHealthStep.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/imputation/CheckWdsHealthStep.java
@@ -23,7 +23,7 @@ public class CheckWdsHealthStep implements Step {
   }
 
   @Override
-  public StepResult doStep(FlightContext flightContext) throws InterruptedException {
+  public StepResult doStep(FlightContext flightContext) {
     // validate and extract parameters from working map
     FlightMap workingMap = flightContext.getWorkingMap();
     FlightUtils.validateRequiredEntries(workingMap, RunImputationJobFlightMapKeys.WDS_URI);
@@ -41,7 +41,7 @@ public class CheckWdsHealthStep implements Step {
   }
 
   @Override
-  public StepResult undoStep(FlightContext context) throws InterruptedException {
+  public StepResult undoStep(FlightContext context) {
     // nothing to undo; this step just checks that wds is healthy
     return StepResult.getStepResultSuccess();
   }

--- a/service/src/main/java/bio/terra/pipelines/stairway/imputation/CheckWdsHealthStep.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/imputation/CheckWdsHealthStep.java
@@ -6,7 +6,6 @@ import bio.terra.pipelines.dependencies.sam.SamService;
 import bio.terra.pipelines.dependencies.wds.WdsService;
 import bio.terra.pipelines.dependencies.wds.WdsServiceApiException;
 import bio.terra.stairway.*;
-import bio.terra.stairway.exception.RetryException;
 import org.databiosphere.workspacedata.client.ApiException;
 
 /**
@@ -24,8 +23,7 @@ public class CheckWdsHealthStep implements Step {
   }
 
   @Override
-  public StepResult doStep(FlightContext flightContext)
-      throws InterruptedException, RetryException {
+  public StepResult doStep(FlightContext flightContext) throws InterruptedException {
     // validate and extract parameters from working map
     FlightMap workingMap = flightContext.getWorkingMap();
     FlightUtils.validateRequiredEntries(workingMap, RunImputationJobFlightMapKeys.WDS_URI);

--- a/service/src/main/java/bio/terra/pipelines/stairway/imputation/CompletePipelineRunStep.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/imputation/CompletePipelineRunStep.java
@@ -9,7 +9,6 @@ import bio.terra.stairway.StepResult;
 import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.retry.RetryException;
 
 public class CompletePipelineRunStep implements Step {
   private final PipelineRunsService pipelineRunsService;
@@ -20,8 +19,7 @@ public class CompletePipelineRunStep implements Step {
   }
 
   @Override
-  public StepResult doStep(FlightContext flightContext)
-      throws InterruptedException, RetryException {
+  public StepResult doStep(FlightContext flightContext) {
     // validate and extract parameters from input map
     var inputParameters = flightContext.getInputParameters();
     FlightUtils.validateRequiredEntries(inputParameters, JobMapKeys.USER_ID.getKeyName());
@@ -37,7 +35,7 @@ public class CompletePipelineRunStep implements Step {
   }
 
   @Override
-  public StepResult undoStep(FlightContext flightContext) throws InterruptedException {
+  public StepResult undoStep(FlightContext flightContext) {
     // nothing to undo
     return StepResult.getStepResultSuccess();
   }

--- a/service/src/main/java/bio/terra/pipelines/stairway/imputation/GetAppUrisStep.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/imputation/GetAppUrisStep.java
@@ -4,7 +4,6 @@ import bio.terra.pipelines.common.utils.FlightUtils;
 import bio.terra.pipelines.dependencies.leonardo.LeonardoService;
 import bio.terra.pipelines.dependencies.sam.SamService;
 import bio.terra.stairway.*;
-import bio.terra.stairway.exception.RetryException;
 import java.util.List;
 import org.broadinstitute.dsde.workbench.client.leonardo.model.ListAppResponse;
 
@@ -26,7 +25,7 @@ public class GetAppUrisStep implements Step {
   }
 
   @Override
-  public StepResult doStep(FlightContext flightContext) throws RetryException {
+  public StepResult doStep(FlightContext flightContext) {
     // validate and extract parameters from input map
     FlightMap inputParameters = flightContext.getInputParameters();
     FlightUtils.validateRequiredEntries(

--- a/service/src/main/java/bio/terra/pipelines/stairway/imputation/GetAppUrisStep.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/imputation/GetAppUrisStep.java
@@ -49,7 +49,7 @@ public class GetAppUrisStep implements Step {
   }
 
   @Override
-  public StepResult undoStep(FlightContext context) throws InterruptedException {
+  public StepResult undoStep(FlightContext context) {
     // nothing to undo; this step only puts stuff in the working map for downstream steps
     return StepResult.getStepResultSuccess();
   }

--- a/service/src/main/java/bio/terra/pipelines/stairway/imputation/PollCromwellRunSetStatusStep.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/imputation/PollCromwellRunSetStatusStep.java
@@ -8,7 +8,6 @@ import bio.terra.pipelines.dependencies.cbas.CbasService;
 import bio.terra.pipelines.dependencies.cbas.CbasServiceApiException;
 import bio.terra.pipelines.dependencies.sam.SamService;
 import bio.terra.stairway.*;
-import bio.terra.stairway.exception.RetryException;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
@@ -40,8 +39,7 @@ public class PollCromwellRunSetStatusStep implements Step {
   }
 
   @Override
-  public StepResult doStep(FlightContext flightContext)
-      throws InterruptedException, RetryException {
+  public StepResult doStep(FlightContext flightContext) throws InterruptedException {
     // validate and extract parameters from working map
     FlightMap workingMap = flightContext.getWorkingMap();
     FlightUtils.validateRequiredEntries(
@@ -70,7 +68,7 @@ public class PollCromwellRunSetStatusStep implements Step {
         }
       }
     } catch (CbasServiceApiException e) {
-      throw new RetryException("Error polling for run set status. Will retry.", e);
+      return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, e);
     }
 
     // if there are any non-successful logs, fatally fail the step

--- a/service/src/main/java/bio/terra/pipelines/stairway/imputation/PollCromwellRunSetStatusStep.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/imputation/PollCromwellRunSetStatusStep.java
@@ -5,6 +5,7 @@ import bio.terra.common.exception.InternalServerErrorException;
 import bio.terra.pipelines.app.configuration.internal.ImputationConfiguration;
 import bio.terra.pipelines.common.utils.FlightUtils;
 import bio.terra.pipelines.dependencies.cbas.CbasService;
+import bio.terra.pipelines.dependencies.cbas.CbasServiceApiException;
 import bio.terra.pipelines.dependencies.sam.SamService;
 import bio.terra.stairway.*;
 import bio.terra.stairway.exception.RetryException;
@@ -68,7 +69,7 @@ public class PollCromwellRunSetStatusStep implements Step {
               imputationConfiguration.getCromwellSubmissionPollingIntervalInSeconds());
         }
       }
-    } catch (Exception e) {
+    } catch (CbasServiceApiException e) {
       throw new RetryException("Error polling for run set status. Will retry.", e);
     }
 

--- a/service/src/main/java/bio/terra/pipelines/stairway/imputation/PollCromwellRunSetStatusStep.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/imputation/PollCromwellRunSetStatusStep.java
@@ -86,7 +86,7 @@ public class PollCromwellRunSetStatusStep implements Step {
   }
 
   @Override
-  public StepResult undoStep(FlightContext context) throws InterruptedException {
+  public StepResult undoStep(FlightContext context) {
     // nothing to undo; there's nothing to undo about polling a cromwell run set
     return StepResult.getStepResultSuccess();
   }

--- a/service/src/main/java/bio/terra/pipelines/stairway/imputation/PollCromwellRunSetStatusStep.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/imputation/PollCromwellRunSetStatusStep.java
@@ -54,17 +54,22 @@ public class PollCromwellRunSetStatusStep implements Step {
     // poll until all runs are in a finalized state
     RunLogResponse runLogResponse = null;
     boolean stillRunning = true;
-    while (stillRunning) {
-      runLogResponse =
-          cbasService.getRunsForRunSet(cbasUri, samService.getTspsServiceAccountToken(), runSetId);
-      stillRunning = CbasService.containsRunningRunLog(runLogResponse);
-      if (stillRunning) {
-        logger.info(
-            "Polling Started, sleeping for {} seconds",
-            imputationConfiguration.getCromwellSubmissionPollingIntervalInSeconds());
-        TimeUnit.SECONDS.sleep(
-            imputationConfiguration.getCromwellSubmissionPollingIntervalInSeconds());
+    try {
+      while (stillRunning) {
+        runLogResponse =
+            cbasService.getRunsForRunSet(
+                cbasUri, samService.getTspsServiceAccountToken(), runSetId);
+        stillRunning = CbasService.containsRunningRunLog(runLogResponse);
+        if (stillRunning) {
+          logger.info(
+              "Polling Started, sleeping for {} seconds",
+              imputationConfiguration.getCromwellSubmissionPollingIntervalInSeconds());
+          TimeUnit.SECONDS.sleep(
+              imputationConfiguration.getCromwellSubmissionPollingIntervalInSeconds());
+        }
       }
+    } catch (Exception e) {
+      throw new RetryException("Error polling for run set status. Will retry.", e);
     }
 
     // if there are any non-successful logs, fatally fail the step

--- a/service/src/main/java/bio/terra/pipelines/stairway/imputation/PrepareImputationInputsStep.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/imputation/PrepareImputationInputsStep.java
@@ -15,7 +15,6 @@ import java.util.List;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.retry.RetryException;
 
 /**
  * This step prepares the inputs for the imputation pipeline by assembling the (already validated)
@@ -37,8 +36,7 @@ public class PrepareImputationInputsStep implements Step {
   }
 
   @Override
-  public StepResult doStep(FlightContext flightContext)
-      throws InterruptedException, RetryException {
+  public StepResult doStep(FlightContext flightContext) {
     // validate and extract parameters from input map
     var inputParameters = flightContext.getInputParameters();
     var workingMap = flightContext.getWorkingMap();
@@ -92,7 +90,7 @@ public class PrepareImputationInputsStep implements Step {
   }
 
   @Override
-  public StepResult undoStep(FlightContext flightContext) throws InterruptedException {
+  public StepResult undoStep(FlightContext flightContext) {
     // no undo for this step
     return StepResult.getStepResultSuccess();
   }

--- a/service/src/main/java/bio/terra/pipelines/stairway/imputation/RunImputationJobFlight.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/imputation/RunImputationJobFlight.java
@@ -15,7 +15,7 @@ public class RunImputationJobFlight extends Flight {
 
   /** Retry for interacting with data plane apps */
   private final RetryRule dataPlaneAppRetryRule =
-      new RetryRuleFixedInterval(/*intervalSeconds= */ 20, /* maxCount= */ 5);
+      new RetryRuleFixedInterval(/*intervalSeconds= */ 20, /* maxCount= */ 2);
 
   // addStep is protected in Flight, so make an override that is public
   @Override

--- a/service/src/main/java/bio/terra/pipelines/stairway/imputation/SubmitCromwellRunSetStep.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/imputation/SubmitCromwellRunSetStep.java
@@ -148,8 +148,13 @@ public class SubmitCromwellRunSetStep implements Step {
     }
 
     // launch the submission
-    RunSetStateResponse runSetStateResponse =
-        cbasService.createRunSet(cbasUri, samService.getTspsServiceAccountToken(), runSetRequest);
+    RunSetStateResponse runSetStateResponse;
+    try {
+      runSetStateResponse =
+          cbasService.createRunSet(cbasUri, samService.getTspsServiceAccountToken(), runSetRequest);
+    } catch (Exception e) {
+      throw new RetryException("Failed to submit run set. Will retry.", e);
+    }
     workingMap.put(RunImputationJobFlightMapKeys.RUN_SET_ID, runSetStateResponse.getRunSetId());
     return StepResult.getStepResultSuccess();
   }

--- a/service/src/main/java/bio/terra/pipelines/stairway/imputation/SubmitCromwellRunSetStep.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/imputation/SubmitCromwellRunSetStep.java
@@ -12,7 +12,6 @@ import bio.terra.pipelines.dependencies.sam.SamService;
 import bio.terra.pipelines.dependencies.stairway.JobMapKeys;
 import bio.terra.pipelines.service.PipelinesService;
 import bio.terra.stairway.*;
-import bio.terra.stairway.exception.RetryException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import java.util.List;
 import java.util.UUID;
@@ -48,8 +47,7 @@ public class SubmitCromwellRunSetStep implements Step {
   @SuppressWarnings(
       "java:S2259") // suppress warning for possible NPE when calling pipelineName.getValue(),
   //  since we do validate that pipelineName is not null in `validateRequiredEntries`
-  public StepResult doStep(FlightContext flightContext)
-      throws InterruptedException, RetryException {
+  public StepResult doStep(FlightContext flightContext) throws InterruptedException {
     // validate and extract parameters from input map
     FlightMap inputParameters = flightContext.getInputParameters();
     FlightUtils.validateRequiredEntries(
@@ -154,7 +152,7 @@ public class SubmitCromwellRunSetStep implements Step {
       runSetStateResponse =
           cbasService.createRunSet(cbasUri, samService.getTspsServiceAccountToken(), runSetRequest);
     } catch (CbasServiceApiException e) {
-      throw new RetryException("Failed to submit run set. Will retry.", e);
+      return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, e);
     }
     workingMap.put(RunImputationJobFlightMapKeys.RUN_SET_ID, runSetStateResponse.getRunSetId());
     return StepResult.getStepResultSuccess();

--- a/service/src/main/java/bio/terra/pipelines/stairway/imputation/SubmitCromwellRunSetStep.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/imputation/SubmitCromwellRunSetStep.java
@@ -7,6 +7,7 @@ import bio.terra.pipelines.common.utils.FlightUtils;
 import bio.terra.pipelines.common.utils.PipelinesEnum;
 import bio.terra.pipelines.db.entities.PipelineInputDefinition;
 import bio.terra.pipelines.dependencies.cbas.CbasService;
+import bio.terra.pipelines.dependencies.cbas.CbasServiceApiException;
 import bio.terra.pipelines.dependencies.sam.SamService;
 import bio.terra.pipelines.dependencies.stairway.JobMapKeys;
 import bio.terra.pipelines.service.PipelinesService;
@@ -152,7 +153,7 @@ public class SubmitCromwellRunSetStep implements Step {
     try {
       runSetStateResponse =
           cbasService.createRunSet(cbasUri, samService.getTspsServiceAccountToken(), runSetRequest);
-    } catch (Exception e) {
+    } catch (CbasServiceApiException e) {
       throw new RetryException("Failed to submit run set. Will retry.", e);
     }
     workingMap.put(RunImputationJobFlightMapKeys.RUN_SET_ID, runSetStateResponse.getRunSetId());

--- a/service/src/main/java/bio/terra/pipelines/stairway/imputation/SubmitCromwellRunSetStep.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/imputation/SubmitCromwellRunSetStep.java
@@ -47,7 +47,7 @@ public class SubmitCromwellRunSetStep implements Step {
   @SuppressWarnings(
       "java:S2259") // suppress warning for possible NPE when calling pipelineName.getValue(),
   //  since we do validate that pipelineName is not null in `validateRequiredEntries`
-  public StepResult doStep(FlightContext flightContext) throws InterruptedException {
+  public StepResult doStep(FlightContext flightContext) {
     // validate and extract parameters from input map
     FlightMap inputParameters = flightContext.getInputParameters();
     FlightUtils.validateRequiredEntries(
@@ -159,7 +159,7 @@ public class SubmitCromwellRunSetStep implements Step {
   }
 
   @Override
-  public StepResult undoStep(FlightContext context) throws InterruptedException {
+  public StepResult undoStep(FlightContext context) {
     // nothing to undo; there's nothing to undo about submitting a run set
     return StepResult.getStepResultSuccess();
   }

--- a/service/src/test/java/bio/terra/pipelines/stairway/imputation/AddWdsRowsStepTest.java
+++ b/service/src/test/java/bio/terra/pipelines/stairway/imputation/AddWdsRowsStepTest.java
@@ -1,7 +1,6 @@
 package bio.terra.pipelines.stairway.imputation;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -14,7 +13,6 @@ import bio.terra.pipelines.testutils.BaseEmbeddedDbTest;
 import bio.terra.pipelines.testutils.StairwayTestUtils;
 import bio.terra.pipelines.testutils.TestUtils;
 import bio.terra.stairway.*;
-import bio.terra.stairway.exception.RetryException;
 import java.util.UUID;
 import org.databiosphere.workspacedata.client.ApiException;
 import org.databiosphere.workspacedata.model.RecordAttributes;
@@ -86,9 +84,11 @@ class AddWdsRowsStepTest extends BaseEmbeddedDbTest {
 
     StairwayTestUtils.constructCreateJobInputs(flightContext.getInputParameters());
 
-    // do the step, expect a RetryException
+    // do the step, expect a Retry status
     AddWdsRowStep addWdsRowStep = new AddWdsRowStep(wdsService, samService);
-    assertThrows(RetryException.class, () -> addWdsRowStep.doStep(flightContext));
+    StepResult result = addWdsRowStep.doStep(flightContext);
+
+    assertEquals(StepStatus.STEP_RESULT_FAILURE_RETRY, result.getStepStatus());
   }
 
   @Test

--- a/service/src/test/java/bio/terra/pipelines/stairway/imputation/AddWdsRowsStepTest.java
+++ b/service/src/test/java/bio/terra/pipelines/stairway/imputation/AddWdsRowsStepTest.java
@@ -77,10 +77,8 @@ class AddWdsRowsStepTest extends BaseEmbeddedDbTest {
     when(flightContext.getFlightId()).thenReturn(testJobId.toString());
     WdsServiceApiException thrownException =
         new WdsServiceApiException(new ApiException("this is the error message"));
-    // first call throws an exception, second call is successful
     when(wdsService.createOrReplaceRecord(any(), any(), any(), any(), any(), any(), any()))
-        .thenThrow(thrownException)
-        .thenReturn(null);
+        .thenThrow(thrownException);
 
     StairwayTestUtils.constructCreateJobInputs(flightContext.getInputParameters());
 

--- a/service/src/test/java/bio/terra/pipelines/stairway/imputation/AddWdsRowsStepTest.java
+++ b/service/src/test/java/bio/terra/pipelines/stairway/imputation/AddWdsRowsStepTest.java
@@ -45,7 +45,7 @@ class AddWdsRowsStepTest extends BaseEmbeddedDbTest {
   }
 
   @Test
-  void doStepSuccess() throws WdsServiceException, InterruptedException {
+  void doStepSuccess() throws WdsServiceException {
     // setup
     when(flightContext.getFlightId()).thenReturn(testJobId.toString());
 
@@ -72,7 +72,7 @@ class AddWdsRowsStepTest extends BaseEmbeddedDbTest {
   }
 
   @Test
-  void doStepWdsExceptionRetry() throws WdsServiceException, InterruptedException {
+  void doStepWdsExceptionRetry() throws WdsServiceException {
     // setup
     when(flightContext.getFlightId()).thenReturn(testJobId.toString());
     WdsServiceApiException thrownException =
@@ -90,7 +90,7 @@ class AddWdsRowsStepTest extends BaseEmbeddedDbTest {
   }
 
   @Test
-  void undoStepSuccess() throws InterruptedException {
+  void undoStepSuccess() {
     AddWdsRowStep addWdsRowStep = new AddWdsRowStep(wdsService, samService);
     StepResult result = addWdsRowStep.undoStep(flightContext);
 

--- a/service/src/test/java/bio/terra/pipelines/stairway/imputation/CheckCbasHealthStepTest.java
+++ b/service/src/test/java/bio/terra/pipelines/stairway/imputation/CheckCbasHealthStepTest.java
@@ -33,7 +33,7 @@ class CheckCbasHealthStepTest extends BaseEmbeddedDbTest {
   }
 
   @Test
-  void doStepSuccess() throws InterruptedException {
+  void doStepSuccess() {
     // setup
     when(cbasService.checkHealth(any(), any()))
         .thenReturn(new HealthCheckWorkspaceApps.Result(true, "cbas is healthy"));
@@ -47,7 +47,7 @@ class CheckCbasHealthStepTest extends BaseEmbeddedDbTest {
   }
 
   @Test
-  void doStepUnhealthyCbas() throws InterruptedException {
+  void doStepUnhealthyCbas() {
     // setup
     when(cbasService.checkHealth(any(), any()))
         .thenReturn(new HealthCheckWorkspaceApps.Result(false, "wds is not healthy"));
@@ -63,7 +63,7 @@ class CheckCbasHealthStepTest extends BaseEmbeddedDbTest {
   }
 
   @Test
-  void undoStepSuccess() throws InterruptedException {
+  void undoStepSuccess() {
     CheckCbasHealthStep checkCbasHealthStep = new CheckCbasHealthStep(cbasService, samService);
     StepResult result = checkCbasHealthStep.undoStep(flightContext);
 

--- a/service/src/test/java/bio/terra/pipelines/stairway/imputation/CheckCbasHealthStepTest.java
+++ b/service/src/test/java/bio/terra/pipelines/stairway/imputation/CheckCbasHealthStepTest.java
@@ -5,7 +5,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import bio.terra.pipelines.dependencies.cbas.CbasService;
-import bio.terra.pipelines.dependencies.cbas.CbasServiceApiException;
 import bio.terra.pipelines.dependencies.common.HealthCheckWorkspaceApps;
 import bio.terra.pipelines.dependencies.sam.SamService;
 import bio.terra.pipelines.testutils.BaseEmbeddedDbTest;
@@ -14,7 +13,6 @@ import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
-import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -46,20 +44,6 @@ class CheckCbasHealthStepTest extends BaseEmbeddedDbTest {
 
     // make sure the step was a success
     assertEquals(StepStatus.STEP_RESULT_SUCCESS, result.getStepStatus());
-  }
-
-  @Test
-  void doStepCbasServiceApiException() throws InterruptedException {
-    // setup
-    when(cbasService.checkHealth(any(), any()))
-        .thenThrow(new CbasServiceApiException("cbas service api exception"));
-
-    // do the step
-    CheckCbasHealthStep checkCbasHealthStep = new CheckCbasHealthStep(cbasService, samService);
-    StepResult result = checkCbasHealthStep.doStep(flightContext);
-
-    // make sure the appropriate step status was returned
-    assertEquals(StepStatus.STEP_RESULT_FAILURE_RETRY, result.getStepStatus());
   }
 
   @Test

--- a/service/src/test/java/bio/terra/pipelines/stairway/imputation/CheckWdsHealthStepTest.java
+++ b/service/src/test/java/bio/terra/pipelines/stairway/imputation/CheckWdsHealthStepTest.java
@@ -33,7 +33,7 @@ class CheckWdsHealthStepTest extends BaseEmbeddedDbTest {
   }
 
   @Test
-  void doStepSuccess() throws InterruptedException {
+  void doStepSuccess() {
     // setup
     when(wdsService.checkHealth(any(), any()))
         .thenReturn(new HealthCheckWorkspaceApps.Result(true, "wds is healthy"));
@@ -49,7 +49,7 @@ class CheckWdsHealthStepTest extends BaseEmbeddedDbTest {
   }
 
   @Test
-  void doStepUnhealthyWds() throws InterruptedException {
+  void doStepUnhealthyWds() {
     // setup
     when(wdsService.checkHealth(any(), any()))
         .thenReturn(new HealthCheckWorkspaceApps.Result(false, "wds is not healthy"));
@@ -65,7 +65,7 @@ class CheckWdsHealthStepTest extends BaseEmbeddedDbTest {
   }
 
   @Test
-  void undoStepSuccess() throws InterruptedException {
+  void undoStepSuccess() {
     CheckWdsHealthStep checkWdsHealthStep = new CheckWdsHealthStep(wdsService, samService);
     StepResult result = checkWdsHealthStep.undoStep(flightContext);
 

--- a/service/src/test/java/bio/terra/pipelines/stairway/imputation/CompletePipelineRunStepTest.java
+++ b/service/src/test/java/bio/terra/pipelines/stairway/imputation/CompletePipelineRunStepTest.java
@@ -39,7 +39,7 @@ class CompletePipelineRunStepTest extends BaseEmbeddedDbTest {
   }
 
   @Test
-  void doStepSuccess() throws InterruptedException {
+  void doStepSuccess() {
     // setup
     when(flightContext.getFlightId()).thenReturn(testJobId.toString());
 
@@ -77,7 +77,7 @@ class CompletePipelineRunStepTest extends BaseEmbeddedDbTest {
   // do we want to test how the step handles a failure in the service call?
 
   @Test
-  void undoStepSuccess() throws InterruptedException {
+  void undoStepSuccess() {
     var writeJobStep = new CompletePipelineRunStep(pipelineRunsService);
     var result = writeJobStep.undoStep(flightContext);
 

--- a/service/src/test/java/bio/terra/pipelines/stairway/imputation/GetAppUrisStepTest.java
+++ b/service/src/test/java/bio/terra/pipelines/stairway/imputation/GetAppUrisStepTest.java
@@ -55,7 +55,7 @@ class GetAppUrisStepTest extends BaseEmbeddedDbTest {
   }
 
   @Test
-  void undoStepSuccess() throws InterruptedException {
+  void undoStepSuccess() {
     GetAppUrisStep getAppUrisStep = new GetAppUrisStep(leonardoService, samService);
     StepResult result = getAppUrisStep.undoStep(flightContext);
 

--- a/service/src/test/java/bio/terra/pipelines/stairway/imputation/PollCromwellRunSetStatusStepTest.java
+++ b/service/src/test/java/bio/terra/pipelines/stairway/imputation/PollCromwellRunSetStatusStepTest.java
@@ -125,7 +125,7 @@ class PollCromwellRunSetStatusStepTest extends BaseEmbeddedDbTest {
   }
 
   @Test
-  void undoStepSuccess() throws InterruptedException {
+  void undoStepSuccess() {
     PollCromwellRunSetStatusStep pollCromwellRunSetStatusStep =
         new PollCromwellRunSetStatusStep(cbasService, samService, imputationConfiguration);
     StepResult result = pollCromwellRunSetStatusStep.undoStep(flightContext);

--- a/service/src/test/java/bio/terra/pipelines/stairway/imputation/PrepareImputationInputsStepTest.java
+++ b/service/src/test/java/bio/terra/pipelines/stairway/imputation/PrepareImputationInputsStepTest.java
@@ -60,7 +60,7 @@ class PrepareImputationInputsStepTest extends BaseEmbeddedDbTest {
   }
 
   @Test
-  void doStepSuccess() throws InterruptedException {
+  void doStepSuccess() {
     // setup
     when(flightContext.getFlightId()).thenReturn(testJobId.toString());
 
@@ -127,10 +127,8 @@ class PrepareImputationInputsStepTest extends BaseEmbeddedDbTest {
     }
   }
 
-  // do we want to test how the step handles a failure in the service call?
-
   @Test
-  void undoStepSuccess() throws InterruptedException {
+  void undoStepSuccess() {
     StairwayTestUtils.constructCreateJobInputs(flightContext.getInputParameters());
     var prepareImputationInputsStep = new PrepareImputationInputsStep(pipelinesService);
     var result = prepareImputationInputsStep.undoStep(flightContext);

--- a/service/src/test/java/bio/terra/pipelines/stairway/imputation/SubmitCromwellRunSetStepTest.java
+++ b/service/src/test/java/bio/terra/pipelines/stairway/imputation/SubmitCromwellRunSetStepTest.java
@@ -53,7 +53,7 @@ class SubmitCromwellRunSetStepTest extends BaseEmbeddedDbTest {
   }
 
   @Test
-  void doStepSuccess() throws InterruptedException {
+  void doStepSuccess() {
     // setup
     StairwayTestUtils.constructCreateJobInputs(flightContext.getInputParameters());
     UUID runSetId = UUID.randomUUID();
@@ -107,7 +107,7 @@ class SubmitCromwellRunSetStepTest extends BaseEmbeddedDbTest {
   }
 
   @Test
-  void doStepNoMatchingMethod() throws InterruptedException {
+  void doStepNoMatchingMethod() {
     // setup
     StairwayTestUtils.constructCreateJobInputs(flightContext.getInputParameters());
     MethodListResponse getAllMethodsResponse =
@@ -130,7 +130,7 @@ class SubmitCromwellRunSetStepTest extends BaseEmbeddedDbTest {
   }
 
   @Test
-  void doStepCbasErrorRetry() throws InterruptedException {
+  void doStepCbasErrorRetry() {
     // setup
     StairwayTestUtils.constructCreateJobInputs(flightContext.getInputParameters());
     MethodListResponse getAllMethodsResponse =
@@ -157,7 +157,7 @@ class SubmitCromwellRunSetStepTest extends BaseEmbeddedDbTest {
   }
 
   @Test
-  void undoStepSuccess() throws InterruptedException {
+  void undoStepSuccess() {
     SubmitCromwellRunSetStep submitCromwellRunSetStep =
         new SubmitCromwellRunSetStep(cbasService, samService, pipelinesService, cbasConfiguration);
     StepResult result = submitCromwellRunSetStep.undoStep(flightContext);


### PR DESCRIPTION
### Description 

- TSPS-257: add Stairway retry logic to steps that call CBAS or WDS
- TSPS-243: filter out NoResourceFoundExceptions from Sentry (still will be logged as errors, plus a warning that it wasn't sent to sentry)

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-257
https://broadworkbench.atlassian.net/browse/TSPS-243