### PR TITLE
TSPS-268 unify PipelineVariableTypesEnum and associated changes

### DIFF
--- a/service/src/main/java/bio/terra/pipelines/common/utils/PipelineVariableTypesEnum.java
+++ b/service/src/main/java/bio/terra/pipelines/common/utils/PipelineVariableTypesEnum.java
@@ -120,8 +120,8 @@ public enum PipelineVariableTypesEnum {
               .map(itemValue -> FILE.cast(fieldName, itemValue, new TypeReference<String>() {}))
               .toList();
       // if any item in the cast list is null, it means the item was not cast-able as a
-      // string, and we consider the entire list to be un-cast-able as a VCF array.
-      // Note that the VCF cast does not include a '.vcf.gz' suffix check.
+      // string, and we consider the entire list to be un-cast-able as a FILE array.
+      // Note that the FILE cast does not include a suffix check.
       if (stringList.contains(null)) {
         return null;
       }

--- a/service/src/main/java/bio/terra/pipelines/db/entities/BasePipelineVariableDefinition.java
+++ b/service/src/main/java/bio/terra/pipelines/db/entities/BasePipelineVariableDefinition.java
@@ -1,5 +1,6 @@
 package bio.terra.pipelines.db.entities;
 
+import bio.terra.pipelines.common.utils.PipelineVariableTypesEnum;
 import jakarta.persistence.Column;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -28,9 +29,14 @@ public abstract class BasePipelineVariableDefinition {
   @Column(name = "wdl_variable_name", nullable = false)
   private String wdlVariableName;
 
-  protected BasePipelineVariableDefinition(Long pipelineId, String name, String wdlVariableName) {
+  @Column(name = "type", nullable = false)
+  private PipelineVariableTypesEnum type;
+
+  protected BasePipelineVariableDefinition(
+      Long pipelineId, String name, String wdlVariableName, PipelineVariableTypesEnum type) {
     this.pipelineId = pipelineId;
     this.name = name;
     this.wdlVariableName = wdlVariableName;
+    this.type = type;
   }
 }

--- a/service/src/main/java/bio/terra/pipelines/db/entities/PipelineInputDefinition.java
+++ b/service/src/main/java/bio/terra/pipelines/db/entities/PipelineInputDefinition.java
@@ -13,6 +13,7 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 @Table(name = "pipeline_input_definitions")
+@SuppressWarnings("java:S107") // Disable "Methods should not have too many parameters"
 public class PipelineInputDefinition extends BasePipelineVariableDefinition {
   @Column(name = "is_required", nullable = false)
   private Boolean isRequired;

--- a/service/src/main/java/bio/terra/pipelines/db/entities/PipelineInputDefinition.java
+++ b/service/src/main/java/bio/terra/pipelines/db/entities/PipelineInputDefinition.java
@@ -1,6 +1,6 @@
 package bio.terra.pipelines.db.entities;
 
-import bio.terra.pipelines.common.utils.PipelineInputTypesEnum;
+import bio.terra.pipelines.common.utils.PipelineVariableTypesEnum;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
@@ -23,19 +23,20 @@ public class PipelineInputDefinition extends BasePipelineVariableDefinition {
   @Column(name = "default_value")
   private String defaultValue; // must be a String representation of the value
 
-  @Column(name = "type", nullable = false)
-  private PipelineInputTypesEnum type;
+  @Column(name = "file_suffix")
+  private String fileSuffix;
 
   public PipelineInputDefinition(
       Long pipelineId,
       String name,
       String wdlVariableName,
-      PipelineInputTypesEnum type,
+      PipelineVariableTypesEnum type,
+      String fileSuffix,
       Boolean isRequired,
       Boolean userProvided,
       String defaultValue) {
-    super(pipelineId, name, wdlVariableName);
-    this.type = type;
+    super(pipelineId, name, wdlVariableName, type);
+    this.fileSuffix = fileSuffix;
     this.isRequired = isRequired;
     this.userProvided = userProvided;
     this.defaultValue = defaultValue;

--- a/service/src/main/java/bio/terra/pipelines/db/entities/PipelineOutputDefinition.java
+++ b/service/src/main/java/bio/terra/pipelines/db/entities/PipelineOutputDefinition.java
@@ -1,6 +1,6 @@
 package bio.terra.pipelines.db.entities;
 
-import jakarta.persistence.Column;
+import bio.terra.pipelines.common.utils.PipelineVariableTypesEnum;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
 import lombok.Getter;
@@ -14,12 +14,8 @@ import lombok.Setter;
 @Table(name = "pipeline_output_definitions")
 public class PipelineOutputDefinition extends BasePipelineVariableDefinition {
 
-  @Column(name = "type", nullable = false)
-  private String type;
-
   public PipelineOutputDefinition(
-      Long pipelineId, String name, String wdlVariableName, String type) {
-    super(pipelineId, name, wdlVariableName);
-    this.type = type;
+      Long pipelineId, String name, String wdlVariableName, PipelineVariableTypesEnum type) {
+    super(pipelineId, name, wdlVariableName, type);
   }
 }

--- a/service/src/main/java/bio/terra/pipelines/db/entities/converters/PipelineInputTypeConverter.java
+++ b/service/src/main/java/bio/terra/pipelines/db/entities/converters/PipelineInputTypeConverter.java
@@ -1,20 +1,20 @@
 package bio.terra.pipelines.db.entities.converters;
 
-import bio.terra.pipelines.common.utils.PipelineInputTypesEnum;
+import bio.terra.pipelines.common.utils.PipelineVariableTypesEnum;
 import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.Converter;
 
 // inspired by https://www.baeldung.com/jpa-persisting-enums-in-jpa
 @Converter(autoApply = true)
 public class PipelineInputTypeConverter
-    implements AttributeConverter<PipelineInputTypesEnum, String> {
+    implements AttributeConverter<PipelineVariableTypesEnum, String> {
   @Override
-  public String convertToDatabaseColumn(PipelineInputTypesEnum pipelineInputTypeEnum) {
+  public String convertToDatabaseColumn(PipelineVariableTypesEnum pipelineInputTypeEnum) {
     return pipelineInputTypeEnum.toString();
   }
 
   @Override
-  public PipelineInputTypesEnum convertToEntityAttribute(String pipelineInputTypeString) {
-    return PipelineInputTypesEnum.valueOf(pipelineInputTypeString);
+  public PipelineVariableTypesEnum convertToEntityAttribute(String pipelineInputTypeString) {
+    return PipelineVariableTypesEnum.valueOf(pipelineInputTypeString);
   }
 }

--- a/service/src/main/java/bio/terra/pipelines/db/entities/converters/PipelineVariableTypeConverter.java
+++ b/service/src/main/java/bio/terra/pipelines/db/entities/converters/PipelineVariableTypeConverter.java
@@ -6,15 +6,15 @@ import jakarta.persistence.Converter;
 
 // inspired by https://www.baeldung.com/jpa-persisting-enums-in-jpa
 @Converter(autoApply = true)
-public class PipelineInputTypeConverter
+public class PipelineVariableTypeConverter
     implements AttributeConverter<PipelineVariableTypesEnum, String> {
   @Override
-  public String convertToDatabaseColumn(PipelineVariableTypesEnum pipelineInputTypeEnum) {
-    return pipelineInputTypeEnum.toString();
+  public String convertToDatabaseColumn(PipelineVariableTypesEnum pipelineVariableTypeEnum) {
+    return pipelineVariableTypeEnum.toString();
   }
 
   @Override
-  public PipelineVariableTypesEnum convertToEntityAttribute(String pipelineInputTypeString) {
-    return PipelineVariableTypesEnum.valueOf(pipelineInputTypeString);
+  public PipelineVariableTypesEnum convertToEntityAttribute(String pipelineVariableTypeString) {
+    return PipelineVariableTypesEnum.valueOf(pipelineVariableTypeString);
   }
 }

--- a/service/src/main/java/bio/terra/pipelines/service/PipelinesService.java
+++ b/service/src/main/java/bio/terra/pipelines/service/PipelinesService.java
@@ -140,8 +140,7 @@ public class PipelinesService {
           if (inputsMap.containsKey(inputName)) {
             PipelineVariableTypesEnum inputType = inputDefinition.getType();
             String validationErrorMessage =
-                inputType.validate(
-                    inputName, inputDefinition.getFileSuffix(), inputsMap.get(inputName));
+                inputType.validate(inputDefinition, inputsMap.get(inputName));
             if (validationErrorMessage != null) {
               errorMessages.add(validationErrorMessage);
             }

--- a/service/src/main/java/bio/terra/pipelines/stairway/imputation/PrepareImputationInputsStep.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/imputation/PrepareImputationInputsStep.java
@@ -4,7 +4,7 @@ import static bio.terra.pipelines.common.utils.FileUtils.constructDestinationBlo
 
 import bio.terra.pipelines.app.configuration.internal.ImputationConfiguration;
 import bio.terra.pipelines.common.utils.FlightUtils;
-import bio.terra.pipelines.common.utils.PipelineInputTypesEnum;
+import bio.terra.pipelines.common.utils.PipelineVariableTypesEnum;
 import bio.terra.pipelines.common.utils.PipelinesEnum;
 import bio.terra.pipelines.db.entities.PipelineInputDefinition;
 import bio.terra.pipelines.dependencies.stairway.JobMapKeys;
@@ -88,7 +88,7 @@ public class PrepareImputationInputsStep implements Step {
     for (PipelineInputDefinition inputDefinition : allInputDefinitions) {
       String keyName = inputDefinition.getName();
       String wdlVariableName = inputDefinition.getWdlVariableName();
-      PipelineInputTypesEnum pipelineInputType = inputDefinition.getType();
+      PipelineVariableTypesEnum pipelineInputType = inputDefinition.getType();
       String rawValue;
       if (keysToPrependWithStorageURL.contains(keyName)) {
         rawValue = storageWorkspaceStorageContainerUrl + allPipelineInputs.get(keyName).toString();

--- a/service/src/main/resources/db/changelog.xml
+++ b/service/src/main/resources/db/changelog.xml
@@ -19,6 +19,7 @@
   <include file="changesets/20240621_add_wdl_variable_name_to_input_definitions.yaml" relativeToChangelogFile="true"/>
   <include file="changesets/20240625_add_workspace_storage_url_to_pipeline_runs.yaml" relativeToChangelogFile="true"/>
   <include file="changesets/20240711_add_pipeline_output_definitions.yaml" relativeToChangelogFile="true"/>
+  <include file="changesets/20240716_add_file_suffix_to_input_defs_and_update_FILE_types.yaml" relativeToChangelogFile="true"/>
 
   <include file="changesets/20240412-testdata.yaml" relativeToChangelogFile="true"/>
 

--- a/service/src/main/resources/db/changesets/20240716_add_file_suffix_to_input_defs_and_update_FILE_types.yaml
+++ b/service/src/main/resources/db/changesets/20240716_add_file_suffix_to_input_defs_and_update_FILE_types.yaml
@@ -1,0 +1,31 @@
+# Add file_suffix field to pipeline_input_definitions and update all VCF types to FILE
+databaseChangeLog:
+  - changeSet:
+      id: Add file_suffix field to pipeline_input_definitions and update all VCF types to FILE
+      author: mma
+      changes:
+        # add file_suffix column to pipeline_input_definitions
+        - addColumn:
+            tableName: pipeline_input_definitions
+            columns:
+              - column:
+                  name: file_suffix
+                  type: text
+                  constraints:
+                    nullable: true
+        # set all VCF types' file_suffix to ".vcf.gz"
+        - update:
+            tableName: pipeline_input_definitions
+            where: type='VCF'
+            columns:
+              - column:
+                  name: file_suffix
+                  value: ".vcf.gz"
+        # update all VCF types to FILE
+        - update:
+            tableName: pipeline_input_definitions
+            where: type='VCF'
+            columns:
+              - column:
+                  name: type
+                  value: FILE

--- a/service/src/test/java/bio/terra/pipelines/common/utils/PipelineVariableTypesEnumTest.java
+++ b/service/src/test/java/bio/terra/pipelines/common/utils/PipelineVariableTypesEnumTest.java
@@ -1,10 +1,10 @@
 package bio.terra.pipelines.common.utils;
 
-import static bio.terra.pipelines.common.utils.PipelineInputTypesEnum.INTEGER;
-import static bio.terra.pipelines.common.utils.PipelineInputTypesEnum.STRING;
-import static bio.terra.pipelines.common.utils.PipelineInputTypesEnum.STRING_ARRAY;
-import static bio.terra.pipelines.common.utils.PipelineInputTypesEnum.VCF;
-import static bio.terra.pipelines.common.utils.PipelineInputTypesEnum.VCF_ARRAY;
+import static bio.terra.pipelines.common.utils.PipelineVariableTypesEnum.FILE;
+import static bio.terra.pipelines.common.utils.PipelineVariableTypesEnum.FILE_ARRAY;
+import static bio.terra.pipelines.common.utils.PipelineVariableTypesEnum.INTEGER;
+import static bio.terra.pipelines.common.utils.PipelineVariableTypesEnum.STRING;
+import static bio.terra.pipelines.common.utils.PipelineVariableTypesEnum.STRING_ARRAY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
@@ -19,139 +19,181 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-class PipelineInputTypesEnumTest extends BaseTest {
+class PipelineVariableTypesEnumTest extends BaseTest {
 
   private static Stream<Arguments> castValidations() {
     // error messages
     String stringTypeErrorMessage = "input_name must be a string";
     String integerTypeErrorMessage = "input_name must be an integer";
-    String vcfTypeErrorMessage = "input_name must be a path to a VCF file ending in .vcf.gz";
+    String vcfTypeErrorMessage = "input_name must be a path to a file ending in .vcf.gz";
     String stringArrayTypeErrorMessage = "input_name must be an array of strings";
     String vcfArrayTypeErrorMessage =
-        "input_name must be an array of paths to VCF files ending in .vcf.gz";
+        "input_name must be an array of paths to files ending in .vcf.gz";
     String notNullOrEmptyErrorMessage = "input_name must not be null or empty";
 
     return Stream.of(
-        // arguments: type enum, input value to cast, expected cast value if successful, error
+        // arguments: type enum, file suffix, input value to cast, expected cast value if
+        // successful, error
         // message if fails
 
         // INTEGER
-        arguments(INTEGER, 123, 123, null),
-        arguments(INTEGER, "123", 123, null),
-        arguments(INTEGER, "I am a string", null, integerTypeErrorMessage),
-        arguments(INTEGER, 2.3, null, integerTypeErrorMessage),
-        arguments(INTEGER, "2.3", null, integerTypeErrorMessage),
-        arguments(INTEGER, null, null, integerTypeErrorMessage),
-        arguments(INTEGER, "", null, integerTypeErrorMessage),
+        arguments(INTEGER, null, 123, 123, null),
+        arguments(INTEGER, null, "123", 123, null),
+        arguments(INTEGER, null, "I am a string", null, integerTypeErrorMessage),
+        arguments(INTEGER, null, 2.3, null, integerTypeErrorMessage),
+        arguments(INTEGER, null, "2.3", null, integerTypeErrorMessage),
+        arguments(INTEGER, null, null, null, integerTypeErrorMessage),
+        arguments(INTEGER, null, "", null, integerTypeErrorMessage),
 
         // STRING
-        arguments(STRING, "I am a string", "I am a string", null),
-        arguments(STRING, "\"I am a string\"", "\"I am a string\"", null),
-        arguments(STRING, "$tr1nG.w1th.0th3r.ch@r@ct3r$", "$tr1nG.w1th.0th3r.ch@r@ct3r$", null),
+        arguments(STRING, null, "I am a string", "I am a string", null),
+        arguments(STRING, null, "\"I am a string\"", "\"I am a string\"", null),
+        arguments(
+            STRING, null, "$tr1nG.w1th.0th3r.ch@r@ct3r$", "$tr1nG.w1th.0th3r.ch@r@ct3r$", null),
         arguments(
             STRING,
+            null,
             "    I am a string with extra whitespace    ",
             "I am a string with extra whitespace",
             null),
         arguments(
-            STRING, List.of("this", "is", "not", "a", "string"), null, stringTypeErrorMessage),
-        arguments(STRING, 123, null, stringTypeErrorMessage),
-        arguments(STRING, null, null, stringTypeErrorMessage),
-        arguments(STRING, "", null, stringTypeErrorMessage),
+            STRING,
+            null,
+            List.of("this", "is", "not", "a", "string"),
+            null,
+            stringTypeErrorMessage),
+        arguments(STRING, null, 123, null, stringTypeErrorMessage),
+        arguments(STRING, null, null, null, stringTypeErrorMessage),
+        arguments(STRING, null, "", null, stringTypeErrorMessage),
 
-        // VCF
-        arguments(VCF, "path/to/file.vcf.gz", "path/to/file.vcf.gz", null),
-        arguments(VCF, "   path/to/file.vcf.gz   ", "path/to/file.vcf.gz", null),
+        // FILE
+        arguments(FILE, ".vcf.gz", "path/to/file.vcf.gz", "path/to/file.vcf.gz", null),
+        arguments(FILE, ".vcf.gz", "   path/to/file.vcf.gz   ", "path/to/file.vcf.gz", null),
         arguments(
-            VCF,
+            FILE,
+            ".vcf.gz",
             "path/to/file.vcf",
             "path/to/file.vcf",
             vcfTypeErrorMessage), // cast is successful but validation fails
-        arguments(VCF, 3, null, vcfTypeErrorMessage),
-        arguments(VCF, null, null, vcfTypeErrorMessage),
-        arguments(VCF, "", null, vcfTypeErrorMessage),
+        arguments(FILE, ".vcf.gz", 3, null, vcfTypeErrorMessage),
+        arguments(FILE, ".vcf.gz", null, null, vcfTypeErrorMessage),
+        arguments(FILE, ".vcf.gz", "", null, vcfTypeErrorMessage),
+        arguments(
+            FILE,
+            ".bed",
+            "path/to/not/a/bed/file",
+            "path/to/not/a/bed/file",
+            "input_name must be a path to a file ending in .bed"), // cast is successful but
+        // validation fails
 
         // STRING_ARRAY
         arguments(
             STRING_ARRAY,
+            null,
             List.of("this", "is", "a", "list", "of", "strings"),
             List.of("this", "is", "a", "list", "of", "strings"),
             null),
-        arguments(STRING_ARRAY, List.of("singleton list"), List.of("singleton list"), null),
+        arguments(STRING_ARRAY, null, List.of("singleton list"), List.of("singleton list"), null),
         arguments(
             STRING_ARRAY,
+            null,
             List.of(
                 "this ", " is", " a ", "  list", "of  ", "  strings  ", "with extra whitespace"),
             List.of("this", "is", "a", "list", "of", "strings", "with extra whitespace"),
             null),
         arguments(
             STRING_ARRAY,
+            null,
             "[\"this\", \"is\", \"a\", \"stringy\", \"list\",  \"of\", \"strings\"]",
             List.of("this", "is", "a", "stringy", "list", "of", "strings"),
             null),
         arguments(
             STRING_ARRAY,
+            null,
             "[\" stringy \", \" and\",  \"whitespace \"]",
             List.of("stringy", "and", "whitespace"),
             null),
-        arguments(STRING_ARRAY, "I am not an array", null, stringArrayTypeErrorMessage),
-        arguments(STRING_ARRAY, Arrays.asList("string", 2, 3), null, stringArrayTypeErrorMessage),
-        arguments(STRING_ARRAY, Arrays.asList(1, 2, 3), null, stringArrayTypeErrorMessage),
-        arguments(STRING_ARRAY, null, null, notNullOrEmptyErrorMessage),
+        arguments(STRING_ARRAY, null, "I am not an array", null, stringArrayTypeErrorMessage),
+        arguments(
+            STRING_ARRAY, null, Arrays.asList("string", 2, 3), null, stringArrayTypeErrorMessage),
+        arguments(STRING_ARRAY, null, Arrays.asList(1, 2, 3), null, stringArrayTypeErrorMessage),
+        arguments(STRING_ARRAY, null, null, null, notNullOrEmptyErrorMessage),
         arguments(
             STRING_ARRAY,
+            null,
             Collections.emptyList(),
             Collections.emptyList(), // cast is successful but validation fails
             notNullOrEmptyErrorMessage),
         arguments(
             STRING_ARRAY,
+            null,
             Arrays.asList("", "array with empty string"),
             null,
             stringArrayTypeErrorMessage),
         arguments(
             STRING_ARRAY,
+            null,
             Arrays.asList(null, "array with null"),
             null,
             stringArrayTypeErrorMessage),
 
-        // VCF_ARRAY
+        // FILE_ARRAY
         arguments(
-            VCF_ARRAY,
+            FILE_ARRAY,
+            ".vcf.gz",
             List.of("path/to/file.vcf.gz", "path/to/file2.vcf.gz"),
             List.of("path/to/file.vcf.gz", "path/to/file2.vcf.gz"),
             null),
         arguments(
-            VCF_ARRAY,
+            FILE_ARRAY,
+            ".vcf.gz",
             List.of("  path/to/file/with/extra/whitespace.vcf.gz  "),
             List.of("path/to/file/with/extra/whitespace.vcf.gz"),
             null),
         arguments(
-            VCF_ARRAY,
+            FILE_ARRAY,
+            ".vcf.gz",
             "[\"path/to/file1.vcf.gz\", \"path/to/file2.vcf.gz\"]",
             List.of("path/to/file1.vcf.gz", "path/to/file2.vcf.gz"),
             null),
         arguments(
-            VCF_ARRAY,
+            FILE_ARRAY,
+            ".vcf.gz",
             "[\" path/to/file1.vcf.gz \", \"path/to/file2.vcf.gz \"]",
             List.of("path/to/file1.vcf.gz", "path/to/file2.vcf.gz"),
             null),
-        arguments(VCF_ARRAY, "this/is/not/an/array.vcf.gz", null, vcfArrayTypeErrorMessage),
         arguments(
-            VCF_ARRAY,
+            FILE_ARRAY, ".vcf.gz", "this/is/not/an/array.vcf.gz", null, vcfArrayTypeErrorMessage),
+        arguments(
+            FILE_ARRAY,
+            ".vcf.gz",
             Arrays.asList("path/to/file.vcf.gz", "just/a/string"),
             Arrays.asList(
                 "path/to/file.vcf.gz", "just/a/string"), // cast is successful but validation fails
             vcfArrayTypeErrorMessage),
         arguments(
-            VCF_ARRAY, Arrays.asList("path/to/file.vcf.gz", 2.5), null, vcfArrayTypeErrorMessage),
-        arguments(VCF_ARRAY, null, null, notNullOrEmptyErrorMessage),
+            FILE_ARRAY,
+            ".vcf.gz",
+            Arrays.asList("path/to/file.vcf.gz", 2.5),
+            null,
+            vcfArrayTypeErrorMessage),
         arguments(
-            VCF_ARRAY,
+            FILE_ARRAY,
+            ".bed",
+            Arrays.asList("file.vcf.gz", "file.bed"),
+            Arrays.asList("file.vcf.gz", "file.bed"),
+            "input_name must be an array of paths to files ending in .bed"), // cast is successful
+        // but validation fails
+        arguments(FILE_ARRAY, ".vcf.gz", null, null, notNullOrEmptyErrorMessage),
+        arguments(
+            FILE_ARRAY,
+            ".vcf.gz",
             Collections.emptyList(),
             Collections.emptyList(),
             notNullOrEmptyErrorMessage), // cast is successful but validation fails
         arguments(
-            VCF_ARRAY,
+            FILE_ARRAY,
+            ".vcf.gz",
             Arrays.asList(null, "list/with/null.vcf.gz"),
             null,
             vcfArrayTypeErrorMessage));
@@ -160,7 +202,10 @@ class PipelineInputTypesEnumTest extends BaseTest {
   @ParameterizedTest
   @MethodSource("castValidations")
   <T> void castInputValues(
-      PipelineInputTypesEnum inputType, Object inputValue, T expectedCastValue) {
+      PipelineVariableTypesEnum inputType,
+      String fileSuffix,
+      Object inputValue,
+      T expectedCastValue) {
     if (expectedCastValue != null) {
       if (expectedCastValue instanceof List expectedListCastValue) {
         List<String> listCastValue =
@@ -188,16 +233,17 @@ class PipelineInputTypesEnumTest extends BaseTest {
   @ParameterizedTest
   @MethodSource("castValidations")
   <T> void validateInputValues(
-      PipelineInputTypesEnum inputType,
+      PipelineVariableTypesEnum inputType,
+      String fileSuffix,
       Object inputValue,
       T expectedCastValue,
       String expectedErrorMessage) {
     if (expectedErrorMessage == null) {
       // should validate
-      assertNull(inputType.validate("input_name", inputValue));
+      assertNull(inputType.validate("input_name", fileSuffix, inputValue));
     } else {
       // should not validate
-      assertEquals(expectedErrorMessage, inputType.validate("input_name", inputValue));
+      assertEquals(expectedErrorMessage, inputType.validate("input_name", fileSuffix, inputValue));
     }
   }
 }

--- a/service/src/test/java/bio/terra/pipelines/common/utils/PipelineVariableTypesEnumTest.java
+++ b/service/src/test/java/bio/terra/pipelines/common/utils/PipelineVariableTypesEnumTest.java
@@ -48,6 +48,9 @@ class PipelineVariableTypesEnumTest extends BaseTest {
     PipelineInputDefinition fileBedInputDefinition =
         new PipelineInputDefinition(
             1L, commonInputName, "file_bed_input", FILE, ".bed", true, true, null);
+    PipelineInputDefinition fileNoSuffixInputDefinition =
+        new PipelineInputDefinition(
+            1L, commonInputName, "file_no_suffix_input", FILE, "", true, true, null);
     PipelineInputDefinition stringArrayInputDefinition =
         new PipelineInputDefinition(
             1L, commonInputName, "string_array_input", STRING_ARRAY, null, true, true, null);
@@ -60,8 +63,7 @@ class PipelineVariableTypesEnumTest extends BaseTest {
 
     return Stream.of(
         // arguments: input definition, input value to cast, expected cast value if
-        // successful, error
-        // message if fails
+        // successful, error message if fails
 
         // INTEGER
         arguments(integerInputDefinition, 123, 123, null),
@@ -110,8 +112,8 @@ class PipelineVariableTypesEnumTest extends BaseTest {
             "path/to/not/a/bed/file",
             "path/to/not/a/bed/file",
             "%s must be a path to a file ending in .bed"
-                .formatted(commonInputName)), // cast is successful but
-        // validation fails
+                .formatted(commonInputName)), // cast is successful but validation fails
+        arguments(fileNoSuffixInputDefinition, "path/to/file", "path/to/file", null),
 
         // STRING_ARRAY
         arguments(
@@ -205,8 +207,7 @@ class PipelineVariableTypesEnumTest extends BaseTest {
             Arrays.asList("file.vcf.gz", "file.bed"),
             Arrays.asList("file.vcf.gz", "file.bed"),
             "%s must be an array of paths to files ending in .bed"
-                .formatted(commonInputName)), // cast is successful
-        // but validation fails
+                .formatted(commonInputName)), // cast is successful but validation fails
         arguments(fileArrayVcfInputDefinition, null, null, notNullOrEmptyErrorMessage),
         arguments(
             fileArrayVcfInputDefinition,

--- a/service/src/test/java/bio/terra/pipelines/service/PipelinesServiceDatabaseTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/PipelinesServiceDatabaseTest.java
@@ -76,6 +76,17 @@ class PipelinesServiceDatabaseTest extends BaseEmbeddedDbTest {
   }
 
   @Test
+  void allFileInputsHaveDefinedFileSuffixes() {
+    // make sure each FILE input has a defined value for file_suffix
+    for (PipelineInputDefinition p : pipelineInputDefinitionsRepository.findAll()) {
+      if (p.getType() == PipelineVariableTypesEnum.FILE
+          || p.getType() == PipelineVariableTypesEnum.FILE_ARRAY) {
+        assertNotNull(p.getFileSuffix());
+      }
+    }
+  }
+
+  @Test
   void imputationPipelineHasCorrectInputs() {
     // make sure the imputation pipeline has the correct inputs
     Pipeline pipeline = pipelinesRepository.findByName(PipelinesEnum.IMPUTATION_BEAGLE);

--- a/service/src/test/java/bio/terra/pipelines/service/PipelinesServiceDatabaseTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/PipelinesServiceDatabaseTest.java
@@ -7,7 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import bio.terra.pipelines.common.utils.PipelineInputTypesEnum;
+import bio.terra.pipelines.common.utils.PipelineVariableTypesEnum;
 import bio.terra.pipelines.common.utils.PipelinesEnum;
 import bio.terra.pipelines.db.entities.Pipeline;
 import bio.terra.pipelines.db.entities.PipelineInputDefinition;
@@ -58,8 +58,8 @@ class PipelinesServiceDatabaseTest extends BaseEmbeddedDbTest {
     // make sure all pipeline input definition default values pass type validation and are cast-able
     for (PipelineInputDefinition p : pipelineInputDefinitionsRepository.findAll()) {
       if (p.getDefaultValue() != null) {
-        PipelineInputTypesEnum inputType = p.getType();
-        assertNull(inputType.validate(p.getName(), p.getDefaultValue()));
+        PipelineVariableTypesEnum inputType = p.getType();
+        assertNull(inputType.validate(p.getName(), p.getFileSuffix(), p.getDefaultValue()));
         assertNotNull(inputType.cast(p.getName(), p.getDefaultValue(), new TypeReference<>() {}));
       }
     }
@@ -152,7 +152,7 @@ class PipelinesServiceDatabaseTest extends BaseEmbeddedDbTest {
     newInput.setPipelineId(pipeline.getId());
     newInput.setName("multiSampleVcf");
     newInput.setWdlVariableName("multi_sample_vcf");
-    newInput.setType(PipelineInputTypesEnum.INTEGER);
+    newInput.setType(PipelineVariableTypesEnum.INTEGER);
     newInput.setIsRequired(false);
     newInput.setUserProvided(true);
     newInput.setDefaultValue("42");

--- a/service/src/test/java/bio/terra/pipelines/service/PipelinesServiceDatabaseTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/PipelinesServiceDatabaseTest.java
@@ -59,7 +59,7 @@ class PipelinesServiceDatabaseTest extends BaseEmbeddedDbTest {
     for (PipelineInputDefinition p : pipelineInputDefinitionsRepository.findAll()) {
       if (p.getDefaultValue() != null) {
         PipelineVariableTypesEnum inputType = p.getType();
-        assertNull(inputType.validate(p.getName(), p.getFileSuffix(), p.getDefaultValue()));
+        assertNull(inputType.validate(p, p.getDefaultValue()));
         assertNotNull(inputType.cast(p.getName(), p.getDefaultValue(), new TypeReference<>() {}));
       }
     }

--- a/service/src/test/java/bio/terra/pipelines/stairway/imputation/PrepareImputationInputsStepTest.java
+++ b/service/src/test/java/bio/terra/pipelines/stairway/imputation/PrepareImputationInputsStepTest.java
@@ -7,7 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 import bio.terra.pipelines.app.configuration.internal.ImputationConfiguration;
-import bio.terra.pipelines.common.utils.PipelineInputTypesEnum;
+import bio.terra.pipelines.common.utils.PipelineVariableTypesEnum;
 import bio.terra.pipelines.common.utils.PipelinesEnum;
 import bio.terra.pipelines.db.entities.Pipeline;
 import bio.terra.pipelines.db.entities.PipelineInputDefinition;
@@ -141,7 +141,7 @@ class PrepareImputationInputsStepTest extends BaseEmbeddedDbTest {
     // user-provided file inputs should contain the control workspace's storage url
     for (String wdlInputName :
         userProvidedPipelineInputDefinitions.stream()
-            .filter(input -> input.getType().equals(PipelineInputTypesEnum.VCF))
+            .filter(input -> input.getType().equals(PipelineVariableTypesEnum.FILE))
             .map(PipelineInputDefinition::getWdlVariableName)
             .collect(Collectors.toSet())) {
       assertTrue(

--- a/service/src/test/java/bio/terra/pipelines/testutils/TestUtils.java
+++ b/service/src/test/java/bio/terra/pipelines/testutils/TestUtils.java
@@ -1,6 +1,6 @@
 package bio.terra.pipelines.testutils;
 
-import bio.terra.pipelines.common.utils.PipelineInputTypesEnum;
+import bio.terra.pipelines.common.utils.PipelineVariableTypesEnum;
 import bio.terra.pipelines.common.utils.PipelinesEnum;
 import bio.terra.pipelines.db.entities.Pipeline;
 import bio.terra.pipelines.db.entities.PipelineInputDefinition;
@@ -53,7 +53,8 @@ public class TestUtils {
                   3L,
                   "testRequiredStringInput",
                   "test_required_string_input",
-                  PipelineInputTypesEnum.STRING,
+                  PipelineVariableTypesEnum.STRING,
+                  null,
                   true,
                   true,
                   null),
@@ -61,7 +62,8 @@ public class TestUtils {
                   3L,
                   "testOptionalStringInput",
                   "test_optional_string_input",
-                  PipelineInputTypesEnum.STRING,
+                  PipelineVariableTypesEnum.STRING,
+                  null,
                   false,
                   true,
                   "testDefaultValue"),
@@ -69,7 +71,8 @@ public class TestUtils {
                   3L,
                   "testRequiredIntInput",
                   "test_required_int_input",
-                  PipelineInputTypesEnum.INTEGER,
+                  PipelineVariableTypesEnum.INTEGER,
+                  null,
                   true,
                   true,
                   null),
@@ -77,7 +80,8 @@ public class TestUtils {
                   3L,
                   "testOptionalIntInput",
                   "test_optional_int_input",
-                  PipelineInputTypesEnum.INTEGER,
+                  PipelineVariableTypesEnum.INTEGER,
+                  null,
                   false,
                   true,
                   "42"),
@@ -85,7 +89,8 @@ public class TestUtils {
                   3L,
                   "testServiceProvidedInput",
                   "test_service_provided_input",
-                  PipelineInputTypesEnum.STRING,
+                  PipelineVariableTypesEnum.STRING,
+                  null,
                   true,
                   false,
                   "testServiceProvidedDefaultValue"),
@@ -93,14 +98,17 @@ public class TestUtils {
                   3L,
                   "testRequiredVcfInput",
                   "test_required_vcf_input",
-                  PipelineInputTypesEnum.VCF,
+                  PipelineVariableTypesEnum.FILE,
+                  ".vcf.gz",
                   true,
                   true,
                   null)));
 
   public static final List<PipelineOutputDefinition> TEST_PIPELINE_OUTPUTS_DEFINITION_LIST =
       new ArrayList<>(
-          List.of(new PipelineOutputDefinition(3L, "outputName", "output_name", "FILE")));
+          List.of(
+              new PipelineOutputDefinition(
+                  3L, "outputName", "output_name", PipelineVariableTypesEnum.FILE)));
 
   public static final Pipeline TEST_PIPELINE_1 =
       new Pipeline(


### PR DESCRIPTION
### Description 

- rename `PipelineInputTypesEnum` to `PipelineVariableTypesEnum`
- use it in base `BasePipelineVariableDefinition` class, so used for both `PipelineInputDefinition` and `PipelineOutputDefinition`
- add a `file_suffix` field to pipeline_input_definitions table in the db, change existing `VCF` types to `FILE`s and add `".vcf.gz"` as the file suffix for those
- refactor enum values `VCF` -> `FILE` and `VCF_ARRAY` -> `FILE_ARRAY`; update the `validate()` method to check the fileSuffix for FILE and FILE_ARRAY types

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-268