### PR TITLE
TSPS-262 paginated get pipeline runs endpoint

### DIFF
--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -193,6 +193,24 @@ paths:
         500:
           $ref: '#/components/responses/ServerError'
 
+  /api/pipelineruns/v1/pipelineruns:
+    get:
+      tags: [ pipelineRuns ]
+      summary: Return a list of all pipeline runs the caller has access to
+      operationId: getAllPipelineRuns
+      parameters:
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/PageToken'
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetPipelineRunsResponse'
+        500:
+          $ref: '#/components/responses/ServerError'
+
   # Stairway job related APIs go here
   /api/job/v1/jobs:
     get:
@@ -524,6 +542,17 @@ components:
         Pipeline:
           $ref: '#/components/schemas/Pipeline'
 
+    GetPipelineRunsResponse:
+      type: object
+      properties:
+        pageToken:
+          type: string
+        results:
+          description: List of retried pipeline runs
+          type: array
+          items:
+            $ref: '#/components/schemas/PipelineRun'
+
     Id:
       description: |
         Required unique identifier (UUID) for a job.
@@ -594,6 +623,31 @@ components:
     PipelineName:
       description: |
         The identifier string for the Pipeline.
+      type: string
+      format: string
+
+    PipelineRun:
+      description: |
+        Object containing the pipeline identifier, display name, and description of a Pipeline.
+      type: object
+      required: [ pipelineName, displayName, description ]
+      properties:
+        jobId:
+          $ref: '#/components/schemas/Id'
+        status:
+          $ref: "#/components/schemas/PipelineRunStatus"
+        description:
+          $ref: "#/components/schemas/PipelineRunDescription"
+
+    PipelineRunDescription:
+      description: |
+        The description for the pipeline run.
+      type: string
+      format: string
+
+    PipelineRunStatus:
+      description: |
+        The current status of the pipeline run.
       type: string
       format: string
 

--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -196,7 +196,7 @@ paths:
   /api/pipelineruns/v1/pipelineruns:
     get:
       tags: [ pipelineRuns ]
-      summary: Return a list of all pipeline runs the caller has access to
+      summary: Return a paginated list of all pipeline runs the caller has access to
       operationId: getAllPipelineRuns
       parameters:
         - $ref: '#/components/parameters/Limit'

--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -548,7 +548,7 @@ components:
         pageToken:
           type: string
         results:
-          description: List of retried pipeline runs
+          description: List of pipeline runs
           type: array
           items:
             $ref: '#/components/schemas/PipelineRun'
@@ -628,7 +628,7 @@ components:
 
     PipelineRun:
       description: |
-        Object containing the pipeline identifier, display name, and description of a Pipeline.
+        Object containing the job id, status, and user-provided description of a Pipeline Run.
       type: object
       required: [ pipelineName, displayName, description ]
       properties:
@@ -641,7 +641,7 @@ components:
 
     PipelineRunDescription:
       description: |
-        The description for the pipeline run.
+        The user-provided description for the pipeline run.
       type: string
       format: string
 

--- a/service/src/main/java/bio/terra/pipelines/app/controller/PipelineRunsApiController.java
+++ b/service/src/main/java/bio/terra/pipelines/app/controller/PipelineRunsApiController.java
@@ -6,21 +6,22 @@ import bio.terra.common.iam.SamUserFactory;
 import bio.terra.pipelines.app.configuration.external.IngressConfiguration;
 import bio.terra.pipelines.app.configuration.external.SamConfiguration;
 import bio.terra.pipelines.common.utils.PipelinesEnum;
+import bio.terra.pipelines.common.utils.pagination.CursorBasedPageable;
+import bio.terra.pipelines.common.utils.pagination.FieldEqualsSpecification;
+import bio.terra.pipelines.common.utils.pagination.PageResponse;
+import bio.terra.pipelines.common.utils.pagination.PageSpecification;
 import bio.terra.pipelines.db.entities.Pipeline;
 import bio.terra.pipelines.db.entities.PipelineRun;
 import bio.terra.pipelines.dependencies.stairway.JobService;
 import bio.terra.pipelines.generated.api.PipelineRunsApi;
-import bio.terra.pipelines.generated.model.ApiAsyncPipelineRunResponse;
-import bio.terra.pipelines.generated.model.ApiJobReport;
-import bio.terra.pipelines.generated.model.ApiPreparePipelineRunRequestBody;
-import bio.terra.pipelines.generated.model.ApiPreparePipelineRunResponse;
-import bio.terra.pipelines.generated.model.ApiStartPipelineRunRequestBody;
+import bio.terra.pipelines.generated.model.*;
 import bio.terra.pipelines.service.PipelineRunsService;
 import bio.terra.pipelines.service.PipelinesService;
 import io.swagger.annotations.Api;
 import jakarta.servlet.http.HttpServletRequest;
 import java.nio.file.Path;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.slf4j.Logger;
@@ -164,6 +165,54 @@ public class PipelineRunsApiController implements PipelineRunsApi {
     return new ResponseEntity<>(runResponse, getAsyncResponseCode(runResponse.getJobReport()));
   }
 
+  /**
+   * Returns a paginated list of Pipeline Runs for the user calling this endpoint. This will return
+   * is descending order i.e. will return the most recent runs first. pageToken is used to navigate
+   * to the corresponding "page" of results using <a
+   * href="https://bun.uptrace.dev/guide/cursor-pagination.html">cursor based pagination</a>
+   *
+   * @param limit - how many results the caller wants to be returned, maximum value is 100
+   * @param pageToken - token used for cursor based pagination. if not supplied then the first page
+   *     will be returned
+   * @return ResponseEntity containing the current page of results and a page token for the next
+   *     page if a next page exists
+   */
+  @Override
+  public ResponseEntity<ApiGetPipelineRunsResponse> getAllPipelineRuns(
+      Integer limit, String pageToken) {
+    final SamUser userRequest = getAuthenticatedInfo();
+    String userId = userRequest.getSubjectId();
+
+    int maxLimit = Math.min(limit, 100);
+    CursorBasedPageable cursorBasedPageable = new CursorBasedPageable(maxLimit, pageToken, null);
+    PageSpecification<PipelineRun> pageSpecification =
+        new PageSpecification<>("id", cursorBasedPageable);
+    FieldEqualsSpecification<PipelineRun> userIdSpecification =
+        new FieldEqualsSpecification<>("userId", userId);
+    // grab results from current page based
+    PageResponse<List<PipelineRun>> pageResults =
+        pipelineRunsService.findPageResults(
+            pageSpecification, userIdSpecification, cursorBasedPageable);
+
+    // convert PageResponse object to list of ApiPipelineRun objects for response
+    List<ApiPipelineRun> apiPipelineRuns =
+        pageResults.content().stream()
+            .map(
+                pipelineRun ->
+                    new ApiPipelineRun()
+                        .jobId(pipelineRun.getJobId())
+                        .status(pipelineRun.getStatus().name())
+                        .description(pipelineRun.getDescription()))
+            .toList();
+
+    ApiGetPipelineRunsResponse apiGetPipelineRunsResponse =
+        new ApiGetPipelineRunsResponse()
+            .results(apiPipelineRuns)
+            .pageToken(pageResults.nextPageCursor());
+    return new ResponseEntity<>(apiGetPipelineRunsResponse, HttpStatus.OK);
+  }
+
+  // helper methods
   /**
    * Converts a PipelineRun to an ApiAsyncPipelineRunResponse. If the PipelineRun has completed
    * successfully (isSuccess is true), we know there are no errors to retrieve and all the

--- a/service/src/main/java/bio/terra/pipelines/app/controller/PipelineRunsApiController.java
+++ b/service/src/main/java/bio/terra/pipelines/app/controller/PipelineRunsApiController.java
@@ -6,10 +6,7 @@ import bio.terra.common.iam.SamUserFactory;
 import bio.terra.pipelines.app.configuration.external.IngressConfiguration;
 import bio.terra.pipelines.app.configuration.external.SamConfiguration;
 import bio.terra.pipelines.common.utils.PipelinesEnum;
-import bio.terra.pipelines.common.utils.pagination.CursorBasedPageable;
-import bio.terra.pipelines.common.utils.pagination.FieldEqualsSpecification;
 import bio.terra.pipelines.common.utils.pagination.PageResponse;
-import bio.terra.pipelines.common.utils.pagination.PageSpecification;
 import bio.terra.pipelines.db.entities.Pipeline;
 import bio.terra.pipelines.db.entities.PipelineRun;
 import bio.terra.pipelines.dependencies.stairway.JobService;
@@ -167,7 +164,7 @@ public class PipelineRunsApiController implements PipelineRunsApi {
 
   /**
    * Returns a paginated list of Pipeline Runs for the user calling this endpoint. This will return
-   * is descending order i.e. will return the most recent runs first. pageToken is used to navigate
+   * in descending order i.e. will return the most recent runs first. pageToken is used to navigate
    * to the corresponding "page" of results using <a
    * href="https://bun.uptrace.dev/guide/cursor-pagination.html">cursor based pagination</a>
    *
@@ -182,17 +179,11 @@ public class PipelineRunsApiController implements PipelineRunsApi {
       Integer limit, String pageToken) {
     final SamUser userRequest = getAuthenticatedInfo();
     String userId = userRequest.getSubjectId();
-
     int maxLimit = Math.min(limit, 100);
-    CursorBasedPageable cursorBasedPageable = new CursorBasedPageable(maxLimit, pageToken, null);
-    PageSpecification<PipelineRun> pageSpecification =
-        new PageSpecification<>("id", cursorBasedPageable);
-    FieldEqualsSpecification<PipelineRun> userIdSpecification =
-        new FieldEqualsSpecification<>("userId", userId);
-    // grab results from current page based
+
+    // grab results from current page based on user provided inputs
     PageResponse<List<PipelineRun>> pageResults =
-        pipelineRunsService.findPageResults(
-            pageSpecification, userIdSpecification, cursorBasedPageable);
+        pipelineRunsService.findPipelineRunsPaginated(maxLimit, pageToken, userId);
 
     // convert PageResponse object to list of ApiPipelineRun objects for response
     List<ApiPipelineRun> apiPipelineRuns =

--- a/service/src/main/java/bio/terra/pipelines/common/utils/pagination/CursorBasedPageable.java
+++ b/service/src/main/java/bio/terra/pipelines/common/utils/pagination/CursorBasedPageable.java
@@ -24,6 +24,7 @@ public class CursorBasedPageable {
   private final String prevPageCursor;
 
   public static final String POSTGRES_INT4_MAX_VALUE = "2147483647";
+  public static final String ENCODED_PADDING_AROUND_VALUE = "###";
 
   public boolean hasNextPageCursor() {
     return nextPageCursor != null && !nextPageCursor.isEmpty();
@@ -37,7 +38,7 @@ public class CursorBasedPageable {
     return hasPrevPageCursor() || hasNextPageCursor();
   }
 
-  public String getDecodedCursor(String cursorValue) {
+  public static String getDecodedCursor(String cursorValue) {
     if (cursorValue == null || cursorValue.isEmpty()) {
       throw new IllegalArgumentException("Cursor value is not valid!");
     }
@@ -47,12 +48,17 @@ public class CursorBasedPageable {
     return substringBetween(decodedValue, "###");
   }
 
-  public String getEncodedCursor(String field, boolean hasPrevOrNextElements) {
+  public static String getEncodedCursor(String field, boolean hasPrevOrNextElements) {
     requireNonNull(field);
 
     if (!hasPrevOrNextElements) return null;
 
-    var structuredValue = "###" + field + "### - " + LocalDateTime.now();
+    var structuredValue =
+        ENCODED_PADDING_AROUND_VALUE
+            + field
+            + ENCODED_PADDING_AROUND_VALUE
+            + " - "
+            + LocalDateTime.now();
     return Base64.getEncoder().encodeToString(structuredValue.getBytes());
   }
 

--- a/service/src/main/java/bio/terra/pipelines/common/utils/pagination/CursorBasedPageable.java
+++ b/service/src/main/java/bio/terra/pipelines/common/utils/pagination/CursorBasedPageable.java
@@ -45,7 +45,7 @@ public class CursorBasedPageable {
     var decodedBytes = Base64.getDecoder().decode(cursorValue);
     var decodedValue = new String(decodedBytes);
 
-    return substringBetween(decodedValue, "###");
+    return substringBetween(decodedValue, ENCODED_PADDING_AROUND_VALUE);
   }
 
   public static String getEncodedCursor(String field, boolean hasPrevOrNextElements) {

--- a/service/src/main/java/bio/terra/pipelines/common/utils/pagination/CursorBasedPageable.java
+++ b/service/src/main/java/bio/terra/pipelines/common/utils/pagination/CursorBasedPageable.java
@@ -1,0 +1,92 @@
+package bio.terra.pipelines.common.utils.pagination;
+
+import static java.util.Objects.requireNonNull;
+import static org.apache.commons.lang3.StringUtils.substringBetween;
+
+import java.time.LocalDateTime;
+import java.util.Base64;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+/**
+ * This class is used to help with determining page token encoding/decoding for our paginated
+ * endpoints. There is logic to decode already created page tokens and encode the field you are
+ * paginating over into page tokens. It is assumed that the field you are paginating over is a
+ * postgres id field of type int4
+ */
+@Data
+@AllArgsConstructor
+public class CursorBasedPageable {
+  private int size;
+  private final String nextPageCursor;
+  private final String prevPageCursor;
+
+  public static final String POSTGRES_INT4_MAX_VALUE = "2147483647";
+
+  public boolean hasNextPageCursor() {
+    return nextPageCursor != null && !nextPageCursor.isEmpty();
+  }
+
+  public boolean hasPrevPageCursor() {
+    return prevPageCursor != null && !prevPageCursor.isEmpty();
+  }
+
+  public boolean hasCursors() {
+    return hasPrevPageCursor() || hasNextPageCursor();
+  }
+
+  public String getDecodedCursor(String cursorValue) {
+    if (cursorValue == null || cursorValue.isEmpty()) {
+      throw new IllegalArgumentException("Cursor value is not valid!");
+    }
+    var decodedBytes = Base64.getDecoder().decode(cursorValue);
+    var decodedValue = new String(decodedBytes);
+
+    return substringBetween(decodedValue, "###");
+  }
+
+  public String getEncodedCursor(String field, boolean hasPrevOrNextElements) {
+    requireNonNull(field);
+
+    if (!hasPrevOrNextElements) return null;
+
+    var structuredValue = "###" + field + "### - " + LocalDateTime.now();
+    return Base64.getEncoder().encodeToString(structuredValue.getBytes());
+  }
+
+  public String getSearchValue() {
+    // postgres does not have a positive infinity symbol for an int4 field type so we hard code the
+    // largest possible
+    // value that can occur in that column type here.  very hacky
+    if (!hasCursors()) return POSTGRES_INT4_MAX_VALUE;
+
+    return hasPrevPageCursor()
+        ? getDecodedCursor(prevPageCursor)
+        : getDecodedCursor(nextPageCursor);
+  }
+
+  @Override
+  public int hashCode() {
+    return new HashCodeBuilder(17, 31)
+        // two randomly chosen prime numbers
+        // if deriving: appendSuper(super.hashCode()).
+        .append(size)
+        .append(nextPageCursor)
+        .append(prevPageCursor)
+        .toHashCode();
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj instanceof CursorBasedPageable otherObject)) return false;
+    if (obj == this) return true;
+
+    return new EqualsBuilder()
+        .append(size, otherObject.size)
+        .append(nextPageCursor, otherObject.nextPageCursor)
+        .append(prevPageCursor, otherObject.prevPageCursor)
+        .isEquals();
+  }
+}

--- a/service/src/main/java/bio/terra/pipelines/common/utils/pagination/FieldEqualsSpecification.java
+++ b/service/src/main/java/bio/terra/pipelines/common/utils/pagination/FieldEqualsSpecification.java
@@ -1,0 +1,51 @@
+package bio.terra.pipelines.common.utils.pagination;
+
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.data.jpa.domain.Specification;
+
+/**
+ * This class is used to help build a predicate to filter based on a match to a value for a column.
+ * This is currently used to filter paginated results based on the user id field but can be used
+ * generically for any column / value combination.
+ *
+ * @param <T> - DB entity you are filtering on
+ */
+@RequiredArgsConstructor
+public class FieldEqualsSpecification<T> implements Specification<T> {
+
+  private final transient String fieldName;
+  private final transient String fieldValue;
+
+  @Override
+  public Predicate toPredicate(
+      @NotNull Root<T> root, CriteriaQuery<?> query, @NotNull CriteriaBuilder criteriaBuilder) {
+    return criteriaBuilder.equal(root.get(fieldName), fieldValue);
+  }
+
+  public int hashCode() {
+    return new HashCodeBuilder(17, 31)
+        // two randomly chosen prime numbers
+        // if deriving: appendSuper(super.hashCode()).
+        .append(fieldName)
+        .append(fieldValue)
+        .toHashCode();
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj instanceof FieldEqualsSpecification<?> otherObject)) return false;
+    if (obj == this) return true;
+
+    return new EqualsBuilder()
+        .append(fieldName, otherObject.fieldName)
+        .append(fieldValue, otherObject.fieldValue)
+        .isEquals();
+  }
+}

--- a/service/src/main/java/bio/terra/pipelines/common/utils/pagination/PageResponse.java
+++ b/service/src/main/java/bio/terra/pipelines/common/utils/pagination/PageResponse.java
@@ -1,0 +1,11 @@
+package bio.terra.pipelines.common.utils.pagination;
+
+/**
+ * Class used to structure the response from a paginated call to the database
+ *
+ * @param content - records returned from database
+ * @param previousPageCursor - if exists, the page token for the next page
+ * @param nextPageCursor - if exists, the page token for the previous page
+ * @param <T> - Db entity queried over
+ */
+public record PageResponse<T>(T content, String previousPageCursor, String nextPageCursor) {}

--- a/service/src/main/java/bio/terra/pipelines/common/utils/pagination/PageSpecification.java
+++ b/service/src/main/java/bio/terra/pipelines/common/utils/pagination/PageSpecification.java
@@ -1,0 +1,63 @@
+package bio.terra.pipelines.common.utils.pagination;
+
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.data.jpa.domain.Specification;
+
+/**
+ * This class is used to help build a predicate to both filter by greater than or less than a field
+ * name and value as well as ordering the results of the query, currently this is hardcoded to
+ * descending to get the most recent records first. This is done based on the CursorBasePageable
+ * passed in.
+ *
+ * @param <T> - DB entity you are filtering on
+ */
+@RequiredArgsConstructor
+public class PageSpecification<T> implements Specification<T> {
+
+  private final transient String mainFieldName;
+  private final transient CursorBasedPageable cursorBasedPageable;
+
+  @Override
+  public Predicate toPredicate(
+      @NotNull Root<T> root, CriteriaQuery<?> query, @NotNull CriteriaBuilder criteriaBuilder) {
+    var predicate = applyPaginationFilter(root, criteriaBuilder);
+    query.orderBy(criteriaBuilder.desc(root.get(mainFieldName)));
+
+    return predicate;
+  }
+
+  private Predicate applyPaginationFilter(Root<T> root, CriteriaBuilder criteriaBuilder) {
+    var searchValue = cursorBasedPageable.getSearchValue();
+
+    return cursorBasedPageable.hasPrevPageCursor()
+        ? criteriaBuilder.greaterThan(root.get(mainFieldName), searchValue)
+        : criteriaBuilder.lessThan(root.get(mainFieldName), searchValue);
+  }
+
+  public int hashCode() {
+    return new HashCodeBuilder(17, 31)
+        // two randomly chosen prime numbers
+        // if deriving: appendSuper(super.hashCode()).
+        .append(mainFieldName)
+        .append(cursorBasedPageable)
+        .toHashCode();
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj instanceof PageSpecification<?> otherObject)) return false;
+    if (obj == this) return true;
+
+    return new EqualsBuilder()
+        .append(mainFieldName, otherObject.mainFieldName)
+        .append(cursorBasedPageable, otherObject.cursorBasedPageable)
+        .isEquals();
+  }
+}

--- a/service/src/main/java/bio/terra/pipelines/db/entities/Pipeline.java
+++ b/service/src/main/java/bio/terra/pipelines/db/entities/Pipeline.java
@@ -120,10 +120,9 @@ public class Pipeline {
 
   @Override
   public boolean equals(Object obj) {
-    if (!(obj instanceof Pipeline)) return false;
+    if (!(obj instanceof Pipeline otherObject)) return false;
     if (obj == this) return true;
 
-    Pipeline otherObject = (Pipeline) obj;
     return new EqualsBuilder()
         .append(id, otherObject.id)
         .append(name, otherObject.name)

--- a/service/src/main/java/bio/terra/pipelines/db/repositories/PipelineRunsRepository.java
+++ b/service/src/main/java/bio/terra/pipelines/db/repositories/PipelineRunsRepository.java
@@ -4,12 +4,16 @@ import bio.terra.pipelines.db.entities.PipelineRun;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.repository.CrudRepository;
 
-public interface PipelineRunsRepository extends CrudRepository<PipelineRun, Long> {
+public interface PipelineRunsRepository
+    extends CrudRepository<PipelineRun, Long>, JpaSpecificationExecutor<PipelineRun> {
   List<PipelineRun> findAllByUserId(String userId);
 
   boolean existsByJobId(UUID jobId);
 
   Optional<PipelineRun> findByJobIdAndUserId(UUID jobId, String userId);
+
+  boolean existsByIdGreaterThan(Long id);
 }

--- a/service/src/test/java/bio/terra/pipelines/common/utils/pagination/CursorBasedPageableTest.java
+++ b/service/src/test/java/bio/terra/pipelines/common/utils/pagination/CursorBasedPageableTest.java
@@ -19,7 +19,6 @@ class CursorBasedPageableTest extends BaseTest {
   @Test
   void decodeValue() {
     String originalValue = "10";
-    CursorBasedPageable cursorBasedPageable = new CursorBasedPageable(100, null, null);
     // encode value
     String encodedString = CursorBasedPageable.getEncodedCursor(originalValue, true);
     // decode value
@@ -29,7 +28,6 @@ class CursorBasedPageableTest extends BaseTest {
 
   @Test
   void decodeNullValueOrEmpty() {
-    CursorBasedPageable cursorBasedPageable = new CursorBasedPageable(100, null, null);
     // decode value
     assertThrows(IllegalArgumentException.class, () -> CursorBasedPageable.getDecodedCursor(null));
     assertThrows(IllegalArgumentException.class, () -> CursorBasedPageable.getDecodedCursor(""));
@@ -39,8 +37,6 @@ class CursorBasedPageableTest extends BaseTest {
 
   @Test
   void encodeValue() {
-    CursorBasedPageable cursorBasedPageable = new CursorBasedPageable(10, null, null);
-
     // because this uses a LocalDateTime.now() as part of its encoding strategy, its hard to test
     // the full string matches so we are just testing the first 10 characters as a "good enough"
     String structuredValue =

--- a/service/src/test/java/bio/terra/pipelines/common/utils/pagination/CursorBasedPageableTest.java
+++ b/service/src/test/java/bio/terra/pipelines/common/utils/pagination/CursorBasedPageableTest.java
@@ -1,0 +1,115 @@
+package bio.terra.pipelines.common.utils.pagination;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import bio.terra.pipelines.testutils.BaseTest;
+import java.time.LocalDateTime;
+import java.util.Base64;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class CursorBasedPageableTest extends BaseTest {
+
+  private final String encodedTenValue = "IyMjMTAjIyMgLSAyMDI0LTA3LTIzVDE0OjQzOjEyLjQ5NDk4OA==";
+
+  @Test
+  void decodeValue() {
+    String originalValue = "10";
+    CursorBasedPageable cursorBasedPageable = new CursorBasedPageable(100, null, null);
+    // encode value
+    String encodedString = cursorBasedPageable.getEncodedCursor(originalValue, true);
+    // decode value
+    String decodedValue = cursorBasedPageable.getDecodedCursor(encodedString);
+    assertEquals(originalValue, decodedValue);
+  }
+
+  @Test
+  void decodeNullValueOrEmpty() {
+    CursorBasedPageable cursorBasedPageable = new CursorBasedPageable(100, null, null);
+    // decode value
+    assertThrows(IllegalArgumentException.class, () -> cursorBasedPageable.getDecodedCursor(null));
+    assertThrows(IllegalArgumentException.class, () -> cursorBasedPageable.getDecodedCursor(""));
+    assertThrows(
+        IllegalArgumentException.class, () -> cursorBasedPageable.getDecodedCursor("    "));
+  }
+
+  @Test
+  void encodeValue() {
+    CursorBasedPageable cursorBasedPageable = new CursorBasedPageable(10, null, null);
+
+    // because this uses a LocalDateTime.now() as part of its encoding strategy, its hard to test
+    // the full string matches so we are just testing the first 10 characters as a "good enough"
+    // test
+    String structuredValue = "###" + 10 + "### - " + LocalDateTime.now();
+    String encodedString = Base64.getEncoder().encodeToString(structuredValue.getBytes());
+    assertEquals(
+        encodedString.substring(0, 10),
+        cursorBasedPageable.getEncodedCursor("10", true).substring(0, 10));
+  }
+
+  @Test
+  void encodeValueNoPreviousOrNextPages() {
+    CursorBasedPageable cursorBasedPageable = new CursorBasedPageable(10, null, null);
+    assertFalse(cursorBasedPageable.hasCursors());
+    assertNull(cursorBasedPageable.getEncodedCursor("10", false));
+  }
+
+  @Test
+  void hasNextCursor() {
+    CursorBasedPageable cursorBasedPageableNoNext = new CursorBasedPageable(10, null, "blah");
+    Assertions.assertFalse(cursorBasedPageableNoNext.hasNextPageCursor());
+    assertTrue(cursorBasedPageableNoNext.hasCursors());
+    CursorBasedPageable cursorBasedPageableNext = new CursorBasedPageable(10, "balhblah", null);
+    assertTrue(cursorBasedPageableNext.hasNextPageCursor());
+    assertEquals("balhblah", cursorBasedPageableNext.getNextPageCursor());
+  }
+
+  @Test
+  void hasPrevCursor() {
+    CursorBasedPageable cursorBasedPageableNoPrev = new CursorBasedPageable(10, "blah", null);
+    Assertions.assertFalse(cursorBasedPageableNoPrev.hasPrevPageCursor());
+    assertTrue(cursorBasedPageableNoPrev.hasCursors());
+    CursorBasedPageable cursorBasedPageablePrev = new CursorBasedPageable(10, null, "balhblah");
+    assertTrue(cursorBasedPageablePrev.hasPrevPageCursor());
+    assertEquals("balhblah", cursorBasedPageablePrev.getPrevPageCursor());
+  }
+
+  @Test
+  void getSearchValue() {
+    CursorBasedPageable cursorBasedPageableNoCursor = new CursorBasedPageable(10, null, null);
+    assertEquals(
+        CursorBasedPageable.POSTGRES_INT4_MAX_VALUE, cursorBasedPageableNoCursor.getSearchValue());
+    CursorBasedPageable cursorBasedPageable = new CursorBasedPageable(10, encodedTenValue, null);
+    assertEquals("10", cursorBasedPageable.getSearchValue());
+    cursorBasedPageable = new CursorBasedPageable(10, null, encodedTenValue);
+    assertEquals("10", cursorBasedPageable.getSearchValue());
+  }
+
+  @Test
+  void cursorBasedPageableHashCode() {
+    CursorBasedPageable cursorBasedPageableNextCursor =
+        new CursorBasedPageable(10, "hmmm_ok", null);
+    assertEquals(
+        new HashCodeBuilder(17, 31).append(10).append("hmmm_ok").append((String) null).toHashCode(),
+        cursorBasedPageableNextCursor.hashCode());
+
+    CursorBasedPageable cursorBasedPageablePrevCursor =
+        new CursorBasedPageable(10, null, "hmmm_ok");
+    assertEquals(
+        new HashCodeBuilder(17, 31).append(10).append((String) null).append("hmmm_ok").toHashCode(),
+        cursorBasedPageablePrevCursor.hashCode());
+  }
+
+  @Test
+  void cursorBasedPageableEquals() {
+    CursorBasedPageable cursorBasedPageableOne = new CursorBasedPageable(10, "hmmm_ok", null);
+    CursorBasedPageable cursorBasedPageableSameAsOne = new CursorBasedPageable(10, "hmmm_ok", null);
+    CursorBasedPageable cursorBasedPageableDifferentFromOne =
+        new CursorBasedPageable(15, null, "hmmm_ok");
+
+    assertEquals(cursorBasedPageableOne, cursorBasedPageableSameAsOne);
+    assertNotEquals(cursorBasedPageableOne, cursorBasedPageableDifferentFromOne);
+    assertNotEquals(cursorBasedPageableSameAsOne, cursorBasedPageableDifferentFromOne);
+  }
+}

--- a/service/src/test/java/bio/terra/pipelines/common/utils/pagination/FieldEqualsSpecificationTest.java
+++ b/service/src/test/java/bio/terra/pipelines/common/utils/pagination/FieldEqualsSpecificationTest.java
@@ -1,0 +1,34 @@
+package bio.terra.pipelines.common.utils.pagination;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import bio.terra.pipelines.testutils.BaseTest;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.junit.jupiter.api.Test;
+
+class FieldEqualsSpecificationTest extends BaseTest {
+
+  @Test
+  void fieldEqualsSpecificationHashCode() {
+    FieldEqualsSpecification<?> fieldEqualsSpecification =
+        new FieldEqualsSpecification<>("userId", "12");
+    assertEquals(
+        new HashCodeBuilder(17, 31).append("userId").append("12").toHashCode(),
+        fieldEqualsSpecification.hashCode());
+  }
+
+  @Test
+  void fieldEqualsSpecificationEquals() {
+    FieldEqualsSpecification<?> fieldEqualsSpecificationOne =
+        new FieldEqualsSpecification<>("userId", "12");
+    FieldEqualsSpecification<?> fieldEqualsSpecificationSameAsOne =
+        new FieldEqualsSpecification<>("userId", "12");
+    FieldEqualsSpecification<?> fieldEqualsSpecificationDifferentFromOne =
+        new FieldEqualsSpecification<>("userId", "43");
+
+    assertEquals(fieldEqualsSpecificationOne, fieldEqualsSpecificationSameAsOne);
+    assertNotEquals(fieldEqualsSpecificationOne, fieldEqualsSpecificationDifferentFromOne);
+    assertNotEquals(fieldEqualsSpecificationSameAsOne, fieldEqualsSpecificationDifferentFromOne);
+  }
+}

--- a/service/src/test/java/bio/terra/pipelines/common/utils/pagination/FieldEqualsSpecificationTest.java
+++ b/service/src/test/java/bio/terra/pipelines/common/utils/pagination/FieldEqualsSpecificationTest.java
@@ -13,6 +13,7 @@ class FieldEqualsSpecificationTest extends BaseTest {
   void fieldEqualsSpecificationHashCode() {
     FieldEqualsSpecification<?> fieldEqualsSpecification =
         new FieldEqualsSpecification<>("userId", "12");
+    // 17 and 31 are hardcoded in this hashCode method of this class
     assertEquals(
         new HashCodeBuilder(17, 31).append("userId").append("12").toHashCode(),
         fieldEqualsSpecification.hashCode());

--- a/service/src/test/java/bio/terra/pipelines/common/utils/pagination/PageSpecificationTest.java
+++ b/service/src/test/java/bio/terra/pipelines/common/utils/pagination/PageSpecificationTest.java
@@ -13,6 +13,7 @@ class PageSpecificationTest extends BaseTest {
   void pageSpecificationHashCode() {
     CursorBasedPageable cursorBasedPageable = new CursorBasedPageable(14, "doesnt_matter", null);
     PageSpecification<?> pageSpecification = new PageSpecification<>("id", cursorBasedPageable);
+    // 17 and 31 are hardcoded in this hashCode method of this class
     assertEquals(
         new HashCodeBuilder(17, 31).append("id").append(cursorBasedPageable).toHashCode(),
         pageSpecification.hashCode());

--- a/service/src/test/java/bio/terra/pipelines/common/utils/pagination/PageSpecificationTest.java
+++ b/service/src/test/java/bio/terra/pipelines/common/utils/pagination/PageSpecificationTest.java
@@ -1,0 +1,34 @@
+package bio.terra.pipelines.common.utils.pagination;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import bio.terra.pipelines.testutils.BaseTest;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.junit.jupiter.api.Test;
+
+class PageSpecificationTest extends BaseTest {
+
+  @Test
+  void pageSpecificationHashCode() {
+    CursorBasedPageable cursorBasedPageable = new CursorBasedPageable(14, "doesnt_matter", null);
+    PageSpecification<?> pageSpecification = new PageSpecification<>("id", cursorBasedPageable);
+    assertEquals(
+        new HashCodeBuilder(17, 31).append("id").append(cursorBasedPageable).toHashCode(),
+        pageSpecification.hashCode());
+  }
+
+  @Test
+  void pageSpecificationEquals() {
+    CursorBasedPageable cursorBasedPageable = new CursorBasedPageable(14, "doesnt_matter", null);
+    PageSpecification<?> pageSpecificationOne = new PageSpecification<>("id", cursorBasedPageable);
+    PageSpecification<?> pageSpecificationSameAsOne =
+        new PageSpecification<>("id", cursorBasedPageable);
+    PageSpecification<?> pageSpecificationDifferentFromOne =
+        new PageSpecification<>("not_id", cursorBasedPageable);
+
+    assertEquals(pageSpecificationOne, pageSpecificationSameAsOne);
+    assertNotEquals(pageSpecificationOne, pageSpecificationDifferentFromOne);
+    assertNotEquals(pageSpecificationSameAsOne, pageSpecificationDifferentFromOne);
+  }
+}

--- a/service/src/test/java/bio/terra/pipelines/controller/PipelineRunsApiControllerTest.java
+++ b/service/src/test/java/bio/terra/pipelines/controller/PipelineRunsApiControllerTest.java
@@ -597,10 +597,10 @@ class PipelineRunsApiControllerTest {
     PageResponse<List<PipelineRun>> pageResponse =
         new PageResponse<>(List.of(pipelineRun), null, nextPageToken);
 
-    // the mocks
+    // mocks
+
     // hardcoding the limit to 100 here because the code should limit, if it didn't then the mock
-    // wouldn't work
-    // and the test would fail
+    // wouldn't work and the test would fail
     when(pipelineRunsServiceMock.findPipelineRunsPaginated(
             100, requestPageToken, testUser.getSubjectId()))
         .thenReturn(pageResponse);

--- a/service/src/test/java/bio/terra/pipelines/controller/PipelineRunsApiControllerTest.java
+++ b/service/src/test/java/bio/terra/pipelines/controller/PipelineRunsApiControllerTest.java
@@ -25,16 +25,11 @@ import bio.terra.pipelines.app.controller.JobApiUtils;
 import bio.terra.pipelines.app.controller.PipelineRunsApiController;
 import bio.terra.pipelines.common.utils.CommonPipelineRunStatusEnum;
 import bio.terra.pipelines.common.utils.PipelinesEnum;
+import bio.terra.pipelines.common.utils.pagination.*;
 import bio.terra.pipelines.db.entities.PipelineRun;
 import bio.terra.pipelines.dependencies.stairway.JobService;
 import bio.terra.pipelines.dependencies.stairway.exception.InternalStairwayException;
-import bio.terra.pipelines.generated.model.ApiAsyncPipelineRunResponse;
-import bio.terra.pipelines.generated.model.ApiErrorReport;
-import bio.terra.pipelines.generated.model.ApiJobControl;
-import bio.terra.pipelines.generated.model.ApiJobReport;
-import bio.terra.pipelines.generated.model.ApiPipelineRunOutputs;
-import bio.terra.pipelines.generated.model.ApiPreparePipelineRunResponse;
-import bio.terra.pipelines.generated.model.ApiStartPipelineRunRequestBody;
+import bio.terra.pipelines.generated.model.*;
 import bio.terra.pipelines.service.PipelineRunsService;
 import bio.terra.pipelines.service.PipelinesService;
 import bio.terra.pipelines.testutils.MockMvcUtils;
@@ -47,6 +42,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -559,6 +555,88 @@ class PipelineRunsApiControllerTest {
         PipelineRunsApiController.getAsyncResultEndpoint(ingressConfiguration, request, jobId));
   }
 
+  @Test
+  void getAllPipelineRunsWithNoPageToken() throws Exception {
+    int limit = 5;
+    CursorBasedPageable cursorBasedPageable = new CursorBasedPageable(limit, null, null);
+    PageSpecification<PipelineRun> pageSpecification =
+        new PageSpecification<>("id", cursorBasedPageable);
+    FieldEqualsSpecification<PipelineRun> userIdSpecification =
+        new FieldEqualsSpecification<>("userId", testUser.getSubjectId());
+    PipelineRun pipelineRun = getPipelineRunPreparing();
+    PageResponse<List<PipelineRun>> pageResponse =
+        new PageResponse<>(List.of(pipelineRun), null, null);
+
+    // the mocks
+    when(pipelineRunsServiceMock.findPageResults(
+            pageSpecification, userIdSpecification, cursorBasedPageable))
+        .thenReturn(pageResponse);
+
+    MvcResult result =
+        mockMvc
+            .perform(get(String.format("/api/pipelineruns/v1/pipelineruns?limit=%s", limit)))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andReturn();
+
+    ApiGetPipelineRunsResponse response =
+        new ObjectMapper()
+            .readValue(result.getResponse().getContentAsString(), ApiGetPipelineRunsResponse.class);
+
+    // response should include the job report and no error report or pipeline output object
+    assertNull(response.getPageToken());
+    assertEquals(1, response.getResults().size());
+    ApiPipelineRun responsePipelineRun = response.getResults().get(0);
+    assertEquals(pipelineRun.getStatus().name(), responsePipelineRun.getStatus());
+    assertEquals(pipelineRun.getDescription(), responsePipelineRun.getDescription());
+    assertEquals(pipelineRun.getJobId(), responsePipelineRun.getJobId());
+  }
+
+  @Test
+  void getAllPipelineRunsWithPageTokenWithNextPageOverMaxLimit() throws Exception {
+    int limit = 105; // this should be limited to 100 inside of controller code
+    String requestPageToken = "requestPageToken";
+    String nextPageToken = "nextPageToken";
+    // hardcoding to 100 here because the code should limit, if it didnt then the mock wouldnt work
+    // and the test would fail
+    CursorBasedPageable cursorBasedPageable = new CursorBasedPageable(100, requestPageToken, null);
+    PageSpecification<PipelineRun> pageSpecification =
+        new PageSpecification<>("id", cursorBasedPageable);
+    FieldEqualsSpecification<PipelineRun> userIdSpecification =
+        new FieldEqualsSpecification<>("userId", testUser.getSubjectId());
+    PipelineRun pipelineRun = getPipelineRunRunning();
+    PageResponse<List<PipelineRun>> pageResponse =
+        new PageResponse<>(List.of(pipelineRun), null, nextPageToken);
+
+    // the mocks
+    when(pipelineRunsServiceMock.findPageResults(
+            pageSpecification, userIdSpecification, cursorBasedPageable))
+        .thenReturn(pageResponse);
+
+    MvcResult result =
+        mockMvc
+            .perform(
+                get(
+                    String.format(
+                        "/api/pipelineruns/v1/pipelineruns?limit=%s&pageToken=%s",
+                        limit, requestPageToken)))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andReturn();
+
+    ApiGetPipelineRunsResponse response =
+        new ObjectMapper()
+            .readValue(result.getResponse().getContentAsString(), ApiGetPipelineRunsResponse.class);
+
+    // response should include the job report and no error report or pipeline output object
+    assertEquals(nextPageToken, response.getPageToken());
+    assertEquals(1, response.getResults().size());
+    ApiPipelineRun responsePipelineRun = response.getResults().get(0);
+    assertEquals(pipelineRun.getStatus().name(), responsePipelineRun.getStatus());
+    assertEquals(pipelineRun.getDescription(), responsePipelineRun.getDescription());
+    assertEquals(pipelineRun.getJobId(), responsePipelineRun.getJobId());
+  }
+
   // support methods
 
   private String testPreparePipelineRunPostBody(String jobId) throws JsonProcessingException {
@@ -571,6 +649,22 @@ class PipelineRunsApiControllerTest {
   private String testStartPipelineRunPostBody(String jobId, String description) {
     return String.format(
         "{\"jobControl\":{\"id\":\"%s\"},\"description\":\"%s\"}", jobId, description);
+  }
+
+  /** helper method to create a PipelineRun object for a running job */
+  private PipelineRun getPipelineRunPreparing() {
+    return new PipelineRun(
+        newJobId,
+        testUser.getSubjectId(),
+        1L,
+        TestUtils.CONTROL_WORKSPACE_ID,
+        TestUtils.CONTROL_WORKSPACE_STORAGE_CONTAINER_URL,
+        createdTime,
+        updatedTime,
+        CommonPipelineRunStatusEnum.PREPARING,
+        TestUtils.TEST_PIPELINE_DESCRIPTION_1,
+        testResultPath,
+        null);
   }
 
   /** helper method to create a PipelineRun object for a running job */

--- a/service/src/test/java/bio/terra/pipelines/service/PipelineRunsServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/PipelineRunsServiceTest.java
@@ -12,6 +12,10 @@ import static org.mockito.Mockito.when;
 import bio.terra.common.exception.BadRequestException;
 import bio.terra.common.exception.InternalServerErrorException;
 import bio.terra.pipelines.common.utils.CommonPipelineRunStatusEnum;
+import bio.terra.pipelines.common.utils.pagination.CursorBasedPageable;
+import bio.terra.pipelines.common.utils.pagination.FieldEqualsSpecification;
+import bio.terra.pipelines.common.utils.pagination.PageResponse;
+import bio.terra.pipelines.common.utils.pagination.PageSpecification;
 import bio.terra.pipelines.db.entities.Pipeline;
 import bio.terra.pipelines.db.entities.PipelineInput;
 import bio.terra.pipelines.db.entities.PipelineOutput;
@@ -31,6 +35,7 @@ import bio.terra.pipelines.testutils.TestUtils;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -491,5 +496,84 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
     for (Map.Entry<String, String> entry : TestUtils.TEST_PIPELINE_OUTPUTS.entrySet()) {
       assertEquals(entry.getValue(), extractedOutputs.get(entry.getKey()));
     }
+  }
+
+  @Test
+  void findPageResultsNoResults() {
+    CursorBasedPageable cursorBasedPageable = new CursorBasedPageable(10, null, null);
+    PageSpecification<PipelineRun> pageSpecification =
+        new PageSpecification<>("id", cursorBasedPageable);
+    // querying on a user that doenst have records
+    FieldEqualsSpecification<PipelineRun> userIdSpecification =
+        new FieldEqualsSpecification<>("userId", "userIdDoesntHaveRecords");
+
+    PageResponse<List<PipelineRun>> pageResults =
+        pipelineRunsService.findPageResults(
+            pageSpecification, userIdSpecification, cursorBasedPageable);
+
+    assertTrue(pageResults.content().isEmpty());
+    assertNull(pageResults.nextPageCursor());
+    assertNull(pageResults.previousPageCursor());
+  }
+
+  @Test
+  void findPageResultsResultsNoOtherPages() {
+    CursorBasedPageable cursorBasedPageable = new CursorBasedPageable(10, null, null);
+    PageSpecification<PipelineRun> pageSpecification =
+        new PageSpecification<>("id", cursorBasedPageable);
+    FieldEqualsSpecification<PipelineRun> userIdSpecification =
+        new FieldEqualsSpecification<>("userId", testUserId);
+
+    PageResponse<List<PipelineRun>> pageResults =
+        pipelineRunsService.findPageResults(
+            pageSpecification, userIdSpecification, cursorBasedPageable);
+
+    assertEquals(1, pageResults.content().size());
+    assertNull(pageResults.nextPageCursor());
+    assertNull(pageResults.previousPageCursor());
+  }
+
+  @Test
+  void findPageResultsResultsNoOtherPagesUsingNextPage() {
+    // add 3 new jobs so 4 total exist in database
+    PipelineRun pipelineRun = createNewRunWithJobId(testJobId);
+    pipelineRunsRepository.save(pipelineRun);
+    pipelineRun = createNewRunWithJobId(UUID.randomUUID());
+    pipelineRunsRepository.save(pipelineRun);
+    pipelineRun = createNewRunWithJobId(UUID.randomUUID());
+    pipelineRunsRepository.save(pipelineRun);
+
+    // page size of 2 so there is a next page token that exists
+    CursorBasedPageable cursorBasedPageable = new CursorBasedPageable(2, null, null);
+    PageSpecification<PipelineRun> pageSpecification =
+        new PageSpecification<>("id", cursorBasedPageable);
+    FieldEqualsSpecification<PipelineRun> userIdSpecification =
+        new FieldEqualsSpecification<>("userId", testUserId);
+
+    // query for first (default) page
+    PageResponse<List<PipelineRun>> pageResults =
+        pipelineRunsService.findPageResults(
+            pageSpecification, userIdSpecification, cursorBasedPageable);
+
+    assertEquals(2, pageResults.content().size());
+    assertNotNull(pageResults.nextPageCursor());
+    assertNull(pageResults.previousPageCursor());
+    LocalDateTime firstResultTime = pageResults.content().get(0).getCreated();
+
+    // now query for next page
+    cursorBasedPageable = new CursorBasedPageable(2, pageResults.nextPageCursor(), null);
+    pageSpecification = new PageSpecification<>("id", cursorBasedPageable);
+    userIdSpecification = new FieldEqualsSpecification<>("userId", testUserId);
+    pageResults =
+        pipelineRunsService.findPageResults(
+            pageSpecification, userIdSpecification, cursorBasedPageable);
+
+    assertEquals(2, pageResults.content().size());
+    assertNull(pageResults.nextPageCursor());
+    assertNotNull(pageResults.previousPageCursor());
+
+    LocalDateTime thirdResultTime = pageResults.content().get(0).getCreated();
+    // test that results are coming with most recent first
+    assertTrue(firstResultTime.isAfter(thirdResultTime));
   }
 }

--- a/service/src/test/java/bio/terra/pipelines/service/PipelineRunsServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/PipelineRunsServiceTest.java
@@ -12,10 +12,7 @@ import static org.mockito.Mockito.when;
 import bio.terra.common.exception.BadRequestException;
 import bio.terra.common.exception.InternalServerErrorException;
 import bio.terra.pipelines.common.utils.CommonPipelineRunStatusEnum;
-import bio.terra.pipelines.common.utils.pagination.CursorBasedPageable;
-import bio.terra.pipelines.common.utils.pagination.FieldEqualsSpecification;
 import bio.terra.pipelines.common.utils.pagination.PageResponse;
-import bio.terra.pipelines.common.utils.pagination.PageSpecification;
 import bio.terra.pipelines.db.entities.Pipeline;
 import bio.terra.pipelines.db.entities.PipelineInput;
 import bio.terra.pipelines.db.entities.PipelineOutput;
@@ -510,12 +507,6 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
 
   @Test
   void findPipelineRunsPaginatedNoOtherPages() {
-    CursorBasedPageable cursorBasedPageable = new CursorBasedPageable(10, null, null);
-    PageSpecification<PipelineRun> pageSpecification =
-        new PageSpecification<>("id", cursorBasedPageable);
-    FieldEqualsSpecification<PipelineRun> userIdSpecification =
-        new FieldEqualsSpecification<>("userId", testUserId);
-
     PageResponse<List<PipelineRun>> pageResults =
         pipelineRunsService.findPipelineRunsPaginated(10, null, testUserId);
 

--- a/service/src/test/java/bio/terra/pipelines/service/PipelinesServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/PipelinesServiceTest.java
@@ -121,6 +121,7 @@ class PipelinesServiceTest extends BaseEmbeddedDbTest {
     List<Pipeline> pipelineList = pipelinesService.getPipelines();
     assertEquals(1, pipelineList.size());
     for (Pipeline p : pipelineList) {
+      // 17 and 31 are hardcoded in this hashCode method of this class
       assertEquals(
           new HashCodeBuilder(17, 31)
               .append(p.getId())


### PR DESCRIPTION
### Description 

this addes a getPipelineRuns endpoint that allows a user to query for the pipelineRuns they've created in a cursor based  paginated way.  This will return the most recent runs first followed by older runs.  Currently there is no extra filtering on type of pipeline but that can be done in the future if the UI/UX requires it but for now it will just return all pipelines associated to the user making the request.

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-262