### PR TITLE
TSPS-300 store control workspace storage container url in db, update via admin api

### DIFF
--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -484,7 +484,7 @@ components:
       description: |
         Object containing the pipeline identifier, display name, description, and control workspace information for a Pipeline.
       type: object
-      required: [ pipelineName, displayName, description, workspaceProject, workspaceName ]
+      required: [ pipelineName, displayName, description, workspaceProject, workspaceName, workspaceStorageContainerUrl ]
       properties:
         pipelineName:
           $ref: "#/components/schemas/PipelineName"
@@ -496,6 +496,8 @@ components:
           $ref: "#/components/schemas/PipelineWorkspaceProject"
         workspaceName:
           $ref: "#/components/schemas/PipelineWorkspaceName"
+        workspaceStorageContainerUrl:
+          $ref: "#/components/schemas/PipelineWorkspaceStorageContainerUrl"
 
     AsyncPipelineRunResponse:
       description: Result of an asynchronous pipeline run request.
@@ -716,6 +718,12 @@ components:
       type: string
       format: string
 
+    PipelineWorkspaceStorageContainerUrl:
+      description: |
+          The URL of the workspace storage container (e.g. gs:// bucket path).
+      type: string
+      format: string
+
     PipelineWithDetails:
       description: |
         Object containing the pipeline identifier, display name, description, type, and required inputs of a Pipeline.
@@ -761,12 +769,14 @@ components:
       description: |
         json object containing the admin provided information to update a pipeline with
       type: object
-      required: [ workspaceProject, workspaceName ]
+      required: [ workspaceProject, workspaceName, workspaceStorageContainerUrl ]
       properties:
         workspaceProject:
           $ref: "#/components/schemas/PipelineWorkspaceProject"
         workspaceName:
           $ref: "#/components/schemas/PipelineWorkspaceName"
+        workspaceStorageContainerUrl:
+          $ref: "#/components/schemas/PipelineWorkspaceStorageContainerUrl"
 
     UserId:
       description: |

--- a/service/src/main/java/bio/terra/pipelines/app/controller/AdminApiController.java
+++ b/service/src/main/java/bio/terra/pipelines/app/controller/AdminApiController.java
@@ -67,9 +67,10 @@ public class AdminApiController implements AdminApi {
         PipelineApiUtils.validatePipelineName(pipelineName, logger);
     String workspaceProject = body.getWorkspaceProject();
     String workspaceName = body.getWorkspaceName();
+    String workspaceStorageContainerUrl = body.getWorkspaceStorageContainerUrl();
     Pipeline updatedPipeline =
         pipelinesService.updatePipelineWorkspace(
-            validatedPipelineName, workspaceProject, workspaceName);
+            validatedPipelineName, workspaceProject, workspaceName, workspaceStorageContainerUrl);
     return new ResponseEntity<>(pipelineToApiAdminPipeline(updatedPipeline), HttpStatus.OK);
   }
 
@@ -79,6 +80,7 @@ public class AdminApiController implements AdminApi {
         .displayName(pipeline.getDisplayName())
         .description(pipeline.getDescription())
         .workspaceProject(pipeline.getWorkspaceProject())
-        .workspaceName(pipeline.getWorkspaceName());
+        .workspaceName(pipeline.getWorkspaceName())
+        .workspaceStorageContainerUrl(pipeline.getWorkspaceStorageContainerUrl());
   }
 }

--- a/service/src/main/java/bio/terra/pipelines/db/entities/Pipeline.java
+++ b/service/src/main/java/bio/terra/pipelines/db/entities/Pipeline.java
@@ -56,6 +56,9 @@ public class Pipeline {
   @Column(name = "workspace_name")
   private String workspaceName;
 
+  @Column(name = "workspace_storage_container_url")
+  private String workspaceStorageContainerUrl;
+
   // Note: we fetch eagerly despite not always needing inputs definitions because
   // the number of inputs definitions is expected to be small. Beware using OneToMany with
   // eager fetch on large collections.
@@ -76,6 +79,7 @@ public class Pipeline {
       UUID workspaceId,
       String workspaceProject,
       String workspaceName,
+      String workspaceStorageContainerUrl,
       List<PipelineInputDefinition> pipelineInputDefinitions,
       List<PipelineOutputDefinition> pipelineOutputDefinitions) {
     this.name = name;
@@ -88,6 +92,7 @@ public class Pipeline {
     this.workspaceId = workspaceId;
     this.workspaceProject = workspaceProject;
     this.workspaceName = workspaceName;
+    this.workspaceStorageContainerUrl = workspaceStorageContainerUrl;
     this.pipelineInputDefinitions = pipelineInputDefinitions;
     this.pipelineOutputDefinitions = pipelineOutputDefinitions;
   }
@@ -105,6 +110,7 @@ public class Pipeline {
         .add("workspaceId=" + workspaceId)
         .add("workspaceProject=" + workspaceProject)
         .add("workspaceName=" + workspaceName)
+        .add("workspaceStorageContainerUrl=" + workspaceStorageContainerUrl)
         .toString();
   }
 
@@ -129,6 +135,7 @@ public class Pipeline {
         .append(workspaceId)
         .append(workspaceProject)
         .append(workspaceName)
+        .append(workspaceStorageContainerUrl)
         .toHashCode();
   }
 
@@ -149,6 +156,7 @@ public class Pipeline {
         .append(workspaceId, otherObject.workspaceId)
         .append(workspaceProject, otherObject.workspaceProject)
         .append(workspaceName, otherObject.workspaceName)
+        .append(workspaceStorageContainerUrl, otherObject.workspaceStorageContainerUrl)
         .isEquals();
   }
 

--- a/service/src/main/java/bio/terra/pipelines/service/PipelineRunsService.java
+++ b/service/src/main/java/bio/terra/pipelines/service/PipelineRunsService.java
@@ -85,7 +85,9 @@ public class PipelineRunsService {
 
     PipelinesEnum pipelineName = pipeline.getName();
 
-    if (pipeline.getWorkspaceProject() == null || pipeline.getWorkspaceName() == null) {
+    if (pipeline.getWorkspaceProject() == null
+        || pipeline.getWorkspaceName() == null
+        || pipeline.getWorkspaceStorageContainerUrl() == null) {
       throw new InternalServerErrorException("%s workspace not defined".formatted(pipelineName));
     }
 
@@ -95,11 +97,6 @@ public class PipelineRunsService {
               .formatted(jobId));
     }
 
-    // hardcode for now, ultimately fetch from Rawls or store in config?
-    // this is for dev control workspace:
-    // https://bvdp-saturn-dev.appspot.com/#workspaces/teaspoons-imputation-dev/teaspoons_imputation_dev_control_workspace_20240726
-    String workspaceStorageContainerUrl = "gs://fc-secure-972057b6-fce1-4ec9-be0c-0e5c97fdc3e8";
-
     // save the pipeline run to the database
     writeNewPipelineRunToDb(
         jobId,
@@ -107,7 +104,7 @@ public class PipelineRunsService {
         pipeline.getId(),
         pipeline.getWorkspaceProject(),
         pipeline.getWorkspaceName(),
-        workspaceStorageContainerUrl,
+        pipeline.getWorkspaceStorageContainerUrl(),
         userProvidedInputs);
 
     // increment the prepare metric for this pipeline

--- a/service/src/main/java/bio/terra/pipelines/service/PipelineRunsService.java
+++ b/service/src/main/java/bio/terra/pipelines/service/PipelineRunsService.java
@@ -126,7 +126,9 @@ public class PipelineRunsService {
 
     PipelinesEnum pipelineName = pipeline.getName();
 
-    if (pipeline.getWorkspaceProject() == null || pipeline.getWorkspaceName() == null) {
+    if (pipeline.getWorkspaceProject() == null
+        || pipeline.getWorkspaceName() == null
+        || pipeline.getWorkspaceStorageContainerUrl() == null) {
       throw new InternalServerErrorException("%s workspace not defined".formatted(pipelineName));
     }
 

--- a/service/src/main/java/bio/terra/pipelines/service/PipelinesService.java
+++ b/service/src/main/java/bio/terra/pipelines/service/PipelinesService.java
@@ -18,6 +18,7 @@ import bio.terra.pipelines.db.entities.Pipeline;
 import bio.terra.pipelines.db.entities.PipelineInputDefinition;
 import bio.terra.pipelines.db.entities.PipelineOutputDefinition;
 import bio.terra.pipelines.db.repositories.PipelinesRepository;
+import jakarta.validation.constraints.NotNull;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -30,9 +31,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
 
 /** The Pipelines Service manages information about the service's available Scientific Pipelines. */
 @Component
+@Validated
 public class PipelinesService {
   private static final Logger logger = LoggerFactory.getLogger(PipelinesService.class);
 
@@ -59,7 +62,7 @@ public class PipelinesService {
 
   /**
    * This method is meant to only be called by an admin endpoint to update the control workspace
-   * project and control workspace name for a pipeline.
+   * project, name, and storage container url for a given pipeline.
    *
    * @param pipelineName - name of pipeline to update
    * @param workspaceProject - workspace project to update to
@@ -68,9 +71,9 @@ public class PipelinesService {
    */
   public Pipeline updatePipelineWorkspace(
       PipelinesEnum pipelineName,
-      String workspaceProject,
-      String workspaceName,
-      String workspaceStorageContainerUrl) {
+      @NotNull String workspaceProject,
+      @NotNull String workspaceName,
+      @NotNull String workspaceStorageContainerUrl) {
     Pipeline pipeline = getPipeline(pipelineName);
     pipeline.setWorkspaceProject(workspaceProject);
     pipeline.setWorkspaceName(workspaceName);

--- a/service/src/main/java/bio/terra/pipelines/service/PipelinesService.java
+++ b/service/src/main/java/bio/terra/pipelines/service/PipelinesService.java
@@ -64,12 +64,17 @@ public class PipelinesService {
    * @param pipelineName - name of pipeline to update
    * @param workspaceProject - workspace project to update to
    * @param workspaceName - workspace name to update to
+   * @param workspaceStorageContainerUrl - workspace storage container URL to update to
    */
   public Pipeline updatePipelineWorkspace(
-      PipelinesEnum pipelineName, String workspaceProject, String workspaceName) {
+      PipelinesEnum pipelineName,
+      String workspaceProject,
+      String workspaceName,
+      String workspaceStorageContainerUrl) {
     Pipeline pipeline = getPipeline(pipelineName);
     pipeline.setWorkspaceProject(workspaceProject);
     pipeline.setWorkspaceName(workspaceName);
+    pipeline.setWorkspaceStorageContainerUrl(workspaceStorageContainerUrl);
     pipelinesRepository.save(pipeline);
     return pipeline;
   }

--- a/service/src/main/java/bio/terra/pipelines/stairway/imputation/steps/gcp/SubmitCromwellSubmissionStep.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/imputation/steps/gcp/SubmitCromwellSubmissionStep.java
@@ -78,8 +78,7 @@ public class SubmitCromwellSubmissionStep implements Step {
                     .formatted(
                         pipelineName, wdlMethodName, flightContext.getFlightId(), description))
             .methodConfigurationNamespace(controlWorkspaceProject)
-            .methodConfigurationName("ImputationBeagleEmpty"); // do not hardcode this after doing
-    // https://broadworkbench.atlassian.net/browse/TSPS-301
+            .methodConfigurationName(wdlMethodName);
 
     // submit workflow to rawls
     SubmissionReport submissionReport;

--- a/service/src/main/resources/db/changelog.xml
+++ b/service/src/main/resources/db/changelog.xml
@@ -21,6 +21,7 @@
   <include file="changesets/20240711_add_pipeline_output_definitions.yaml" relativeToChangelogFile="true"/>
   <include file="changesets/20240716_add_file_suffix_to_input_defs_and_update_FILE_types.yaml" relativeToChangelogFile="true"/>
   <include file="changesets/20240806_add_workspace_project_and_workspace_name.yaml" relativeToChangelogFile="true"/>
+  <include file="changesets/20240820_add_workspace_storage_container_url.yaml" relativeToChangelogFile="true"/>
 
   <include file="changesets/20240412-testdata.yaml" relativeToChangelogFile="true"/>
 

--- a/service/src/main/resources/db/changesets/20240820_add_workspace_storage_container_url.yaml
+++ b/service/src/main/resources/db/changesets/20240820_add_workspace_storage_container_url.yaml
@@ -1,0 +1,12 @@
+# Add workspace_storage_container_url to pipelines table
+databaseChangeLog:
+  - changeSet:
+      id: Add workspace_storage_container_url to pipelines table
+      author: mma
+      changes:
+        - addColumn:
+            tableName: pipelines
+            columns:
+              - column:
+                  name: workspace_storage_container_url
+                  type: text

--- a/service/src/test/java/bio/terra/pipelines/controller/AdminApiControllerTest.java
+++ b/service/src/test/java/bio/terra/pipelines/controller/AdminApiControllerTest.java
@@ -2,6 +2,7 @@ package bio.terra.pipelines.controller;
 
 import static bio.terra.pipelines.testutils.MockMvcUtils.TEST_WORKSPACE_NAME;
 import static bio.terra.pipelines.testutils.MockMvcUtils.TEST_WORKSPACE_PROJECT;
+import static bio.terra.pipelines.testutils.MockMvcUtils.TEST_WORKSPACE_STORAGE_CONTAINER_URL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -57,7 +58,10 @@ class AdminApiControllerTest {
   @Test
   void updatePipelineWorkspaceOk() throws Exception {
     when(pipelinesServiceMock.updatePipelineWorkspace(
-            PipelinesEnum.IMPUTATION_BEAGLE, TEST_WORKSPACE_PROJECT, TEST_WORKSPACE_NAME))
+            PipelinesEnum.IMPUTATION_BEAGLE,
+            TEST_WORKSPACE_PROJECT,
+            TEST_WORKSPACE_NAME,
+            TEST_WORKSPACE_STORAGE_CONTAINER_URL))
         .thenReturn(MockMvcUtils.getTestPipeline());
     MvcResult result =
         mockMvc
@@ -67,7 +71,11 @@ class AdminApiControllerTest {
                             "/api/admin/v1/pipeline/%s",
                             PipelinesEnum.IMPUTATION_BEAGLE.getValue()))
                     .contentType(MediaType.APPLICATION_JSON)
-                    .content(createTestJobPostBody(TEST_WORKSPACE_PROJECT, TEST_WORKSPACE_NAME)))
+                    .content(
+                        createTestJobPostBody(
+                            TEST_WORKSPACE_PROJECT,
+                            TEST_WORKSPACE_NAME,
+                            TEST_WORKSPACE_STORAGE_CONTAINER_URL)))
             .andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON))
             .andReturn();
@@ -80,6 +88,7 @@ class AdminApiControllerTest {
     // 200 status with a properly formatted response
     assertEquals(TEST_WORKSPACE_PROJECT, response.getWorkspaceProject());
     assertEquals(TEST_WORKSPACE_NAME, response.getWorkspaceName());
+    assertEquals(TEST_WORKSPACE_STORAGE_CONTAINER_URL, response.getWorkspaceStorageContainerUrl());
   }
 
   @Test
@@ -90,7 +99,9 @@ class AdminApiControllerTest {
                     String.format(
                         "/api/admin/v1/pipeline/%s", PipelinesEnum.IMPUTATION_BEAGLE.getValue()))
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(createTestJobPostBody(TEST_WORKSPACE_PROJECT, null)))
+                .content(
+                    createTestJobPostBody(
+                        TEST_WORKSPACE_PROJECT, null, TEST_WORKSPACE_STORAGE_CONTAINER_URL)))
         .andExpect(status().isBadRequest());
   }
 
@@ -102,7 +113,21 @@ class AdminApiControllerTest {
                     String.format(
                         "/api/admin/v1/pipeline/%s", PipelinesEnum.IMPUTATION_BEAGLE.getValue()))
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(createTestJobPostBody(null, TEST_WORKSPACE_NAME)))
+                .content(
+                    createTestJobPostBody(
+                        null, TEST_WORKSPACE_NAME, TEST_WORKSPACE_STORAGE_CONTAINER_URL)))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void updatePipelineWorkspaceIdRequireWorkspaceStorageContainerUrl() throws Exception {
+    mockMvc
+        .perform(
+            patch(
+                    String.format(
+                        "/api/admin/v1/pipeline/%s", PipelinesEnum.IMPUTATION_BEAGLE.getValue()))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(createTestJobPostBody(TEST_WORKSPACE_PROJECT, TEST_WORKSPACE_NAME, null)))
         .andExpect(status().isBadRequest());
   }
 
@@ -116,7 +141,11 @@ class AdminApiControllerTest {
                     String.format(
                         "/api/admin/v1/pipeline/%s", PipelinesEnum.IMPUTATION_BEAGLE.getValue()))
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(createTestJobPostBody(TEST_WORKSPACE_PROJECT, TEST_WORKSPACE_NAME)))
+                .content(
+                    createTestJobPostBody(
+                        TEST_WORKSPACE_PROJECT,
+                        TEST_WORKSPACE_NAME,
+                        TEST_WORKSPACE_STORAGE_CONTAINER_URL)))
         .andExpect(status().isForbidden());
   }
 
@@ -155,12 +184,14 @@ class AdminApiControllerTest {
         .andExpect(status().isForbidden());
   }
 
-  private String createTestJobPostBody(String workspaceProject, String workspaceName)
+  private String createTestJobPostBody(
+      String workspaceProject, String workspaceName, String workspaceStorageContainerUrl)
       throws JsonProcessingException {
     ApiUpdatePipelineRequestBody apiUpdatePipelineRequestBody =
         new ApiUpdatePipelineRequestBody()
             .workspaceProject(workspaceProject)
-            .workspaceName(workspaceName);
+            .workspaceName(workspaceName)
+            .workspaceStorageContainerUrl(workspaceStorageContainerUrl);
     return MockMvcUtils.convertToJsonString(apiUpdatePipelineRequestBody);
   }
 }

--- a/service/src/test/java/bio/terra/pipelines/service/PipelineRunsServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/PipelineRunsServiceTest.java
@@ -99,6 +99,7 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
             TestUtils.TEST_PIPELINE_1.getWorkspaceId(),
             TestUtils.TEST_PIPELINE_1.getWorkspaceProject(),
             TestUtils.TEST_PIPELINE_1.getWorkspaceName(),
+            TestUtils.TEST_PIPELINE_1.getWorkspaceStorageContainerUrl(),
             TestUtils.TEST_PIPELINE_1.getPipelineInputDefinitions(),
             TestUtils.TEST_PIPELINE_1.getPipelineOutputDefinitions());
     pipeline.setId(3L);

--- a/service/src/test/java/bio/terra/pipelines/service/PipelineRunsServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/PipelineRunsServiceTest.java
@@ -236,6 +236,19 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
         () ->
             pipelineRunsService.preparePipelineRun(
                 testPipelineWithIdMissingWorkspaceName, testJobId, testUserId, testPipelineInputs));
+
+    // missing workspace storage container url
+    Pipeline testPipelineWithIdMissingWorkspaceStorageContainerUrl = createTestPipelineWithId();
+    testPipelineWithIdMissingWorkspaceStorageContainerUrl.setWorkspaceStorageContainerUrl(null);
+
+    assertThrows(
+        InternalServerErrorException.class,
+        () ->
+            pipelineRunsService.preparePipelineRun(
+                testPipelineWithIdMissingWorkspaceStorageContainerUrl,
+                testJobId,
+                testUserId,
+                testPipelineInputs));
   }
 
   @Test
@@ -353,6 +366,20 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
         () ->
             pipelineRunsService.startPipelineRun(
                 testPipelineWithIdMissingWorkspaceName,
+                testJobId,
+                testUserId,
+                testDescription,
+                testResultUrl));
+
+    // missing workspace storage container url
+    Pipeline testPipelineWithIdMissingWorkspaceStorageContainerUrl = createTestPipelineWithId();
+    testPipelineWithIdMissingWorkspaceStorageContainerUrl.setWorkspaceStorageContainerUrl(null);
+
+    assertThrows(
+        InternalServerErrorException.class,
+        () ->
+            pipelineRunsService.startPipelineRun(
+                testPipelineWithIdMissingWorkspaceStorageContainerUrl,
                 testJobId,
                 testUserId,
                 testDescription,

--- a/service/src/test/java/bio/terra/pipelines/service/PipelinesServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/PipelinesServiceTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
@@ -26,6 +25,7 @@ import bio.terra.pipelines.db.entities.PipelineOutputDefinition;
 import bio.terra.pipelines.db.repositories.PipelinesRepository;
 import bio.terra.pipelines.testutils.BaseEmbeddedDbTest;
 import bio.terra.pipelines.testutils.TestUtils;
+import jakarta.validation.ConstraintViolationException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -178,7 +178,7 @@ class PipelinesServiceTest extends BaseEmbeddedDbTest {
   }
 
   @Test
-  void updatePipelineWorkspaceNullValue() {
+  void updatePipelineWorkspaceNullValueThrows() {
     PipelinesEnum pipelinesEnum = PipelinesEnum.IMPUTATION_BEAGLE;
     Pipeline p = pipelinesService.getPipeline(pipelinesEnum);
 
@@ -187,14 +187,11 @@ class PipelinesServiceTest extends BaseEmbeddedDbTest {
     // make sure the current pipeline does not have the workspace info we're trying to update with
     assertNotEquals(newWorkspaceName, p.getWorkspaceName());
 
-    // update pipeline info including null workspaceProject and workspaceStorageContainerUrl
-    pipelinesService.updatePipelineWorkspace(pipelinesEnum, null, newWorkspaceName, null);
-    p = pipelinesService.getPipeline(pipelinesEnum);
-
-    // assert the new workspace info has been updated
-    assertNull(p.getWorkspaceProject());
-    assertEquals(newWorkspaceName, p.getWorkspaceName());
-    assertNull(p.getWorkspaceStorageContainerUrl());
+    // attempt to update pipeline info including null values should fail
+    assertThrows(
+        ConstraintViolationException.class,
+        () ->
+            pipelinesService.updatePipelineWorkspace(pipelinesEnum, null, newWorkspaceName, null));
   }
 
   static final String REQUIRED_STRING_INPUT_NAME = "outputBasename";

--- a/service/src/test/java/bio/terra/pipelines/service/PipelinesServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/PipelinesServiceTest.java
@@ -54,6 +54,7 @@ class PipelinesServiceTest extends BaseEmbeddedDbTest {
     UUID workspaceId = UUID.randomUUID();
     String workspaceProject = "testTerraProject";
     String workspaceName = "testTerraWorkspaceName";
+    String workspaceStorageContainerUrl = "testWorkspaceStorageContainerUrl";
 
     // save a new version of the same pipeline
     pipelinesRepository.save(
@@ -68,6 +69,7 @@ class PipelinesServiceTest extends BaseEmbeddedDbTest {
             workspaceId,
             workspaceProject,
             workspaceName,
+            workspaceStorageContainerUrl,
             null,
             null));
 
@@ -110,7 +112,7 @@ class PipelinesServiceTest extends BaseEmbeddedDbTest {
     for (Pipeline p : pipelineList) {
       assertEquals(
           String.format(
-              "Pipeline[pipelineName=%s, version=%s, displayName=%s, description=%s, pipelineType=%s, wdlUrl=%s, wdlMethodName=%s, workspaceId=%s, workspaceProject=%s, workspaceName=%s]",
+              "Pipeline[pipelineName=%s, version=%s, displayName=%s, description=%s, pipelineType=%s, wdlUrl=%s, wdlMethodName=%s, workspaceId=%s, workspaceProject=%s, workspaceName=%s, workspaceStorageContainerUrl=%s]",
               p.getName(),
               p.getVersion(),
               p.getDisplayName(),
@@ -120,7 +122,8 @@ class PipelinesServiceTest extends BaseEmbeddedDbTest {
               p.getWdlMethodName(),
               p.getWorkspaceId(),
               p.getWorkspaceProject(),
-              p.getWorkspaceName()),
+              p.getWorkspaceName(),
+              p.getWorkspaceStorageContainerUrl()),
           p.toString());
     }
   }
@@ -144,6 +147,7 @@ class PipelinesServiceTest extends BaseEmbeddedDbTest {
               .append(p.getWorkspaceId())
               .append(p.getWorkspaceProject())
               .append(p.getWorkspaceName())
+              .append(p.getWorkspaceStorageContainerUrl())
               .toHashCode(),
           p.hashCode());
     }
@@ -155,18 +159,22 @@ class PipelinesServiceTest extends BaseEmbeddedDbTest {
     Pipeline p = pipelinesService.getPipeline(pipelinesEnum);
     String newWorkspaceProject = "newTestTerraProject";
     String newWorkspaceName = "newTestTerraWorkspaceName";
+    String newWorkspaceStorageContainerUrl = "newTestWorkspaceStorageContainerUrl";
 
     // make sure the current pipeline does not have the workspace info we're trying to update with
     assertNotEquals(newWorkspaceProject, p.getWorkspaceProject());
     assertNotEquals(newWorkspaceName, p.getWorkspaceName());
+    assertNotEquals(newWorkspaceStorageContainerUrl, p.getWorkspaceStorageContainerUrl());
 
     // update pipeline workspace id
-    pipelinesService.updatePipelineWorkspace(pipelinesEnum, newWorkspaceProject, newWorkspaceName);
+    pipelinesService.updatePipelineWorkspace(
+        pipelinesEnum, newWorkspaceProject, newWorkspaceName, newWorkspaceStorageContainerUrl);
     p = pipelinesService.getPipeline(pipelinesEnum);
 
     // assert the workspace info has been updated
     assertEquals(newWorkspaceProject, p.getWorkspaceProject());
     assertEquals(newWorkspaceName, p.getWorkspaceName());
+    assertEquals(newWorkspaceStorageContainerUrl, p.getWorkspaceStorageContainerUrl());
   }
 
   @Test
@@ -179,13 +187,14 @@ class PipelinesServiceTest extends BaseEmbeddedDbTest {
     // make sure the current pipeline does not have the workspace info we're trying to update with
     assertNotEquals(newWorkspaceName, p.getWorkspaceName());
 
-    // update pipeline info including null workspaceProject
-    pipelinesService.updatePipelineWorkspace(pipelinesEnum, null, newWorkspaceName);
+    // update pipeline info including null workspaceProject and workspaceStorageContainerUrl
+    pipelinesService.updatePipelineWorkspace(pipelinesEnum, null, newWorkspaceName, null);
     p = pipelinesService.getPipeline(pipelinesEnum);
 
     // assert the new workspace info has been updated
     assertNull(p.getWorkspaceProject());
     assertEquals(newWorkspaceName, p.getWorkspaceName());
+    assertNull(p.getWorkspaceStorageContainerUrl());
   }
 
   static final String REQUIRED_STRING_INPUT_NAME = "outputBasename";

--- a/service/src/test/java/bio/terra/pipelines/testutils/MockMvcUtils.java
+++ b/service/src/test/java/bio/terra/pipelines/testutils/MockMvcUtils.java
@@ -48,6 +48,7 @@ public class MockMvcUtils {
       UUID.fromString("94fd136b-1234-1234-1234-76d8a2811066");
   public static final String TEST_WORKSPACE_PROJECT = "testTerraProject";
   public static final String TEST_WORKSPACE_NAME = "testTerraWorkspaceName";
+  public static final String TEST_WORKSPACE_STORAGE_CONTAINER_URL = "gs://test-bucket";
   // using this function to build a pipeline with a value set for the id field.  Normally this would
   // be populated
   // by calling `save()` from the repository but since these tests mock that out, we have to set the
@@ -66,6 +67,7 @@ public class MockMvcUtils {
             TEST_WORKSPACE_UUID,
             TEST_WORKSPACE_PROJECT,
             TEST_WORKSPACE_NAME,
+            TEST_WORKSPACE_STORAGE_CONTAINER_URL,
             TestUtils.TEST_PIPELINE_INPUTS_DEFINITION_LIST,
             TestUtils.TEST_PIPELINE_OUTPUTS_DEFINITION_LIST);
     testPipeline.setId(2L);

--- a/service/src/test/java/bio/terra/pipelines/testutils/TestUtils.java
+++ b/service/src/test/java/bio/terra/pipelines/testutils/TestUtils.java
@@ -41,7 +41,7 @@ public class TestUtils {
   public static final String CONTROL_WORKSPACE_PROJECT = "testTerraProject";
   public static final String CONTROL_WORKSPACE_NAME = "testTerraWorkspaceName";
   public static final String CONTROL_WORKSPACE_STORAGE_CONTAINER_URL =
-      "https://lz123.stuff/sc-%s".formatted(CONTROL_WORKSPACE_ID);
+      "gs://fc-secure-%s".formatted(CONTROL_WORKSPACE_ID);
   public static final Map<String, String> TEST_PIPELINE_OUTPUTS =
       new HashMap(
           Map.of(
@@ -124,6 +124,7 @@ public class TestUtils {
           TEST_WORKSPACE_ID_1,
           CONTROL_WORKSPACE_PROJECT,
           CONTROL_WORKSPACE_NAME,
+          CONTROL_WORKSPACE_STORAGE_CONTAINER_URL,
           TEST_PIPELINE_INPUTS_DEFINITION_LIST,
           TEST_PIPELINE_OUTPUTS_DEFINITION_LIST);
   public static final Pipeline TEST_PIPELINE_2 =
@@ -138,6 +139,7 @@ public class TestUtils {
           TEST_WORKSPACE_ID_2,
           CONTROL_WORKSPACE_PROJECT,
           CONTROL_WORKSPACE_NAME,
+          CONTROL_WORKSPACE_STORAGE_CONTAINER_URL,
           TEST_PIPELINE_INPUTS_DEFINITION_LIST,
           TEST_PIPELINE_OUTPUTS_DEFINITION_LIST);
 


### PR DESCRIPTION
### Description 

Rather than hardcoding the control workspace's storage container (bucket) url, we now store it in the db and can update it via an admin API.

We require all the workspace values to be provided in the admin update api to be not null.

Also an add-on update to https://github.com/DataBiosphere/terra-scientific-pipelines-service/pull/112 now that we have an "emptyWDL" dev control workspace to use that has the correct WDL method name.

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-300