### PR TITLE
TSPS-306 getResult returns signed urls for all outputs

### DIFF
--- a/service/src/main/java/bio/terra/pipelines/common/utils/FileUtils.java
+++ b/service/src/main/java/bio/terra/pipelines/common/utils/FileUtils.java
@@ -12,23 +12,26 @@ public class FileUtils {
   private static final String USER_PROVIDED_FILE_INPUT_DIRECTORY = "user-input-files";
 
   /**
-   * Extract the blob name from the full file path, using the workspaceId as a delimiter.
+   * Extract the blob name from the full file path, using a defined delimiter.
    *
-   * <p>For example, `https://lz123.blob.core.windows.net/sc-{workspaceId}/path/to/file` becomes
-   * `path/to/file`
+   * <p>For example, in Azure, with workspaceId as the delimiter,
+   * `https://lz123.blob.core.windows.net/sc-{workspaceDelimiter}/path/to/file` becomes
+   * `path/to/file`.
+   *
+   * <p>In GCP, with workspaceStorageContainerName as the delimiter
+   * `gs://{workspaceDelimiter}/path/to/file` becomes `path/to/file`.
    *
    * @param blobHttpUrl
-   * @param workspaceId
+   * @param delimiter
    * @return blobName
    */
   public static String getBlobNameFromTerraWorkspaceStorageHttpUrl(
-      String blobHttpUrl, UUID workspaceId) {
-    if (!blobHttpUrl.contains(workspaceId.toString())) {
+      String blobHttpUrl, String delimiter) {
+    if (!blobHttpUrl.contains(delimiter)) {
       throw new InternalServerErrorException(
-          "File path and workspaceId do not match. Cannot extract blob name.");
+          "File path and delimiter do not match. Cannot extract blob name.");
     }
-    return blobHttpUrl.substring(
-        blobHttpUrl.indexOf(workspaceId.toString()) + workspaceId.toString().length() + 1);
+    return blobHttpUrl.substring(blobHttpUrl.indexOf(delimiter) + delimiter.length() + 1);
   }
 
   /**

--- a/service/src/main/java/bio/terra/pipelines/common/utils/FileUtils.java
+++ b/service/src/main/java/bio/terra/pipelines/common/utils/FileUtils.java
@@ -12,26 +12,50 @@ public class FileUtils {
   private static final String USER_PROVIDED_FILE_INPUT_DIRECTORY = "user-input-files";
 
   /**
-   * Extract the blob name from the full file path, using a defined delimiter.
+   * Extract the blob name from the full Azure file path, using the workspaceId as a delimiter.
    *
-   * <p>For example, in Azure, with workspaceId as the delimiter,
+   * <p>For example, with workspaceId as the workspaceSubstringStart,
    * `https://lz123.blob.core.windows.net/sc-{workspaceDelimiter}/path/to/file` becomes
    * `path/to/file`.
    *
-   * <p>In GCP, with workspaceStorageContainerName as the delimiter
+   * @param blobUrl
+   * @param workspaceId
+   */
+  public static String getBlobNameFromTerraWorkspaceStorageUrlAzure(
+      String blobUrl, String workspaceId) {
+    return getBlobNameFromTerraWorkspaceStorageUrl(blobUrl, workspaceId);
+  }
+
+  /**
+   * Extract the blob name from the full GCP file path, using the workspaceStorageContainerName as a
+   * delimiter.
+   *
+   * <p>For example, with workspaceStorageContainerName as the workspaceSubstringStart,
    * `gs://{workspaceDelimiter}/path/to/file` becomes `path/to/file`.
    *
-   * @param blobHttpUrl
-   * @param delimiter
+   * @param blobUrl
+   * @param workspaceStorageContainerName
+   */
+  public static String getBlobNameFromTerraWorkspaceStorageUrlGcp(
+      String blobUrl, String workspaceStorageContainerName) {
+    return getBlobNameFromTerraWorkspaceStorageUrl(blobUrl, workspaceStorageContainerName);
+  }
+
+  /**
+   * Extract the blob name from the full file path, using a defined workspaceSubstringStart.
+   *
+   * @param blobUrl
+   * @param workspaceSubstringStart
    * @return blobName
    */
-  public static String getBlobNameFromTerraWorkspaceStorageHttpUrl(
-      String blobHttpUrl, String delimiter) {
-    if (!blobHttpUrl.contains(delimiter)) {
+  private static String getBlobNameFromTerraWorkspaceStorageUrl(
+      String blobUrl, String workspaceSubstringStart) {
+    if (!blobUrl.contains(workspaceSubstringStart)) {
       throw new InternalServerErrorException(
-          "File path and delimiter do not match. Cannot extract blob name.");
+          "File path and workspaceSubstringStart do not match. Cannot extract blob name.");
     }
-    return blobHttpUrl.substring(blobHttpUrl.indexOf(delimiter) + delimiter.length() + 1);
+    return blobUrl.substring(
+        blobUrl.indexOf(workspaceSubstringStart) + workspaceSubstringStart.length() + 1);
   }
 
   /**

--- a/service/src/main/java/bio/terra/pipelines/dependencies/gcs/GcsService.java
+++ b/service/src/main/java/bio/terra/pipelines/dependencies/gcs/GcsService.java
@@ -72,7 +72,7 @@ public class GcsService {
 
     // remove the signature from the URL before logging
     String cleanUrl = url.toString().split("X-Goog-Signature=")[0] + "X-Goog-Signature=REDACTED";
-    logger.info("Generated PUT signed URL: {}", url);
+    logger.info("Generated PUT signed URL: {}", cleanUrl);
 
     return url;
   }

--- a/service/src/main/java/bio/terra/pipelines/dependencies/gcs/GcsService.java
+++ b/service/src/main/java/bio/terra/pipelines/dependencies/gcs/GcsService.java
@@ -72,7 +72,8 @@ public class GcsService {
                         Storage.SignUrlOption.withExtHeaders(extensionHeaders),
                         Storage.SignUrlOption.withV4Signature()));
 
-    logger.info("Generated PUT signed URL: {}", cleanSignedUrl(url));
+    String cleanSignedUrlString = cleanSignedUrl(url);
+    logger.info("Generated PUT signed URL: {}", cleanSignedUrlString);
 
     return url;
   }
@@ -109,7 +110,8 @@ public class GcsService {
                         Storage.SignUrlOption.httpMethod(HttpMethod.GET),
                         Storage.SignUrlOption.withV4Signature()));
 
-    logger.info("Generated GET signed URL: {}", cleanSignedUrl(url));
+    String cleanSignedUrlString = cleanSignedUrl(url);
+    logger.info("Generated GET signed URL: {}", cleanSignedUrlString);
 
     return url;
   }

--- a/service/src/main/java/bio/terra/pipelines/dependencies/rawls/RawlsService.java
+++ b/service/src/main/java/bio/terra/pipelines/dependencies/rawls/RawlsService.java
@@ -94,6 +94,20 @@ public class RawlsService implements HealthCheck {
                 .createEntity(entity, workspaceNamespace, workspaceName));
   }
 
+  public Entity getDataTableEntity(
+      String accessToken,
+      String workspaceNamespace,
+      String workspaceName,
+      String entityType,
+      String entityName) {
+    return executionWithRetryTemplate(
+        listenerResetRetryTemplate,
+        () ->
+            rawlsClient
+                .getEntitiesApi(accessToken)
+                .getEntity(workspaceNamespace, workspaceName, entityType, entityName, null, null));
+  }
+
   // returns true if submission is in a running state
   public static boolean submissionIsRunning(Submission submission) {
     return !FINAL_RUN_STATES.contains(submission.getStatus());

--- a/service/src/main/java/bio/terra/pipelines/service/PipelineRunsService.java
+++ b/service/src/main/java/bio/terra/pipelines/service/PipelineRunsService.java
@@ -414,8 +414,13 @@ public class PipelineRunsService {
     for (PipelineOutputDefinition outputDefinition : pipelineOutputDefinitions) {
       String keyName = outputDefinition.getName();
       String wdlVariableName = outputDefinition.getWdlVariableName();
-      String outputValue = (String) entity.getAttributes().get(wdlVariableName);
-      if (outputValue == null || outputValue.isEmpty()) {
+      String outputValue =
+          (String)
+              entity
+                  .getAttributes()
+                  .get(wdlVariableName); // .get() returns null if the key is missing, or if the
+      // value is empty
+      if (outputValue == null) {
         throw new InternalServerErrorException(
             "Output %s is empty or missing".formatted(wdlVariableName));
       }

--- a/service/src/main/java/bio/terra/pipelines/service/PipelineRunsService.java
+++ b/service/src/main/java/bio/terra/pipelines/service/PipelineRunsService.java
@@ -1,7 +1,7 @@
 package bio.terra.pipelines.service;
 
 import static bio.terra.pipelines.common.utils.FileUtils.constructDestinationBlobNameForUserInputFile;
-import static bio.terra.pipelines.common.utils.FileUtils.getBlobNameFromTerraWorkspaceStorageHttpUrl;
+import static bio.terra.pipelines.common.utils.FileUtils.getBlobNameFromTerraWorkspaceStorageUrlGcp;
 import static java.util.Collections.emptyList;
 import static org.springframework.data.domain.PageRequest.ofSize;
 
@@ -409,7 +409,7 @@ public class PipelineRunsService {
         pipelineRunOutputsAsMap(
             pipelineOutputsRepository.findPipelineOutputsByJobId(pipelineRun.getId()).getOutputs());
 
-    // currently all outputs are paths that will need a SAS token
+    // currently all outputs are paths that will need a signed url
     String workspaceStorageContainerName = pipelineRun.getWorkspaceStorageContainerName();
     outputsMap.replaceAll(
         (k, v) ->
@@ -417,7 +417,7 @@ public class PipelineRunsService {
                 .generateGetObjectSignedUrl(
                     pipelineRun.getWorkspaceGoogleProject(),
                     workspaceStorageContainerName,
-                    getBlobNameFromTerraWorkspaceStorageHttpUrl(v, workspaceStorageContainerName))
+                    getBlobNameFromTerraWorkspaceStorageUrlGcp(v, workspaceStorageContainerName))
                 .toString());
 
     ApiPipelineRunOutputs apiPipelineRunOutputs = new ApiPipelineRunOutputs();

--- a/service/src/main/java/bio/terra/pipelines/stairway/imputation/RunImputationGcpJobFlight.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/imputation/RunImputationGcpJobFlight.java
@@ -5,8 +5,10 @@ import bio.terra.pipelines.common.utils.FlightBeanBag;
 import bio.terra.pipelines.common.utils.FlightUtils;
 import bio.terra.pipelines.common.utils.PipelinesEnum;
 import bio.terra.pipelines.dependencies.stairway.JobMapKeys;
+import bio.terra.pipelines.stairway.imputation.steps.CompletePipelineRunStep;
 import bio.terra.pipelines.stairway.imputation.steps.PrepareImputationInputsStep;
 import bio.terra.pipelines.stairway.imputation.steps.gcp.AddDataTableRowStep;
+import bio.terra.pipelines.stairway.imputation.steps.gcp.FetchOutputsFromDataTableStep;
 import bio.terra.pipelines.stairway.imputation.steps.gcp.PollCromwellSubmissionStatusStep;
 import bio.terra.pipelines.stairway.imputation.steps.gcp.SubmitCromwellSubmissionStep;
 import bio.terra.stairway.Flight;
@@ -71,5 +73,11 @@ public class RunImputationGcpJobFlight extends Flight {
             flightBeanBag.getRawlsService(),
             flightBeanBag.getImputationConfiguration()),
         dbRetryRule);
+
+    addStep(
+        new FetchOutputsFromDataTableStep(
+            flightBeanBag.getRawlsService(), flightBeanBag.getSamService()));
+
+    addStep(new CompletePipelineRunStep(flightBeanBag.getPipelineRunsService()), dbRetryRule);
   }
 }

--- a/service/src/main/java/bio/terra/pipelines/stairway/imputation/RunImputationGcpJobFlight.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/imputation/RunImputationGcpJobFlight.java
@@ -88,7 +88,9 @@ public class RunImputationGcpJobFlight extends Flight {
 
     addStep(
         new FetchOutputsFromDataTableStep(
-            flightBeanBag.getRawlsService(), flightBeanBag.getSamService()),
+            flightBeanBag.getRawlsService(),
+            flightBeanBag.getSamService(),
+            flightBeanBag.getPipelineRunsService()),
         externalServiceRetryRule);
 
     addStep(new CompletePipelineRunStep(flightBeanBag.getPipelineRunsService()), dbRetryRule);

--- a/service/src/main/java/bio/terra/pipelines/stairway/imputation/steps/gcp/FetchOutputsFromDataTableStep.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/imputation/steps/gcp/FetchOutputsFromDataTableStep.java
@@ -77,8 +77,9 @@ public class FetchOutputsFromDataTableStep implements Step {
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, e);
     }
 
-    // this will throw an error and fail without retries if any of the output definitions are not
-    // found or empty
+    // this will throw an error and fail the task without retries if any of the output definitions
+    // are
+    // missing or empty
     Map<String, String> outputs =
         pipelineRunsService.extractPipelineOutputsFromEntity(outputDefinitions, entity);
 

--- a/service/src/main/java/bio/terra/pipelines/stairway/imputation/steps/gcp/FetchOutputsFromDataTableStep.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/imputation/steps/gcp/FetchOutputsFromDataTableStep.java
@@ -1,0 +1,95 @@
+package bio.terra.pipelines.stairway.imputation.steps.gcp;
+
+import bio.terra.pipelines.common.utils.FlightUtils;
+import bio.terra.pipelines.common.utils.PipelinesEnum;
+import bio.terra.pipelines.db.entities.PipelineOutputDefinition;
+import bio.terra.pipelines.dependencies.rawls.RawlsService;
+import bio.terra.pipelines.dependencies.rawls.RawlsServiceApiException;
+import bio.terra.pipelines.dependencies.sam.SamService;
+import bio.terra.pipelines.dependencies.stairway.JobMapKeys;
+import bio.terra.pipelines.stairway.imputation.RunImputationJobFlightMapKeys;
+import bio.terra.rawls.model.Entity;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.StepStatus;
+import com.fasterxml.jackson.core.type.TypeReference;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * This step calls Rawls to fetch outputs from a data table row for a given job and stores them in
+ * the flight's working map. These outputs are considered raw in that they are cloud paths and not
+ * signed urls.
+ */
+public class FetchOutputsFromDataTableStep implements Step {
+
+  private final RawlsService rawlsService;
+  private final SamService samService;
+
+  public FetchOutputsFromDataTableStep(RawlsService rawlsService, SamService samService) {
+    this.rawlsService = rawlsService;
+    this.samService = samService;
+  }
+
+  @Override
+  @SuppressWarnings(
+      "java:S2259") // suppress warning for possible NPE when calling pipelineName.getValue(),
+  //  since we do validate that pipelineName is not null in `validateRequiredEntries`
+  public StepResult doStep(FlightContext flightContext) {
+    String jobId = flightContext.getFlightId();
+
+    // validate and extract parameters from input map
+    var inputParameters = flightContext.getInputParameters();
+    FlightUtils.validateRequiredEntries(
+        inputParameters,
+        JobMapKeys.PIPELINE_NAME.getKeyName(),
+        RunImputationJobFlightMapKeys.CONTROL_WORKSPACE_BILLING_PROJECT,
+        RunImputationJobFlightMapKeys.CONTROL_WORKSPACE_NAME,
+        RunImputationJobFlightMapKeys.PIPELINE_OUTPUT_DEFINITIONS);
+
+    String controlWorkspaceBillingProject =
+        inputParameters.get(
+            RunImputationJobFlightMapKeys.CONTROL_WORKSPACE_BILLING_PROJECT, String.class);
+    String controlWorkspaceName =
+        inputParameters.get(RunImputationJobFlightMapKeys.CONTROL_WORKSPACE_NAME, String.class);
+    PipelinesEnum pipelineName =
+        inputParameters.get(JobMapKeys.PIPELINE_NAME.getKeyName(), PipelinesEnum.class);
+    List<PipelineOutputDefinition> outputDefinitions =
+        inputParameters.get(
+            RunImputationJobFlightMapKeys.PIPELINE_OUTPUT_DEFINITIONS, new TypeReference<>() {});
+
+    Entity entity;
+    try {
+      entity =
+          rawlsService.getDataTableEntity(
+              samService.getTeaspoonsServiceAccountToken(),
+              controlWorkspaceBillingProject,
+              controlWorkspaceName,
+              pipelineName.getValue(),
+              jobId);
+    } catch (RawlsServiceApiException e) {
+      return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, e);
+    }
+
+    Map<String, String> outputs = new HashMap<>();
+    for (PipelineOutputDefinition outputDefinition : outputDefinitions) {
+      String keyName = outputDefinition.getName();
+      String wdlVariableName = outputDefinition.getWdlVariableName();
+      outputs.put(keyName, entity.getAttributes().get(wdlVariableName).toString());
+    }
+
+    FlightMap workingMap = flightContext.getWorkingMap();
+    workingMap.put(RunImputationJobFlightMapKeys.PIPELINE_RUN_OUTPUTS, outputs);
+
+    return StepResult.getStepResultSuccess();
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext flightContext) {
+    // nothing to undo
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/service/src/main/java/bio/terra/pipelines/stairway/imputation/steps/gcp/FetchOutputsFromDataTableStep.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/imputation/steps/gcp/FetchOutputsFromDataTableStep.java
@@ -1,6 +1,5 @@
 package bio.terra.pipelines.stairway.imputation.steps.gcp;
 
-import bio.terra.common.exception.InternalServerErrorException;
 import bio.terra.pipelines.common.utils.FlightUtils;
 import bio.terra.pipelines.common.utils.PipelinesEnum;
 import bio.terra.pipelines.db.entities.PipelineOutputDefinition;
@@ -78,13 +77,10 @@ public class FetchOutputsFromDataTableStep implements Step {
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, e);
     }
 
-    // this will throw an error if any of the output definitions are not found or empty
-    Map<String, String> outputs;
-    try {
-      outputs = pipelineRunsService.extractPipelineOutputsFromEntity(outputDefinitions, entity);
-    } catch (InternalServerErrorException e) {
-      return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, e);
-    }
+    // this will throw an error and fail without retries if any of the output definitions are not
+    // found or empty
+    Map<String, String> outputs =
+        pipelineRunsService.extractPipelineOutputsFromEntity(outputDefinitions, entity);
 
     FlightMap workingMap = flightContext.getWorkingMap();
     workingMap.put(RunImputationJobFlightMapKeys.PIPELINE_RUN_OUTPUTS, outputs);

--- a/service/src/test/java/bio/terra/pipelines/common/utils/FileUtilsTest.java
+++ b/service/src/test/java/bio/terra/pipelines/common/utils/FileUtilsTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test;
 class FileUtilsTest extends BaseTest {
 
   @Test
-  void getBlobNameFromTerraWorkspaceStorageHttpUrlAzure() {
+  void getBlobNameFromTerraWorkspaceStorageUrlAzure() {
     String fullPath =
         "https://lze96253b07f13c61ef712bb.blob.core.windows.net/sc-68a43bd8-e744-4f1e-87a5-c44ecef157a3/workspace-services/cbas/terra-app-b1740821-d6e9-44b5-b53b-960953dea218/ImputationBeagle/1adb690d-3d02-4d4a-9dfa-17a31edd74f3/call-WriteEmptyFile/cacheCopy/execution/empty_file";
     String controlWorkspaceIdForDelimiter = "68a43bd8-e744-4f1e-87a5-c44ecef157a3";
@@ -19,12 +19,12 @@ class FileUtilsTest extends BaseTest {
         "workspace-services/cbas/terra-app-b1740821-d6e9-44b5-b53b-960953dea218/ImputationBeagle/1adb690d-3d02-4d4a-9dfa-17a31edd74f3/call-WriteEmptyFile/cacheCopy/execution/empty_file";
     assertEquals(
         expectedBlobName,
-        FileUtils.getBlobNameFromTerraWorkspaceStorageHttpUrl(
+        FileUtils.getBlobNameFromTerraWorkspaceStorageUrlAzure(
             fullPath, controlWorkspaceIdForDelimiter));
   }
 
   @Test
-  void getBlobNameFromTerraWorkspaceStorageHttpUrlDifferentWorkspaceAzure() {
+  void getBlobNameFromTerraWorkspaceStorageUrlDifferentWorkspaceAzure() {
     String fullPath =
         "https://lze96253b07f13c61ef712bb.blob.core.windows.net/sc-68a43bd8-e744-4f1e-87a5-c44ecef157a3/workspace-services/cbas/terra-app-b1740821-d6e9-44b5-b53b-960953dea218/ImputationBeagle/1adb690d-3d02-4d4a-9dfa-17a31edd74f3/call-WriteEmptyFile/cacheCopy/execution/empty_file";
     String wrongWorkspaceIdForDelimiter = "11111111-1111-1111-1111-111111111111";
@@ -32,12 +32,12 @@ class FileUtilsTest extends BaseTest {
     assertThrows(
         InternalServerErrorException.class,
         () ->
-            FileUtils.getBlobNameFromTerraWorkspaceStorageHttpUrl(
+            FileUtils.getBlobNameFromTerraWorkspaceStorageUrlAzure(
                 fullPath, wrongWorkspaceIdForDelimiter));
   }
 
   @Test
-  void getBlobNameFromTerraWorkspaceStorageHttpUrlGcp() {
+  void getBlobNameFromTerraWorkspaceStorageUrlGcp() {
     String fullPath =
         "gs://fc-secure-68a43bd8-e744-4f1e-87a5-c44ecef157a3/workspace-services/cbas/terra-app-b1740821-d6e9-44b5-b53b-960953dea218/ImputationBeagle/1adb690d-3d02-4d4a-9dfa-17a31edd74f3/call-WriteEmptyFile/cacheCopy/execution/empty_file";
     String controlWorkspaceStorageContainerNameForDelimiter =
@@ -46,12 +46,12 @@ class FileUtilsTest extends BaseTest {
         "workspace-services/cbas/terra-app-b1740821-d6e9-44b5-b53b-960953dea218/ImputationBeagle/1adb690d-3d02-4d4a-9dfa-17a31edd74f3/call-WriteEmptyFile/cacheCopy/execution/empty_file";
     assertEquals(
         expectedBlobName,
-        FileUtils.getBlobNameFromTerraWorkspaceStorageHttpUrl(
+        FileUtils.getBlobNameFromTerraWorkspaceStorageUrlGcp(
             fullPath, controlWorkspaceStorageContainerNameForDelimiter));
   }
 
   @Test
-  void getBlobNameFromTerraWorkspaceStorageHttpUrlDifferentWorkspaceGcp() {
+  void getBlobNameFromTerraWorkspaceStorageUrlDifferentWorkspaceGcp() {
     String fullPath =
         "gs://fc-secure-68a43bd8-e744-4f1e-87a5-c44ecef157a3/workspace-services/cbas/terra-app-b1740821-d6e9-44b5-b53b-960953dea218/ImputationBeagle/1adb690d-3d02-4d4a-9dfa-17a31edd74f3/call-WriteEmptyFile/cacheCopy/execution/empty_file";
     String wrongWorkspaceStorageContainerNameForDelimiter =
@@ -60,7 +60,7 @@ class FileUtilsTest extends BaseTest {
     assertThrows(
         InternalServerErrorException.class,
         () ->
-            FileUtils.getBlobNameFromTerraWorkspaceStorageHttpUrl(
+            FileUtils.getBlobNameFromTerraWorkspaceStorageUrlGcp(
                 fullPath, wrongWorkspaceStorageContainerNameForDelimiter));
   }
 

--- a/service/src/test/java/bio/terra/pipelines/common/utils/FileUtilsTest.java
+++ b/service/src/test/java/bio/terra/pipelines/common/utils/FileUtilsTest.java
@@ -11,26 +11,57 @@ import org.junit.jupiter.api.Test;
 class FileUtilsTest extends BaseTest {
 
   @Test
-  void getBlobNameFromTerraWorkspaceStorageHttpUrl() {
+  void getBlobNameFromTerraWorkspaceStorageHttpUrlAzure() {
     String fullPath =
         "https://lze96253b07f13c61ef712bb.blob.core.windows.net/sc-68a43bd8-e744-4f1e-87a5-c44ecef157a3/workspace-services/cbas/terra-app-b1740821-d6e9-44b5-b53b-960953dea218/ImputationBeagle/1adb690d-3d02-4d4a-9dfa-17a31edd74f3/call-WriteEmptyFile/cacheCopy/execution/empty_file";
-    UUID controlWorkspaceId = UUID.fromString("68a43bd8-e744-4f1e-87a5-c44ecef157a3");
+    String controlWorkspaceIdForDelimiter = "68a43bd8-e744-4f1e-87a5-c44ecef157a3";
     String expectedBlobName =
         "workspace-services/cbas/terra-app-b1740821-d6e9-44b5-b53b-960953dea218/ImputationBeagle/1adb690d-3d02-4d4a-9dfa-17a31edd74f3/call-WriteEmptyFile/cacheCopy/execution/empty_file";
     assertEquals(
         expectedBlobName,
-        FileUtils.getBlobNameFromTerraWorkspaceStorageHttpUrl(fullPath, controlWorkspaceId));
+        FileUtils.getBlobNameFromTerraWorkspaceStorageHttpUrl(
+            fullPath, controlWorkspaceIdForDelimiter));
   }
 
   @Test
-  void getBlobNameFromTerraWorkspaceStorageHttpUrlDifferentWorkspace() {
+  void getBlobNameFromTerraWorkspaceStorageHttpUrlDifferentWorkspaceAzure() {
     String fullPath =
         "https://lze96253b07f13c61ef712bb.blob.core.windows.net/sc-68a43bd8-e744-4f1e-87a5-c44ecef157a3/workspace-services/cbas/terra-app-b1740821-d6e9-44b5-b53b-960953dea218/ImputationBeagle/1adb690d-3d02-4d4a-9dfa-17a31edd74f3/call-WriteEmptyFile/cacheCopy/execution/empty_file";
-    UUID wrongWorkspaceId = UUID.fromString("11111111-1111-1111-1111-111111111111");
+    String wrongWorkspaceIdForDelimiter = "11111111-1111-1111-1111-111111111111";
 
     assertThrows(
         InternalServerErrorException.class,
-        () -> FileUtils.getBlobNameFromTerraWorkspaceStorageHttpUrl(fullPath, wrongWorkspaceId));
+        () ->
+            FileUtils.getBlobNameFromTerraWorkspaceStorageHttpUrl(
+                fullPath, wrongWorkspaceIdForDelimiter));
+  }
+
+  @Test
+  void getBlobNameFromTerraWorkspaceStorageHttpUrlGcp() {
+    String fullPath =
+        "gs://fc-secure-68a43bd8-e744-4f1e-87a5-c44ecef157a3/workspace-services/cbas/terra-app-b1740821-d6e9-44b5-b53b-960953dea218/ImputationBeagle/1adb690d-3d02-4d4a-9dfa-17a31edd74f3/call-WriteEmptyFile/cacheCopy/execution/empty_file";
+    String controlWorkspaceStorageContainerNameForDelimiter =
+        "fc-secure-68a43bd8-e744-4f1e-87a5-c44ecef157a3";
+    String expectedBlobName =
+        "workspace-services/cbas/terra-app-b1740821-d6e9-44b5-b53b-960953dea218/ImputationBeagle/1adb690d-3d02-4d4a-9dfa-17a31edd74f3/call-WriteEmptyFile/cacheCopy/execution/empty_file";
+    assertEquals(
+        expectedBlobName,
+        FileUtils.getBlobNameFromTerraWorkspaceStorageHttpUrl(
+            fullPath, controlWorkspaceStorageContainerNameForDelimiter));
+  }
+
+  @Test
+  void getBlobNameFromTerraWorkspaceStorageHttpUrlDifferentWorkspaceGcp() {
+    String fullPath =
+        "gs://fc-secure-68a43bd8-e744-4f1e-87a5-c44ecef157a3/workspace-services/cbas/terra-app-b1740821-d6e9-44b5-b53b-960953dea218/ImputationBeagle/1adb690d-3d02-4d4a-9dfa-17a31edd74f3/call-WriteEmptyFile/cacheCopy/execution/empty_file";
+    String wrongWorkspaceStorageContainerNameForDelimiter =
+        "fc-secure-11111111-1111-1111-1111-111111111111";
+
+    assertThrows(
+        InternalServerErrorException.class,
+        () ->
+            FileUtils.getBlobNameFromTerraWorkspaceStorageHttpUrl(
+                fullPath, wrongWorkspaceStorageContainerNameForDelimiter));
   }
 
   @Test

--- a/service/src/test/java/bio/terra/pipelines/dependencies/gcs/GcsServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/dependencies/gcs/GcsServiceTest.java
@@ -67,6 +67,22 @@ class GcsServiceTest extends BaseEmbeddedDbTest {
   }
 
   @Test
+  void generateGetObjectSignedUrl() throws MalformedURLException {
+    URL fakeURL = new URL("https://storage.googleapis.com/signed-url-stuff");
+    when(mockStorageService.signUrl(
+            any(BlobInfo.class),
+            anyLong(),
+            any(TimeUnit.class),
+            any(Storage.SignUrlOption.class),
+            any(Storage.SignUrlOption.class)))
+        .thenReturn(fakeURL);
+
+    URL generatedURL =
+        gcsService.generateGetObjectSignedUrl("projectId", "bucketName", "objectName");
+    assertEquals(fakeURL, generatedURL);
+  }
+
+  @Test
   void socketExceptionRetriesEventuallySucceed() throws Exception {
     URL fakeURL = new URL("https://storage.googleapis.com/signed-url-stuff");
 

--- a/service/src/test/java/bio/terra/pipelines/dependencies/gcs/GcsServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/dependencies/gcs/GcsServiceTest.java
@@ -141,4 +141,30 @@ class GcsServiceTest extends BaseEmbeddedDbTest {
           gcsService.generatePutObjectSignedUrl("projectId", "bucketName", "objectName");
         });
   }
+
+  @Test
+  void cleanSignedUrl() throws MalformedURLException {
+    // signed URL with X-Goog-Signature as last element
+    URL fakeURLSignatureLast =
+        new URL(
+            "https://storage.googleapis.com/fc-secure-6970c3a9-dc92-436d-af3d-917bcb4cf05a/user-input-files/ffaffa12-5717-4562-b3fc-2c963f66afa6/TEST.vcf.gz?X-Goog-Date=20240823T170006Z&X-Goog-Expires=900&X-Goog-SignedHeaders=content-type%3Bhost&X-Goog-Signature=12345");
+    String expectedCleanedURLSignatureLast =
+        "https://storage.googleapis.com/fc-secure-6970c3a9-dc92-436d-af3d-917bcb4cf05a/user-input-files/ffaffa12-5717-4562-b3fc-2c963f66afa6/TEST.vcf.gz?X-Goog-Date=20240823T170006Z&X-Goog-Expires=900&X-Goog-SignedHeaders=content-type%3Bhost&X-Goog-Signature=REDACTED";
+    assertEquals(expectedCleanedURLSignatureLast, GcsService.cleanSignedUrl(fakeURLSignatureLast));
+
+    // signed URL with no X-Goog-Signature should not throw an exception
+    URL fakeURLNoSignature =
+        new URL(
+            "https://storage.googleapis.com/fc-secure-6970c3a9-dc92-436d-af3d-917bcb4cf05a/user-input-files/ffaffa12-5717-4562-b3fc-2c963f66afa6/TEST.vcf.gz");
+    assertEquals(fakeURLNoSignature.toString(), GcsService.cleanSignedUrl(fakeURLNoSignature));
+
+    // signed URL with X-Goog-Signature in the middle
+    URL fakeURLSignatureMiddle =
+        new URL(
+            "https://storage.googleapis.com/fc-secure-6970c3a9-dc92-436d-af3d-917bcb4cf05a/user-input-files/ffaffa12-5717-4562-b3fc-2c963f66afa6/TEST.vcf.gz?X-Goog-Date=20240823T170006Z&X-Goog-Expires=900&X-Goog-Signature=12345&X-Goog-SignedHeaders=content-type%3Bhost&Last-Element=foobar");
+    String expectedCleanedURLSignatureMiddle =
+        "https://storage.googleapis.com/fc-secure-6970c3a9-dc92-436d-af3d-917bcb4cf05a/user-input-files/ffaffa12-5717-4562-b3fc-2c963f66afa6/TEST.vcf.gz?X-Goog-Date=20240823T170006Z&X-Goog-Expires=900&X-Goog-Signature=REDACTED&X-Goog-SignedHeaders=content-type%3Bhost&Last-Element=foobar";
+    assertEquals(
+        expectedCleanedURLSignatureMiddle, GcsService.cleanSignedUrl(fakeURLSignatureMiddle));
+  }
 }

--- a/service/src/test/java/bio/terra/pipelines/dependencies/gcs/GcsServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/dependencies/gcs/GcsServiceTest.java
@@ -163,7 +163,7 @@ class GcsServiceTest extends BaseEmbeddedDbTest {
         new URL(
             "https://storage.googleapis.com/fc-secure-6970c3a9-dc92-436d-af3d-917bcb4cf05a/user-input-files/ffaffa12-5717-4562-b3fc-2c963f66afa6/TEST.vcf.gz?X-Goog-Date=20240823T170006Z&X-Goog-Expires=900&X-Goog-Signature=12345&X-Goog-SignedHeaders=content-type%3Bhost&Last-Element=foobar");
     String expectedCleanedURLSignatureMiddle =
-        "https://storage.googleapis.com/fc-secure-6970c3a9-dc92-436d-af3d-917bcb4cf05a/user-input-files/ffaffa12-5717-4562-b3fc-2c963f66afa6/TEST.vcf.gz?X-Goog-Date=20240823T170006Z&X-Goog-Expires=900&X-Goog-Signature=REDACTED&X-Goog-SignedHeaders=content-type%3Bhost&Last-Element=foobar";
+        "https://storage.googleapis.com/fc-secure-6970c3a9-dc92-436d-af3d-917bcb4cf05a/user-input-files/ffaffa12-5717-4562-b3fc-2c963f66afa6/TEST.vcf.gz?X-Goog-Date=20240823T170006Z&X-Goog-Expires=900&X-Goog-SignedHeaders=content-type%3Bhost&Last-Element=foobar&X-Goog-Signature=REDACTED";
     assertEquals(
         expectedCleanedURLSignatureMiddle, GcsService.cleanSignedUrl(fakeURLSignatureMiddle));
   }

--- a/service/src/test/java/bio/terra/pipelines/dependencies/gcs/GcsServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/dependencies/gcs/GcsServiceTest.java
@@ -49,9 +49,17 @@ class GcsServiceTest extends BaseEmbeddedDbTest {
     when(gcsClient.getStorageService(any())).thenReturn(mockStorageService);
   }
 
+  private URL getFakeURL() {
+    try {
+      return new URL("https://storage.googleapis.com/signed-url-stuff?X-Goog-Signature=12345");
+    } catch (MalformedURLException e) {
+      return null;
+    }
+  }
+
   @Test
-  void generatePutObjectSignedUrl() throws MalformedURLException {
-    URL fakeURL = new URL("https://storage.googleapis.com/signed-url-stuff");
+  void generatePutObjectSignedUrl() {
+    URL fakeURL = getFakeURL();
     when(mockStorageService.signUrl(
             any(BlobInfo.class),
             anyLong(),
@@ -67,8 +75,8 @@ class GcsServiceTest extends BaseEmbeddedDbTest {
   }
 
   @Test
-  void generateGetObjectSignedUrl() throws MalformedURLException {
-    URL fakeURL = new URL("https://storage.googleapis.com/signed-url-stuff");
+  void generateGetObjectSignedUrl() {
+    URL fakeURL = getFakeURL();
     when(mockStorageService.signUrl(
             any(BlobInfo.class),
             anyLong(),
@@ -83,8 +91,8 @@ class GcsServiceTest extends BaseEmbeddedDbTest {
   }
 
   @Test
-  void socketExceptionRetriesEventuallySucceed() throws Exception {
-    URL fakeURL = new URL("https://storage.googleapis.com/signed-url-stuff");
+  void socketExceptionRetriesEventuallySucceed() {
+    URL fakeURL = getFakeURL();
 
     when(mockStorageService.signUrl(
             any(BlobInfo.class),
@@ -102,8 +110,8 @@ class GcsServiceTest extends BaseEmbeddedDbTest {
   }
 
   @Test
-  void socketExceptionRetriesEventuallyFail() throws Exception {
-    URL fakeURL = new URL("https://storage.googleapis.com/signed-url-stuff");
+  void socketExceptionRetriesEventuallyFail() {
+    URL fakeURL = getFakeURL();
 
     when(mockStorageService.signUrl(
             any(BlobInfo.class),

--- a/service/src/test/java/bio/terra/pipelines/dependencies/gcs/GcsServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/dependencies/gcs/GcsServiceTest.java
@@ -155,7 +155,7 @@ class GcsServiceTest extends BaseEmbeddedDbTest {
     // signed URL with no X-Goog-Signature should not throw an exception
     URL fakeURLNoSignature =
         new URL(
-            "https://storage.googleapis.com/fc-secure-6970c3a9-dc92-436d-af3d-917bcb4cf05a/user-input-files/ffaffa12-5717-4562-b3fc-2c963f66afa6/TEST.vcf.gz");
+            "https://storage.googleapis.com/fc-secure-6970c3a9-dc92-436d-af3d-917bcb4cf05a/user-input-files/ffaffa12-5717-4562-b3fc-2c963f66afa6/TEST.vcf.gz?X-Goog-Date=20240823T170006Z&X-Goog-Expires=900");
     assertEquals(fakeURLNoSignature.toString(), GcsService.cleanSignedUrl(fakeURLNoSignature));
 
     // signed URL with X-Goog-Signature in the middle

--- a/service/src/test/java/bio/terra/pipelines/dependencies/rawls/RawlsServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/dependencies/rawls/RawlsServiceTest.java
@@ -217,6 +217,25 @@ class RawlsServiceTest extends BaseEmbeddedDbTest {
   }
 
   @Test
+  void getDataTableEntity() throws Exception {
+    Entity expectedResponse = new Entity().name("entityName").entityType("entityType");
+
+    rawlsClient = mock(RawlsClient.class);
+    EntitiesApi entitiesApi = mock(EntitiesApi.class);
+    when(entitiesApi.getEntity(any(), any(), any(), any(), any(), any()))
+        .thenReturn(expectedResponse);
+
+    rawlsService = spy(new RawlsService(rawlsClient, template));
+
+    doReturn(entitiesApi).when(rawlsClient).getEntitiesApi(any());
+
+    assertEquals(
+        expectedResponse,
+        rawlsService.getDataTableEntity(
+            "token", "billingProject", "workspace", "entityType", "entityName"));
+  }
+
+  @Test
   void submissionIsNotRunning() {
     assertFalse(RawlsService.submissionIsRunning(new Submission().status(SubmissionStatus.DONE)));
     assertFalse(

--- a/service/src/test/java/bio/terra/pipelines/service/PipelineRunsServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/PipelineRunsServiceTest.java
@@ -534,7 +534,7 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
   }
 
   @Test
-  void formatPipelineRunOutputs() {
+  void formatPipelineRunOutputs() throws MalformedURLException {
     PipelineRun pipelineRun = createNewRunWithJobId(testJobId);
     pipelineRunsRepository.save(pipelineRun);
 
@@ -544,13 +544,14 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
         pipelineRunsService.pipelineRunOutputsAsString(TestUtils.TEST_PIPELINE_OUTPUTS));
     pipelineOutputsRepository.save(pipelineOutput);
 
-    ApiPipelineRunOutputs expectedOutput = new ApiPipelineRunOutputs();
-    expectedOutput.putAll(TestUtils.TEST_PIPELINE_OUTPUTS);
+    URL fakeUrl = new URL("https://storage.googleapis.com/signed-url-stuff");
+    // mock GCS service
+    when(mockGcsService.generateGetObjectSignedUrl(any(), any(), any())).thenReturn(fakeUrl);
 
     ApiPipelineRunOutputs apiPipelineRunOutputs =
         pipelineRunsService.formatPipelineRunOutputs(pipelineRun);
 
-    assertEquals(expectedOutput, apiPipelineRunOutputs);
+    assertEquals(fakeUrl.toString(), apiPipelineRunOutputs.get("testFileOutputKey"));
   }
 
   @Test

--- a/service/src/test/java/bio/terra/pipelines/stairway/imputation/RunImputationGcpFlightTest.java
+++ b/service/src/test/java/bio/terra/pipelines/stairway/imputation/RunImputationGcpFlightTest.java
@@ -33,7 +33,9 @@ class RunImputationGcpFlightTest extends BaseEmbeddedDbTest {
           "PrepareImputationInputsStep",
           "AddDataTableRowStep",
           "SubmitCromwellSubmissionStep",
-          "PollCromwellSubmissionStatusStep");
+          "PollCromwellSubmissionStatusStep",
+          "CompletePipelineRunStep",
+          "FetchOutputsFromDataTableStep");
 
   @Autowired FlightBeanBag flightBeanBag;
   private SimpleMeterRegistry meterRegistry;

--- a/service/src/test/java/bio/terra/pipelines/stairway/imputation/steps/gcp/FetchOutputsFromDataTableStepTest.java
+++ b/service/src/test/java/bio/terra/pipelines/stairway/imputation/steps/gcp/FetchOutputsFromDataTableStepTest.java
@@ -1,0 +1,90 @@
+package bio.terra.pipelines.stairway.imputation.steps.gcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import bio.terra.pipelines.dependencies.rawls.RawlsService;
+import bio.terra.pipelines.dependencies.rawls.RawlsServiceApiException;
+import bio.terra.pipelines.dependencies.rawls.RawlsServiceException;
+import bio.terra.pipelines.dependencies.sam.SamService;
+import bio.terra.pipelines.stairway.imputation.RunImputationJobFlightMapKeys;
+import bio.terra.pipelines.testutils.BaseEmbeddedDbTest;
+import bio.terra.pipelines.testutils.StairwayTestUtils;
+import bio.terra.rawls.model.Entity;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.StepStatus;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+class FetchOutputsFromDataTableStepTest extends BaseEmbeddedDbTest {
+
+  @Mock RawlsService rawlsService;
+  @Mock SamService samService;
+  @Mock private FlightContext flightContext;
+
+  @BeforeEach
+  void setup() {
+    var inputParameters = new FlightMap();
+    var workingMap = new FlightMap();
+
+    when(flightContext.getInputParameters()).thenReturn(inputParameters);
+    when(flightContext.getWorkingMap()).thenReturn(workingMap);
+  }
+
+  @Test
+  void doStepSuccess() throws RawlsServiceException {
+    // setup
+    StairwayTestUtils.constructCreateJobInputs(flightContext.getInputParameters());
+
+    // outputs to match the test output definitions
+    Map<String, Object> entityAttributes = new HashMap<>(Map.of("output_name", "some/file.vcf.gz"));
+    Entity entity = new Entity().attributes(entityAttributes);
+
+    when(rawlsService.getDataTableEntity(any(), any(), any(), any(), any())).thenReturn(entity);
+
+    FetchOutputsFromDataTableStep fetchOutputsFromDataTableStep =
+        new FetchOutputsFromDataTableStep(rawlsService, samService);
+    StepResult result = fetchOutputsFromDataTableStep.doStep(flightContext);
+
+    assertEquals(StepStatus.STEP_RESULT_SUCCESS, result.getStepStatus());
+
+    // in the step we translate the snake_case output keys to camelCase
+    Map<String, String> expectedOutputsFromWorkingMap = Map.of("outputName", "some/file.vcf.gz");
+
+    assertEquals(
+        expectedOutputsFromWorkingMap,
+        flightContext
+            .getWorkingMap()
+            .get(RunImputationJobFlightMapKeys.PIPELINE_RUN_OUTPUTS, Map.class));
+  }
+
+  @Test
+  void doStepFailureRetry() throws RawlsServiceException {
+    // setup
+    StairwayTestUtils.constructCreateJobInputs(flightContext.getInputParameters());
+
+    when(rawlsService.getDataTableEntity(any(), any(), any(), any(), any()))
+        .thenThrow(new RawlsServiceApiException("Rawls Service Api Exception"));
+
+    FetchOutputsFromDataTableStep fetchOutputsFromDataTableStep =
+        new FetchOutputsFromDataTableStep(rawlsService, samService);
+    StepResult result = fetchOutputsFromDataTableStep.doStep(flightContext);
+
+    assertEquals(StepStatus.STEP_RESULT_FAILURE_RETRY, result.getStepStatus());
+  }
+
+  @Test
+  void undoStepSuccess() {
+    FetchOutputsFromDataTableStep fetchOutputsFromDataTableStep =
+        new FetchOutputsFromDataTableStep(rawlsService, samService);
+    StepResult result = fetchOutputsFromDataTableStep.undoStep(flightContext);
+
+    assertEquals(StepStatus.STEP_RESULT_SUCCESS, result.getStepStatus());
+  }
+}

--- a/service/src/test/java/bio/terra/pipelines/stairway/imputation/steps/gcp/FetchOutputsFromDataTableStepTest.java
+++ b/service/src/test/java/bio/terra/pipelines/stairway/imputation/steps/gcp/FetchOutputsFromDataTableStepTest.java
@@ -3,6 +3,7 @@ package bio.terra.pipelines.stairway.imputation.steps.gcp;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import bio.terra.common.exception.InternalServerErrorException;
@@ -14,7 +15,6 @@ import bio.terra.pipelines.service.PipelineRunsService;
 import bio.terra.pipelines.stairway.imputation.RunImputationJobFlightMapKeys;
 import bio.terra.pipelines.testutils.BaseEmbeddedDbTest;
 import bio.terra.pipelines.testutils.StairwayTestUtils;
-import bio.terra.pipelines.testutils.TestUtils;
 import bio.terra.rawls.model.Entity;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
@@ -54,8 +54,7 @@ class FetchOutputsFromDataTableStepTest extends BaseEmbeddedDbTest {
     when(rawlsService.getDataTableEntity(any(), any(), any(), any(), any())).thenReturn(entity);
     Map<String, String> outputsProcessedFromEntity =
         new HashMap<>(Map.of("outputName", "some/file.vcf.gz"));
-    when(pipelineRunsService.extractPipelineOutputsFromEntity(
-            TestUtils.TEST_PIPELINE_OUTPUTS_DEFINITION_LIST, entity))
+    when(pipelineRunsService.extractPipelineOutputsFromEntity(any(), eq(entity)))
         .thenReturn(outputsProcessedFromEntity);
 
     FetchOutputsFromDataTableStep fetchOutputsFromDataTableStep =

--- a/service/src/test/java/bio/terra/pipelines/testutils/TestUtils.java
+++ b/service/src/test/java/bio/terra/pipelines/testutils/TestUtils.java
@@ -47,7 +47,7 @@ public class TestUtils {
       new HashMap(
           Map.of(
               "testFileOutputKey",
-              "https://lz123.stuff/sc-%s/testFileOutputValue".formatted(CONTROL_WORKSPACE_ID)));
+              "gs://fc-secure-%s/testFileOutputValue".formatted(CONTROL_WORKSPACE_ID)));
 
   public static final List<PipelineInputDefinition> TEST_PIPELINE_INPUTS_DEFINITION_LIST =
       new ArrayList<>(


### PR DESCRIPTION
### Description 

We now return signed GET (read-only) urls for pipeline run outputs, when the user calls get pipeline run result.

Added logic to redact the signature string from the signed url when we log its creation (for both PUT and GET signed urls).

To do this, we had to add two steps to the GCP flight:
- FetchOutputsFromDataTableStep (brand new step, GCP correlary of the Azure FetchOutputsFromWdsStep)
- CompletePipelineRunStep (reused existing step)

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-306
