### PR TITLE
Add WDL pipelines to Dockstore

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -2,18 +2,21 @@ version: 1.2
 workflows:
 
   - subclass: WDL
+    name: CompareVcfs
     primaryDescriptorPath: /pipelines/testing/CompareVcfs.wdl
     authors:
       - name: Terra Scientific Services
         email: teaspoons-developers@broadinstitute.org
 
   - subclass: WDL
+    name: ImputationBeagleEmpty
     primaryDescriptorPath: /pipelines/testing/ImputationBeagleEmpty.wdl
     authors:
       - name: Terra Scientific Services
         email: teaspoons-developers@broadinstitute.org
 
   - subclass: WDL
+    name: StdPopSim
     primaryDescriptorPath: /pipelines/simulatedData/StdPopSim.wdl
     authors:
       - name: Terra Scientific Services

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -1,14 +1,20 @@
 version: 1.2
 workflows:
 
-  - name: CompareVcfs
-    subclass: WDL
+  - subclass: WDL
     primaryDescriptorPath: /pipelines/testing/CompareVcfs.wdl
+    authors:
+      - name: Terra Scientific Services
+        email: teaspoons-developers@broadinstitute.org
 
-  - name: ImputationBeagleEmpty
-    subclass: WDL
+  - subclass: WDL
     primaryDescriptorPath: /pipelines/testing/ImputationBeagleEmpty.wdl
+    authors:
+      - name: Terra Scientific Services
+        email: teaspoons-developers@broadinstitute.org
 
-  - name: StdPopSim
-    subclass: WDL
+  - subclass: WDL
     primaryDescriptorPath: /pipelines/simulatedData/StdPopSim.wdl
+    authors:
+      - name: Terra Scientific Services
+        email: teaspoons-developers@broadinstitute.org

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -1,0 +1,14 @@
+version: 1.2
+workflows:
+
+  - name: CompareVcfs
+    subclass: WDL
+    primaryDescriptorPath: /pipelines/testing/CompareVcfs.wdl
+
+  - name: ImputationBeagleEmpty
+    subclass: WDL
+    primaryDescriptorPath: /pipelines/testing/ImputationBeagleEmpty.wdl
+
+  - name: StdPopSim
+    subclass: WDL
+    primaryDescriptorPath: /pipelines/simulatedData/StdPopSim.wdl


### PR DESCRIPTION
### Description 

In order to import workflows into GCP Terra workspaces, they need to be either in the Methods Repo (Agora) or Dockstore. Dockstore allows automatic updates via github, so that's what we're doing. This PR adds the required .dockstore.yml file to specify the workflows to sync in Dockstore. 

### Jira Ticket
