### PR TITLE
TSPS-310 final PipelineRun status persisted to PipelineRuns table

### DIFF
--- a/service/src/main/java/bio/terra/pipelines/app/controller/PipelineRunsApiController.java
+++ b/service/src/main/java/bio/terra/pipelines/app/controller/PipelineRunsApiController.java
@@ -227,8 +227,7 @@ public class PipelineRunsApiController implements PipelineRunsApi {
                 pipelineRun
                     .getWdlMethodVersion())); // wdlMethodVersion comes from pipelineRun, since the
     // pipeline might have been updated since the pipelineRun began
-    if (Boolean.TRUE.equals(
-        pipelineRun.getIsSuccess())) { // use Boolean because isSuccess can be null
+    if (pipelineRun.getStatus().isSuccess()) {
       return response
           .jobReport(
               new ApiJobReport()

--- a/service/src/main/java/bio/terra/pipelines/common/utils/CommonPipelineRunStatusEnum.java
+++ b/service/src/main/java/bio/terra/pipelines/common/utils/CommonPipelineRunStatusEnum.java
@@ -5,5 +5,9 @@ public enum CommonPipelineRunStatusEnum {
   SUBMITTED,
   RUNNING,
   SUCCEEDED,
-  FAILED
+  FAILED;
+
+  public boolean isSuccess() {
+    return this == SUCCEEDED;
+  }
 }

--- a/service/src/main/java/bio/terra/pipelines/db/entities/PipelineRun.java
+++ b/service/src/main/java/bio/terra/pipelines/db/entities/PipelineRun.java
@@ -72,9 +72,6 @@ public class PipelineRun {
   @Column(name = "result_url")
   private String resultUrl;
 
-  @Column(name = "is_success")
-  private Boolean isSuccess;
-
   /** Constructor for in progress or complete PipelineRun. */
   public PipelineRun(
       UUID jobId,
@@ -90,8 +87,7 @@ public class PipelineRun {
       LocalDateTime updated,
       CommonPipelineRunStatusEnum status,
       String description,
-      String resultUrl,
-      Boolean isSuccess) {
+      String resultUrl) {
     this.jobId = jobId;
     this.userId = userId;
     this.pipelineId = pipelineId;
@@ -106,7 +102,6 @@ public class PipelineRun {
     this.status = status;
     this.description = description;
     this.resultUrl = resultUrl;
-    this.isSuccess = isSuccess;
   }
 
   /** Constructor for creating a new GCP pipeline run. Timestamps are auto-generated. */

--- a/service/src/main/java/bio/terra/pipelines/service/PipelineRunsService.java
+++ b/service/src/main/java/bio/terra/pipelines/service/PipelineRunsService.java
@@ -378,7 +378,7 @@ public class PipelineRunsService {
   }
 
   /**
-   * Mark a pipeline run as successful (is_success = True) in our database.
+   * Mark a pipeline run as successful (is_success = True, status = SUCCEEDED) in our database.
    *
    * <p>We expect this method to be called by the final step of a flight, at which point we assume
    * that the pipeline_run has completed successfully. Therefore, we do not do any checks on the
@@ -399,6 +399,20 @@ public class PipelineRunsService {
     pipelineRun.setStatus(CommonPipelineRunStatusEnum.SUCCEEDED);
 
     return pipelineRunsRepository.save(pipelineRun);
+  }
+
+  /**
+   * Mark a pipeline run as failed (is_success = False, status = FAILED) in our database.
+   *
+   * <p>We expect this method to be called by the undoStep method of the first step in a flight, so
+   * that it is executed when the flight has failed.
+   */
+  @WriteTransaction
+  public void markPipelineRunFailed(UUID jobId, String userId) {
+    PipelineRun pipelineRun = getPipelineRun(jobId, userId);
+    pipelineRun.setIsSuccess(false);
+    pipelineRun.setStatus(CommonPipelineRunStatusEnum.FAILED);
+    pipelineRunsRepository.save(pipelineRun);
   }
 
   // methods to interact with and format pipeline run outputs

--- a/service/src/main/java/bio/terra/pipelines/service/PipelineRunsService.java
+++ b/service/src/main/java/bio/terra/pipelines/service/PipelineRunsService.java
@@ -396,6 +396,7 @@ public class PipelineRunsService {
     pipelineOutputsRepository.save(pipelineOutput);
 
     pipelineRun.setIsSuccess(true);
+    pipelineRun.setStatus(CommonPipelineRunStatusEnum.SUCCEEDED);
 
     return pipelineRunsRepository.save(pipelineRun);
   }

--- a/service/src/main/java/bio/terra/pipelines/service/PipelineRunsService.java
+++ b/service/src/main/java/bio/terra/pipelines/service/PipelineRunsService.java
@@ -378,7 +378,7 @@ public class PipelineRunsService {
   }
 
   /**
-   * Mark a pipeline run as successful (is_success = True, status = SUCCEEDED) in our database.
+   * Mark a pipeline run as successful (status = SUCCEEDED) in our database.
    *
    * <p>We expect this method to be called by the final step of a flight, at which point we assume
    * that the pipeline_run has completed successfully. Therefore, we do not do any checks on the
@@ -395,22 +395,19 @@ public class PipelineRunsService {
     pipelineOutput.setOutputs(pipelineRunOutputsAsString(outputs));
     pipelineOutputsRepository.save(pipelineOutput);
 
-    pipelineRun.setIsSuccess(true);
     pipelineRun.setStatus(CommonPipelineRunStatusEnum.SUCCEEDED);
 
     return pipelineRunsRepository.save(pipelineRun);
   }
 
   /**
-   * Mark a pipeline run as failed (is_success = False, status = FAILED) in our database.
+   * Mark a pipeline run as failed (status = FAILED) in our database.
    *
    * <p>We expect this method to be called by the undoStep method of the first step in a flight, so
    * that it is executed when the flight has failed.
    */
-  @WriteTransaction
   public void markPipelineRunFailed(UUID jobId, String userId) {
     PipelineRun pipelineRun = getPipelineRun(jobId, userId);
-    pipelineRun.setIsSuccess(false);
     pipelineRun.setStatus(CommonPipelineRunStatusEnum.FAILED);
     pipelineRunsRepository.save(pipelineRun);
   }

--- a/service/src/main/java/bio/terra/pipelines/stairway/imputation/RunImputationAzureJobFlight.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/imputation/RunImputationAzureJobFlight.java
@@ -48,6 +48,13 @@ public class RunImputationAzureJobFlight extends Flight {
             inputParameters.get(JobMapKeys.PIPELINE_NAME.getKeyName(), String.class));
     MetricsUtils.incrementPipelineRun(pipelinesEnum);
 
+    addStep(
+        new PrepareImputationInputsStep(
+            flightBeanBag.getPipelinesService(),
+            flightBeanBag.getPipelineRunsService(),
+            flightBeanBag.getImputationConfiguration()),
+        dbRetryRule);
+
     addStep(new CheckLeonardoHealthStep(flightBeanBag.getLeonardoService()), dataPlaneAppRetryRule);
 
     addStep(
@@ -57,13 +64,6 @@ public class RunImputationAzureJobFlight extends Flight {
     addStep(
         new CheckWdsHealthStep(flightBeanBag.getWdsService(), flightBeanBag.getSamService()),
         dataPlaneAppRetryRule);
-
-    addStep(
-        new PrepareImputationInputsStep(
-            flightBeanBag.getPipelinesService(),
-            flightBeanBag.getPipelineRunsService(),
-            flightBeanBag.getImputationConfiguration()),
-        dbRetryRule);
 
     addStep(
         new AddWdsRowStep(flightBeanBag.getWdsService(), flightBeanBag.getSamService()),

--- a/service/src/main/java/bio/terra/pipelines/stairway/imputation/RunImputationAzureJobFlight.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/imputation/RunImputationAzureJobFlight.java
@@ -60,7 +60,9 @@ public class RunImputationAzureJobFlight extends Flight {
 
     addStep(
         new PrepareImputationInputsStep(
-            flightBeanBag.getPipelinesService(), flightBeanBag.getImputationConfiguration()),
+            flightBeanBag.getPipelinesService(),
+            flightBeanBag.getPipelineRunsService(),
+            flightBeanBag.getImputationConfiguration()),
         dbRetryRule);
 
     addStep(

--- a/service/src/main/java/bio/terra/pipelines/stairway/imputation/RunImputationGcpJobFlight.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/imputation/RunImputationGcpJobFlight.java
@@ -65,7 +65,9 @@ public class RunImputationGcpJobFlight extends Flight {
 
     addStep(
         new PrepareImputationInputsStep(
-            flightBeanBag.getPipelinesService(), flightBeanBag.getImputationConfiguration()),
+            flightBeanBag.getPipelinesService(),
+            flightBeanBag.getPipelineRunsService(),
+            flightBeanBag.getImputationConfiguration()),
         dbRetryRule);
 
     addStep(

--- a/service/src/main/java/bio/terra/pipelines/stairway/imputation/steps/PrepareImputationInputsStep.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/imputation/steps/PrepareImputationInputsStep.java
@@ -122,7 +122,7 @@ public class PrepareImputationInputsStep implements Step {
 
   @Override
   public StepResult undoStep(FlightContext flightContext) {
-    // this is the first step in RunImputationGcpJobFlight.
+    // this is the first step in RunImputationGcpJobFlight and RunImputationAzureJobFlight.
     // if undoStep is called it means the flight failed
     // to be moved to a StairwayHook in https://broadworkbench.atlassian.net/browse/TSPS-181
 

--- a/service/src/main/java/bio/terra/pipelines/stairway/imputation/steps/azure/CheckLeonardoHealthStep.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/imputation/steps/azure/CheckLeonardoHealthStep.java
@@ -1,11 +1,8 @@
 package bio.terra.pipelines.stairway.imputation.steps.azure;
 
-import bio.terra.pipelines.app.common.MetricsUtils;
-import bio.terra.pipelines.common.utils.PipelinesEnum;
 import bio.terra.pipelines.dependencies.common.HealthCheck;
 import bio.terra.pipelines.dependencies.leonardo.LeonardoService;
 import bio.terra.pipelines.dependencies.leonardo.LeonardoServiceApiException;
-import bio.terra.pipelines.dependencies.stairway.JobMapKeys;
 import bio.terra.stairway.*;
 
 /** This step queries the Leonardo status endpoint to check if it is healthy */
@@ -29,16 +26,6 @@ public class CheckLeonardoHealthStep implements Step {
 
   @Override
   public StepResult undoStep(FlightContext flightContext) {
-    // this is the first step in RunImputationAzureJobFlight.
-    // increment pipeline failed counter if undoStep is called which means the flight failed
-    // to be moved to a StairwayHook in https://broadworkbench.atlassian.net/browse/TSPS-181
-    PipelinesEnum pipelinesEnum =
-        PipelinesEnum.valueOf(
-            flightContext
-                .getInputParameters()
-                .get(JobMapKeys.PIPELINE_NAME.getKeyName(), String.class));
-    MetricsUtils.incrementPipelineRunFailed(pipelinesEnum);
-
     // nothing to undo; this step only makes an api call to leonardo to check if its healthy
     return StepResult.getStepResultSuccess();
   }

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -124,7 +124,7 @@ gcs:
   signedUrlGetDurationHours: 24
 
 imputation:
-  cromwellSubmissionPollingIntervalInSeconds: 60 # poll every 10 minutes for a cromwell submission
+  cromwellSubmissionPollingIntervalInSeconds: 600 # poll every 10 minutes for a cromwell submission
   inputKeysToPrependWithStorageUrl: ["refDict", "referencePanelPathPrefix", "geneticMapsPath"]
   storageWorkspaceStorageUrl: ${env.pipelines.imputation.storageWorkspaceStorageUrl}
   useCallCaching: true

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -124,7 +124,7 @@ gcs:
   signedUrlGetDurationHours: 24
 
 imputation:
-  cromwellSubmissionPollingIntervalInSeconds: 600 # poll every 10 minutes for a cromwell submission
+  cromwellSubmissionPollingIntervalInSeconds: 60 # poll every 10 minutes for a cromwell submission
   inputKeysToPrependWithStorageUrl: ["refDict", "referencePanelPathPrefix", "geneticMapsPath"]
   storageWorkspaceStorageUrl: ${env.pipelines.imputation.storageWorkspaceStorageUrl}
   useCallCaching: true

--- a/service/src/main/resources/db/changelog.xml
+++ b/service/src/main/resources/db/changelog.xml
@@ -26,6 +26,7 @@
   <include file="changesets/20240830_add_workspace_google_project_rename_storage_container_field.yaml" relativeToChangelogFile="true"/>
   <include file="changesets/20240903_rename_workspace_project.yaml" relativeToChangelogFile="true"/>
   <include file="changesets/20240906_add_wdl_version_to_pipeline_run.yaml" relativeToChangelogFile="true"/>
+  <include file="changesets/20240911_remove_isSuccess.yaml" relativeToChangelogFile="true"/>
 
   <include file="changesets/20240412-testdata.yaml" relativeToChangelogFile="true"/>
 

--- a/service/src/main/resources/db/changesets/20240911_remove_isSuccess.yaml
+++ b/service/src/main/resources/db/changesets/20240911_remove_isSuccess.yaml
@@ -1,0 +1,11 @@
+# Remove is_success from pipeline_runs table
+databaseChangeLog:
+  - changeSet:
+      id: Remove is_success from pipeline_runs table
+      author: mma
+      changes:
+        - dropColumn:
+            tableName: pipeline_runs
+            columns:
+              - column:
+                  name: is_success

--- a/service/src/test/java/bio/terra/pipelines/controller/PipelineRunsApiControllerTest.java
+++ b/service/src/test/java/bio/terra/pipelines/controller/PipelineRunsApiControllerTest.java
@@ -383,7 +383,7 @@ class PipelineRunsApiControllerTest {
   void getPipelineRunResultDoneSuccess() throws Exception {
     String pipelineName = PipelinesEnum.IMPUTATION_BEAGLE.getValue();
     String jobIdString = newJobId.toString();
-    PipelineRun pipelineRun = getPipelineRunCompleted(CommonPipelineRunStatusEnum.SUCCEEDED);
+    PipelineRun pipelineRun = getPipelineRunWithStatus(CommonPipelineRunStatusEnum.SUCCEEDED);
     ApiPipelineRunOutputs apiPipelineRunOutputs = new ApiPipelineRunOutputs();
     apiPipelineRunOutputs.putAll(testOutputs);
 
@@ -427,7 +427,7 @@ class PipelineRunsApiControllerTest {
     String jobIdString = newJobId.toString();
     String errorMessage = "test exception message";
     Integer statusCode = 500;
-    PipelineRun pipelineRun = getPipelineRunCompleted(CommonPipelineRunStatusEnum.FAILED);
+    PipelineRun pipelineRun = getPipelineRunWithStatus(CommonPipelineRunStatusEnum.FAILED);
 
     ApiErrorReport errorReport = new ApiErrorReport().message(errorMessage).statusCode(statusCode);
 
@@ -677,8 +677,7 @@ class PipelineRunsApiControllerTest {
         updatedTime,
         CommonPipelineRunStatusEnum.PREPARING,
         TestUtils.TEST_PIPELINE_DESCRIPTION_1,
-        testResultPath,
-        null);
+        testResultPath);
   }
 
   /** helper method to create a PipelineRun object for a running job */
@@ -697,13 +696,11 @@ class PipelineRunsApiControllerTest {
         updatedTime,
         CommonPipelineRunStatusEnum.RUNNING,
         TestUtils.TEST_PIPELINE_DESCRIPTION_1,
-        testResultPath,
-        null);
+        testResultPath);
   }
 
   /** helper method to create a PipelineRun object for a completed job. */
-  private PipelineRun getPipelineRunCompleted(CommonPipelineRunStatusEnum status) {
-    Boolean isSuccess = status == CommonPipelineRunStatusEnum.SUCCEEDED ? true : null;
+  private PipelineRun getPipelineRunWithStatus(CommonPipelineRunStatusEnum status) {
     return new PipelineRun(
         newJobId,
         testUser.getSubjectId(),
@@ -718,7 +715,6 @@ class PipelineRunsApiControllerTest {
         updatedTime,
         status,
         TestUtils.TEST_PIPELINE_DESCRIPTION_1,
-        testResultPath,
-        isSuccess);
+        testResultPath);
   }
 }

--- a/service/src/test/java/bio/terra/pipelines/service/PipelineRunsServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/PipelineRunsServiceTest.java
@@ -618,7 +618,7 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
     PipelineRun updatedPipelineRun =
         pipelineRunsService.markPipelineRunSuccessAndWriteOutputs(
             testJobId, testUserId, TestUtils.TEST_PIPELINE_OUTPUTS);
-    assertTrue(updatedPipelineRun.getIsSuccess());
+    assertTrue(updatedPipelineRun.getStatus().isSuccess());
     assertEquals(CommonPipelineRunStatusEnum.SUCCEEDED, updatedPipelineRun.getStatus());
 
     Map<String, String> extractedOutputs =

--- a/service/src/test/java/bio/terra/pipelines/service/PipelineRunsServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/PipelineRunsServiceTest.java
@@ -619,6 +619,7 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
         pipelineRunsService.markPipelineRunSuccessAndWriteOutputs(
             testJobId, testUserId, TestUtils.TEST_PIPELINE_OUTPUTS);
     assertTrue(updatedPipelineRun.getIsSuccess());
+    assertEquals(CommonPipelineRunStatusEnum.SUCCEEDED, updatedPipelineRun.getStatus());
 
     Map<String, String> extractedOutputs =
         pipelineRunsService.pipelineRunOutputsAsMap(

--- a/service/src/test/java/bio/terra/pipelines/stairway/imputation/steps/CompletePipelineRunStepTest.java
+++ b/service/src/test/java/bio/terra/pipelines/stairway/imputation/steps/CompletePipelineRunStepTest.java
@@ -70,8 +70,7 @@ class CompletePipelineRunStepTest extends BaseEmbeddedDbTest {
             null,
             CommonPipelineRunStatusEnum.SUCCEEDED,
             TestUtils.TEST_PIPELINE_DESCRIPTION_1,
-            TestUtils.TEST_RESULT_URL,
-            null));
+            TestUtils.TEST_RESULT_URL));
 
     // do the step
     var writeJobStep = new CompletePipelineRunStep(pipelineRunsService);
@@ -88,8 +87,8 @@ class CompletePipelineRunStepTest extends BaseEmbeddedDbTest {
             .findByJobIdAndUserId(
                 testJobId, inputParams.get(JobMapKeys.USER_ID.getKeyName(), String.class))
             .orElseThrow();
-    assertTrue(writtenJob.getIsSuccess());
     assertEquals(CommonPipelineRunStatusEnum.SUCCEEDED, writtenJob.getStatus());
+    assertTrue(writtenJob.getStatus().isSuccess());
 
     // make sure outputs were written to db
     PipelineOutput pipelineOutput =

--- a/service/src/test/java/bio/terra/pipelines/stairway/imputation/steps/CompletePipelineRunStepTest.java
+++ b/service/src/test/java/bio/terra/pipelines/stairway/imputation/steps/CompletePipelineRunStepTest.java
@@ -89,6 +89,7 @@ class CompletePipelineRunStepTest extends BaseEmbeddedDbTest {
                 testJobId, inputParams.get(JobMapKeys.USER_ID.getKeyName(), String.class))
             .orElseThrow();
     assertTrue(writtenJob.getIsSuccess());
+    assertEquals(CommonPipelineRunStatusEnum.SUCCEEDED, writtenJob.getStatus());
 
     // make sure outputs were written to db
     PipelineOutput pipelineOutput =

--- a/service/src/test/java/bio/terra/pipelines/stairway/imputation/steps/PrepareImputationInputsStepTest.java
+++ b/service/src/test/java/bio/terra/pipelines/stairway/imputation/steps/PrepareImputationInputsStepTest.java
@@ -7,11 +7,15 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 import bio.terra.pipelines.app.configuration.internal.ImputationConfiguration;
+import bio.terra.pipelines.common.utils.CommonPipelineRunStatusEnum;
 import bio.terra.pipelines.common.utils.PipelineVariableTypesEnum;
 import bio.terra.pipelines.common.utils.PipelinesEnum;
 import bio.terra.pipelines.db.entities.Pipeline;
 import bio.terra.pipelines.db.entities.PipelineInputDefinition;
+import bio.terra.pipelines.db.entities.PipelineRun;
+import bio.terra.pipelines.db.repositories.PipelineRunsRepository;
 import bio.terra.pipelines.db.repositories.PipelinesRepository;
+import bio.terra.pipelines.service.PipelineRunsService;
 import bio.terra.pipelines.service.PipelinesService;
 import bio.terra.pipelines.stairway.imputation.RunImputationJobFlightMapKeys;
 import bio.terra.pipelines.testutils.BaseEmbeddedDbTest;
@@ -21,6 +25,7 @@ import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.StepStatus;
 import com.fasterxml.jackson.core.type.TypeReference;
+import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.List;
@@ -37,8 +42,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 class PrepareImputationInputsStepTest extends BaseEmbeddedDbTest {
 
   @Autowired private PipelinesService pipelinesService;
+  @Autowired private PipelineRunsService pipelineRunsService;
   @Autowired PipelinesRepository pipelinesRepository;
   @Autowired ImputationConfiguration imputationConfiguration;
+  @Autowired PipelineRunsRepository pipelineRunsRepository;
   @Mock private FlightContext flightContext;
 
   private final UUID testJobId = TestUtils.TEST_NEW_UUID;
@@ -52,6 +59,7 @@ class PrepareImputationInputsStepTest extends BaseEmbeddedDbTest {
 
     when(flightContext.getInputParameters()).thenReturn(inputParameters);
     when(flightContext.getWorkingMap()).thenReturn(workingMap);
+    when(flightContext.getFlightId()).thenReturn(testJobId.toString());
 
     meterRegistry = new SimpleMeterRegistry();
     Metrics.globalRegistry.add(meterRegistry);
@@ -94,7 +102,8 @@ class PrepareImputationInputsStepTest extends BaseEmbeddedDbTest {
 
     // do the step
     var prepareImputationInputsStep =
-        new PrepareImputationInputsStep(pipelinesService, imputationConfiguration);
+        new PrepareImputationInputsStep(
+            pipelinesService, pipelineRunsService, imputationConfiguration);
     var result = prepareImputationInputsStep.doStep(flightContext);
 
     assertEquals(StepStatus.STEP_RESULT_SUCCESS, result.getStepStatus());
@@ -163,10 +172,34 @@ class PrepareImputationInputsStepTest extends BaseEmbeddedDbTest {
   @Test
   void undoStepSuccess() {
     StairwayTestUtils.constructCreateJobInputs(flightContext.getInputParameters());
+
+    // write pipelineRun to the db
+    PipelineRun pipelineRun =
+        new PipelineRun(
+            UUID.fromString(flightContext.getFlightId()),
+            TestUtils.TEST_USER_ID_1,
+            TestUtils.TEST_PIPELINE_ID_1,
+            TestUtils.TEST_WDL_METHOD_VERSION_1,
+            TestUtils.CONTROL_WORKSPACE_BILLING_PROJECT,
+            TestUtils.CONTROL_WORKSPACE_NAME,
+            TestUtils.CONTROL_WORKSPACE_STORAGE_CONTAINER_NAME,
+            TestUtils.CONTROL_WORKSPACE_GOOGLE_PROJECT,
+            CommonPipelineRunStatusEnum.RUNNING);
+    pipelineRunsRepository.save(pipelineRun);
+
     var prepareImputationInputsStep =
-        new PrepareImputationInputsStep(pipelinesService, imputationConfiguration);
+        new PrepareImputationInputsStep(
+            pipelinesService, pipelineRunsService, imputationConfiguration);
     var result = prepareImputationInputsStep.undoStep(flightContext);
 
     assertEquals(StepStatus.STEP_RESULT_SUCCESS, result.getStepStatus());
+
+    Counter counter = meterRegistry.find("teaspoons.pipeline.failed.count").counter();
+    assertNotNull(counter);
+    assertEquals(1, counter.count());
+
+    PipelineRun writtenPipelineRun =
+        pipelineRunsService.getPipelineRun(testJobId, TestUtils.TEST_USER_ID_1);
+    assertEquals(CommonPipelineRunStatusEnum.FAILED, writtenPipelineRun.getStatus());
   }
 }

--- a/service/src/test/java/bio/terra/pipelines/stairway/imputation/steps/azure/CheckLeonardoHealthStepTest.java
+++ b/service/src/test/java/bio/terra/pipelines/stairway/imputation/steps/azure/CheckLeonardoHealthStepTest.java
@@ -12,7 +12,6 @@ import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
-import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -24,8 +23,6 @@ class CheckLeonardoHealthStepTest extends BaseEmbeddedDbTest {
   @Mock private FlightContext flightContext;
 
   private final UUID testJobId = TestUtils.TEST_NEW_UUID;
-
-  private SimpleMeterRegistry meterRegistry;
 
   @BeforeEach
   void setup() {

--- a/service/src/test/java/bio/terra/pipelines/stairway/imputation/steps/azure/CheckLeonardoHealthStepTest.java
+++ b/service/src/test/java/bio/terra/pipelines/stairway/imputation/steps/azure/CheckLeonardoHealthStepTest.java
@@ -1,7 +1,6 @@
 package bio.terra.pipelines.stairway.imputation.steps.azure;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.when;
 
 import bio.terra.pipelines.dependencies.common.HealthCheck;
@@ -13,11 +12,8 @@ import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
-import io.micrometer.core.instrument.Counter;
-import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.UUID;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -38,15 +34,6 @@ class CheckLeonardoHealthStepTest extends BaseEmbeddedDbTest {
 
     when(flightContext.getInputParameters()).thenReturn(inputParameters);
     when(flightContext.getWorkingMap()).thenReturn(workingMap);
-
-    meterRegistry = new SimpleMeterRegistry();
-    Metrics.globalRegistry.add(meterRegistry);
-  }
-
-  @AfterEach
-  void tearDown() {
-    meterRegistry.clear();
-    Metrics.globalRegistry.clear();
   }
 
   @Test
@@ -89,9 +76,5 @@ class CheckLeonardoHealthStepTest extends BaseEmbeddedDbTest {
     StepResult result = checkLeonardoHealthStep.undoStep(flightContext);
 
     assertEquals(StepStatus.STEP_RESULT_SUCCESS, result.getStepStatus());
-
-    Counter counter = meterRegistry.find("teaspoons.pipeline.failed.count").counter();
-    assertNotNull(counter);
-    assertEquals(1, counter.count());
   }
 }


### PR DESCRIPTION
### Description 

Previously we were not updating the final status of a PipelineRun in the PipelineRuns table, meaning when a user retrieves all their PipelineRuns, they only see status RUNNING.

We now update the status to SUCCEEDED in the (final) CompletePipelineRunStep, and we update status to FAILED in the undo step of (first step in GCP and Azure flights) PrepareImputationInputsStep.

GET pipelineruns endpoint now returns:
```{
  "pageToken": "IyMjNyMjIyAtIDIwMjQtMDktMTBUMTY6MTE6MDcuMDAzMjUw",
  "results": [
    {
      "jobId": "11112115-5717-4562-b3fc-2c963f66afa6",
      "status": "FAILED",
      "description": "test finalize FAILED status"
    },
    {
      "jobId": "11112114-5717-4562-b3fc-2c963f66afa6",
      "status": "SUCCEEDED",
      "description": "test finalize SUCCEEDED status"
    },
```

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-310
https://broadworkbench.atlassian.net/browse/TSPS-299
