### PR TITLE
TSPS-316 remove all unhelpful "any()" matchers from our tests

### DIFF
--- a/service/src/main/java/bio/terra/pipelines/db/entities/BasePipelineVariableDefinition.java
+++ b/service/src/main/java/bio/terra/pipelines/db/entities/BasePipelineVariableDefinition.java
@@ -9,7 +9,6 @@ import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 @Getter
 @Setter
@@ -39,17 +38,5 @@ public abstract class BasePipelineVariableDefinition {
     this.name = name;
     this.wdlVariableName = wdlVariableName;
     this.type = type;
-  }
-
-  // we override equals() below so that we can compare BasePipelineVariableDefinition objects;
-  @Override
-  public int hashCode() {
-    return new HashCodeBuilder(17, 31)
-        // two randomly chosen prime numbers
-        .append(pipelineId)
-        .append(name)
-        .append(wdlVariableName)
-        .append(type)
-        .toHashCode();
   }
 }

--- a/service/src/main/java/bio/terra/pipelines/db/entities/BasePipelineVariableDefinition.java
+++ b/service/src/main/java/bio/terra/pipelines/db/entities/BasePipelineVariableDefinition.java
@@ -9,6 +9,7 @@ import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 @Getter
 @Setter
@@ -38,5 +39,17 @@ public abstract class BasePipelineVariableDefinition {
     this.name = name;
     this.wdlVariableName = wdlVariableName;
     this.type = type;
+  }
+
+  // we override equals() below so that we can compare BasePipelineVariableDefinition objects;
+  @Override
+  public int hashCode() {
+    return new HashCodeBuilder(17, 31)
+        // two randomly chosen prime numbers
+        .append(pipelineId)
+        .append(name)
+        .append(wdlVariableName)
+        .append(type)
+        .toHashCode();
   }
 }

--- a/service/src/main/java/bio/terra/pipelines/db/entities/PipelineInputDefinition.java
+++ b/service/src/main/java/bio/terra/pipelines/db/entities/PipelineInputDefinition.java
@@ -45,16 +45,23 @@ public class PipelineInputDefinition extends BasePipelineVariableDefinition {
     this.defaultValue = defaultValue;
   }
 
-  // we override equals() below so that we can compare PipelineInputDefinition objects;
+  @SuppressWarnings("java:S125") // The comment here isn't "commented code"
+  // we override equals() below so that we can compare PipelineInputDefinition objects in tests;
+  // according to
+  // https://stackoverflow.com/questions/27581/what-issues-should-be-considered-when-overriding-equals-and-hashcode-in-java/27609#27609
+  // we should override hashCode() if we override equals()
   @Override
   public int hashCode() {
     return new HashCodeBuilder(17, 31)
         // two randomly chosen prime numbers
+        .append(getPipelineId())
+        .append(getName())
+        .append(getWdlVariableName())
+        .append(getType())
         .append(fileSuffix)
         .append(isRequired)
         .append(userProvided)
         .append(defaultValue)
-        .appendSuper(super.hashCode())
         .toHashCode();
   }
 
@@ -67,6 +74,7 @@ public class PipelineInputDefinition extends BasePipelineVariableDefinition {
         .append(isRequired, otherObject.isRequired)
         .append(userProvided, otherObject.userProvided)
         .append(defaultValue, otherObject.defaultValue)
+        .append(getId(), otherObject.getId())
         .append(getPipelineId(), otherObject.getPipelineId())
         .append(getName(), otherObject.getName())
         .append(getWdlVariableName(), otherObject.getWdlVariableName())

--- a/service/src/main/java/bio/terra/pipelines/db/entities/PipelineInputDefinition.java
+++ b/service/src/main/java/bio/terra/pipelines/db/entities/PipelineInputDefinition.java
@@ -54,6 +54,7 @@ public class PipelineInputDefinition extends BasePipelineVariableDefinition {
   public int hashCode() {
     return new HashCodeBuilder(17, 31)
         // two randomly chosen prime numbers
+        .append(getId())
         .append(getPipelineId())
         .append(getName())
         .append(getWdlVariableName())
@@ -70,15 +71,15 @@ public class PipelineInputDefinition extends BasePipelineVariableDefinition {
     if (!(obj instanceof PipelineInputDefinition otherObject)) return false;
     if (obj == this) return true;
     return new EqualsBuilder()
-        .append(fileSuffix, otherObject.fileSuffix)
-        .append(isRequired, otherObject.isRequired)
-        .append(userProvided, otherObject.userProvided)
-        .append(defaultValue, otherObject.defaultValue)
         .append(getId(), otherObject.getId())
         .append(getPipelineId(), otherObject.getPipelineId())
         .append(getName(), otherObject.getName())
         .append(getWdlVariableName(), otherObject.getWdlVariableName())
         .append(getType(), otherObject.getType())
+        .append(fileSuffix, otherObject.fileSuffix)
+        .append(isRequired, otherObject.isRequired)
+        .append(userProvided, otherObject.userProvided)
+        .append(defaultValue, otherObject.defaultValue)
         .isEquals();
   }
 }

--- a/service/src/main/java/bio/terra/pipelines/db/entities/PipelineInputDefinition.java
+++ b/service/src/main/java/bio/terra/pipelines/db/entities/PipelineInputDefinition.java
@@ -7,6 +7,8 @@ import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 @Entity
 @Getter
@@ -41,5 +43,34 @@ public class PipelineInputDefinition extends BasePipelineVariableDefinition {
     this.isRequired = isRequired;
     this.userProvided = userProvided;
     this.defaultValue = defaultValue;
+  }
+
+  // we override equals() below so that we can compare PipelineInputDefinition objects;
+  @Override
+  public int hashCode() {
+    return new HashCodeBuilder(17, 31)
+        // two randomly chosen prime numbers
+        .append(fileSuffix)
+        .append(isRequired)
+        .append(userProvided)
+        .append(defaultValue)
+        .appendSuper(super.hashCode())
+        .toHashCode();
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj instanceof PipelineInputDefinition otherObject)) return false;
+    if (obj == this) return true;
+    return new EqualsBuilder()
+        .append(fileSuffix, otherObject.fileSuffix)
+        .append(isRequired, otherObject.isRequired)
+        .append(userProvided, otherObject.userProvided)
+        .append(defaultValue, otherObject.defaultValue)
+        .append(getPipelineId(), otherObject.getPipelineId())
+        .append(getName(), otherObject.getName())
+        .append(getWdlVariableName(), otherObject.getWdlVariableName())
+        .append(getType(), otherObject.getType())
+        .isEquals();
   }
 }

--- a/service/src/main/java/bio/terra/pipelines/db/entities/PipelineOutputDefinition.java
+++ b/service/src/main/java/bio/terra/pipelines/db/entities/PipelineOutputDefinition.java
@@ -6,6 +6,7 @@ import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.apache.commons.lang3.builder.EqualsBuilder;
 
 @Entity
 @Getter
@@ -17,5 +18,23 @@ public class PipelineOutputDefinition extends BasePipelineVariableDefinition {
   public PipelineOutputDefinition(
       Long pipelineId, String name, String wdlVariableName, PipelineVariableTypesEnum type) {
     super(pipelineId, name, wdlVariableName, type);
+  }
+
+  // we override equals() below so that we can compare PipelineInputDefinition objects;
+  @Override
+  public int hashCode() {
+    return super.hashCode();
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj instanceof PipelineOutputDefinition otherObject)) return false;
+    if (obj == this) return true;
+    return new EqualsBuilder()
+        .append(getPipelineId(), otherObject.getPipelineId())
+        .append(getName(), otherObject.getName())
+        .append(getWdlVariableName(), otherObject.getWdlVariableName())
+        .append(getType(), otherObject.getType())
+        .isEquals();
   }
 }

--- a/service/src/main/java/bio/terra/pipelines/db/entities/PipelineOutputDefinition.java
+++ b/service/src/main/java/bio/terra/pipelines/db/entities/PipelineOutputDefinition.java
@@ -30,6 +30,7 @@ public class PipelineOutputDefinition extends BasePipelineVariableDefinition {
   public int hashCode() {
     return new HashCodeBuilder(17, 31)
         // two randomly chosen prime numbers
+        .append(getId())
         .append(getPipelineId())
         .append(getName())
         .append(getWdlVariableName())

--- a/service/src/main/java/bio/terra/pipelines/db/entities/PipelineOutputDefinition.java
+++ b/service/src/main/java/bio/terra/pipelines/db/entities/PipelineOutputDefinition.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 @Entity
 @Getter
@@ -20,10 +21,20 @@ public class PipelineOutputDefinition extends BasePipelineVariableDefinition {
     super(pipelineId, name, wdlVariableName, type);
   }
 
-  // we override equals() below so that we can compare PipelineInputDefinition objects;
+  @SuppressWarnings("java:S125") // The comment here isn't "commented code"
+  // we override equals() below so that we can compare PipelineOutputDefinition objects in tests;
+  // according to
+  // https://stackoverflow.com/questions/27581/what-issues-should-be-considered-when-overriding-equals-and-hashcode-in-java/27609#27609
+  // we should override hashCode() if we override equals()
   @Override
   public int hashCode() {
-    return super.hashCode();
+    return new HashCodeBuilder(17, 31)
+        // two randomly chosen prime numbers
+        .append(getPipelineId())
+        .append(getName())
+        .append(getWdlVariableName())
+        .append(getType())
+        .toHashCode();
   }
 
   @Override
@@ -31,6 +42,7 @@ public class PipelineOutputDefinition extends BasePipelineVariableDefinition {
     if (!(obj instanceof PipelineOutputDefinition otherObject)) return false;
     if (obj == this) return true;
     return new EqualsBuilder()
+        .append(getId(), otherObject.getId())
         .append(getPipelineId(), otherObject.getPipelineId())
         .append(getName(), otherObject.getName())
         .append(getWdlVariableName(), otherObject.getWdlVariableName())

--- a/service/src/test/java/bio/terra/pipelines/controller/AdminApiControllerTest.java
+++ b/service/src/test/java/bio/terra/pipelines/controller/AdminApiControllerTest.java
@@ -49,7 +49,9 @@ class AdminApiControllerTest {
 
   @BeforeEach
   void beforeEach() {
-    when(samUserFactoryMock.from(any(HttpServletRequest.class), any())).thenReturn(testUser);
+    when(samConfiguration.baseUri()).thenReturn("baseSamUri");
+    when(samUserFactoryMock.from(any(HttpServletRequest.class), eq("baseSamUri")))
+        .thenReturn(testUser);
     doNothing().when(samServiceMock).checkAdminAuthz(testUser);
   }
 

--- a/service/src/test/java/bio/terra/pipelines/controller/JobsApiControllerTest.java
+++ b/service/src/test/java/bio/terra/pipelines/controller/JobsApiControllerTest.java
@@ -2,6 +2,7 @@ package bio.terra.pipelines.controller;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -55,7 +56,9 @@ class JobsApiControllerTest {
 
   @BeforeEach
   void beforeEach() {
-    when(samUserFactoryMock.from(any(HttpServletRequest.class), any())).thenReturn(testUser);
+    when(samConfiguration.baseUri()).thenReturn("baseSamUri");
+    when(samUserFactoryMock.from(any(HttpServletRequest.class), eq("baseSamUri")))
+        .thenReturn(testUser);
   }
 
   @Test

--- a/service/src/test/java/bio/terra/pipelines/controller/PipelinesApiControllerTest.java
+++ b/service/src/test/java/bio/terra/pipelines/controller/PipelinesApiControllerTest.java
@@ -53,8 +53,10 @@ class PipelinesApiControllerTest {
 
   @BeforeEach
   void beforeEach() {
-    when(samUserFactoryMock.from(any(HttpServletRequest.class), any())).thenReturn(testUser);
-    when(pipelinesServiceMock.getPipeline(any())).thenReturn(getTestPipeline());
+    when(samConfiguration.baseUri()).thenReturn("baseSamUri");
+    when(samUserFactoryMock.from(any(HttpServletRequest.class), eq("baseSamUri")))
+        .thenReturn(testUser);
+    when(pipelinesServiceMock.getPipeline(any(PipelinesEnum.class))).thenReturn(getTestPipeline());
   }
 
   // getPipeline tests

--- a/service/src/test/java/bio/terra/pipelines/db/entities/PipelineInputDefinitionTest.java
+++ b/service/src/test/java/bio/terra/pipelines/db/entities/PipelineInputDefinitionTest.java
@@ -70,9 +70,12 @@ class PipelineInputDefinitionTest extends BaseTest {
             Boolean.TRUE,
             Boolean.TRUE,
             "default");
+    PipelineOutputDefinition pipelineOutputDefinition =
+        new PipelineOutputDefinition(4L, "name", "wdlVariableName", PipelineVariableTypesEnum.FILE);
     assertEquals(first, first);
     assertEquals(first, sameAsFirst);
     assertNotEquals(first, differentFromFirst);
     assertNotEquals(sameAsFirst, differentFromFirst);
+    assertNotEquals(first, pipelineOutputDefinition);
   }
 }

--- a/service/src/test/java/bio/terra/pipelines/db/entities/PipelineInputDefinitionTest.java
+++ b/service/src/test/java/bio/terra/pipelines/db/entities/PipelineInputDefinitionTest.java
@@ -1,0 +1,78 @@
+package bio.terra.pipelines.db.entities;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import bio.terra.pipelines.common.utils.PipelineVariableTypesEnum;
+import bio.terra.pipelines.testutils.BaseTest;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.junit.jupiter.api.Test;
+
+public class PipelineInputDefinitionTest extends BaseTest {
+
+  @Test
+  void hashCodeEquals() {
+    PipelineInputDefinition pipelineInputDefinition =
+        new PipelineInputDefinition(
+            4L,
+            "name",
+            "wdlVariableName",
+            PipelineVariableTypesEnum.FILE,
+            "suffix",
+            Boolean.TRUE,
+            Boolean.FALSE,
+            "default");
+    pipelineInputDefinition.setId(5L);
+    assertEquals(
+        new HashCodeBuilder(17, 31)
+            .append(5L)
+            .append(4L)
+            .append("name")
+            .append("wdlVariableName")
+            .append(PipelineVariableTypesEnum.FILE)
+            .append("suffix")
+            .append(Boolean.TRUE)
+            .append(Boolean.FALSE)
+            .append("default")
+            .toHashCode(),
+        pipelineInputDefinition.hashCode());
+  }
+
+  @Test
+  void equals() {
+    PipelineInputDefinition first =
+        new PipelineInputDefinition(
+            4L,
+            "name",
+            "wdlVariableName",
+            PipelineVariableTypesEnum.FILE,
+            "suffix",
+            Boolean.TRUE,
+            Boolean.FALSE,
+            "default");
+    PipelineInputDefinition sameAsFirst =
+        new PipelineInputDefinition(
+            4L,
+            "name",
+            "wdlVariableName",
+            PipelineVariableTypesEnum.FILE,
+            "suffix",
+            Boolean.TRUE,
+            Boolean.FALSE,
+            "default");
+    PipelineInputDefinition differentFromFirst =
+        new PipelineInputDefinition(
+            6L,
+            "name",
+            "wdlVariableName",
+            PipelineVariableTypesEnum.FILE,
+            "deeeeefault",
+            Boolean.TRUE,
+            Boolean.TRUE,
+            "default");
+    assertEquals(first, first);
+    assertEquals(first, sameAsFirst);
+    assertNotEquals(first, differentFromFirst);
+    assertNotEquals(sameAsFirst, differentFromFirst);
+  }
+}

--- a/service/src/test/java/bio/terra/pipelines/db/entities/PipelineInputDefinitionTest.java
+++ b/service/src/test/java/bio/terra/pipelines/db/entities/PipelineInputDefinitionTest.java
@@ -8,7 +8,7 @@ import bio.terra.pipelines.testutils.BaseTest;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.junit.jupiter.api.Test;
 
-public class PipelineInputDefinitionTest extends BaseTest {
+class PipelineInputDefinitionTest extends BaseTest {
 
   @Test
   void hashCodeEquals() {

--- a/service/src/test/java/bio/terra/pipelines/db/entities/PipelineOutputDefinitionTest.java
+++ b/service/src/test/java/bio/terra/pipelines/db/entities/PipelineOutputDefinitionTest.java
@@ -33,10 +33,21 @@ class PipelineOutputDefinitionTest extends BaseTest {
         new PipelineOutputDefinition(4L, "name", "wdlVariableName", PipelineVariableTypesEnum.FILE);
     PipelineOutputDefinition differentFromFirst =
         new PipelineOutputDefinition(6L, "name", "agadg", PipelineVariableTypesEnum.FILE);
+    PipelineInputDefinition pipelineInputDefinition =
+        new PipelineInputDefinition(
+            4L,
+            "name",
+            "wdlVariableName",
+            PipelineVariableTypesEnum.FILE,
+            "suffix",
+            Boolean.TRUE,
+            Boolean.FALSE,
+            "default");
 
     assertEquals(first, first);
     assertEquals(first, sameAsFirst);
     assertNotEquals(first, differentFromFirst);
     assertNotEquals(sameAsFirst, differentFromFirst);
+    assertNotEquals(first, pipelineInputDefinition);
   }
 }

--- a/service/src/test/java/bio/terra/pipelines/db/entities/PipelineOutputDefinitionTest.java
+++ b/service/src/test/java/bio/terra/pipelines/db/entities/PipelineOutputDefinitionTest.java
@@ -1,0 +1,42 @@
+package bio.terra.pipelines.db.entities;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import bio.terra.pipelines.common.utils.PipelineVariableTypesEnum;
+import bio.terra.pipelines.testutils.BaseTest;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.junit.jupiter.api.Test;
+
+public class PipelineOutputDefinitionTest extends BaseTest {
+
+  @Test
+  void hashCodeEquals() {
+    PipelineOutputDefinition pipelineOutputDefinition =
+        new PipelineOutputDefinition(4L, "name", "wdlVariableName", PipelineVariableTypesEnum.FILE);
+    pipelineOutputDefinition.setId(5L);
+    assertEquals(
+        new HashCodeBuilder(17, 31)
+            .append(5L)
+            .append(4L)
+            .append("name")
+            .append("wdlVariableName")
+            .append(PipelineVariableTypesEnum.FILE)
+            .toHashCode(),
+        pipelineOutputDefinition.hashCode());
+  }
+
+  @Test
+  void equals() {
+    PipelineOutputDefinition first =
+        new PipelineOutputDefinition(4L, "name", "wdlVariableName", PipelineVariableTypesEnum.FILE);
+    PipelineOutputDefinition sameAsFirst =
+        new PipelineOutputDefinition(4L, "name", "wdlVariableName", PipelineVariableTypesEnum.FILE);
+    PipelineOutputDefinition differentFromFirst =
+        new PipelineOutputDefinition(6L, "name", "agadg", PipelineVariableTypesEnum.FILE);
+
+    assertEquals(first, first);
+    assertEquals(first, sameAsFirst);
+    assertNotEquals(first, differentFromFirst);
+    assertNotEquals(sameAsFirst, differentFromFirst);
+  }
+}

--- a/service/src/test/java/bio/terra/pipelines/db/entities/PipelineOutputDefinitionTest.java
+++ b/service/src/test/java/bio/terra/pipelines/db/entities/PipelineOutputDefinitionTest.java
@@ -7,7 +7,7 @@ import bio.terra.pipelines.testutils.BaseTest;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.junit.jupiter.api.Test;
 
-public class PipelineOutputDefinitionTest extends BaseTest {
+class PipelineOutputDefinitionTest extends BaseTest {
 
   @Test
   void hashCodeEquals() {

--- a/service/src/test/java/bio/terra/pipelines/dependencies/cbas/CbasServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/dependencies/cbas/CbasServiceTest.java
@@ -1,7 +1,6 @@
 package bio.terra.pipelines.dependencies.cbas;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 import static org.mockito.Mockito.doReturn;
 
@@ -14,18 +13,25 @@ import bio.terra.cbas.model.*;
 import bio.terra.pipelines.app.configuration.external.CbasConfiguration;
 import bio.terra.pipelines.app.configuration.internal.RetryConfiguration;
 import bio.terra.pipelines.dependencies.common.HealthCheckWorkspaceApps;
+import bio.terra.pipelines.testutils.BaseEmbeddedDbTest;
 import java.net.SocketTimeoutException;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.stubbing.Answer;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.retry.backoff.FixedBackOffPolicy;
 import org.springframework.retry.support.RetryTemplate;
 
 @ExtendWith(MockitoExtension.class)
-class CbasServiceTest {
+class CbasServiceTest extends BaseEmbeddedDbTest {
+  @Autowired @InjectMocks CbasService cbasService;
+  @MockBean CbasClient cbasClient;
+
   final RetryConfiguration retryConfig = new RetryConfiguration();
   RetryTemplate template = retryConfig.listenerResetRetryTemplate();
 
@@ -51,15 +57,12 @@ class CbasServiceTest {
     MethodListResponse expectedResponse =
         new MethodListResponse().addMethodsItem(new MethodDetails().name("methodName"));
 
-    CbasClient cbasClient = mock(CbasClient.class);
     MethodsApi methodsApi = mock(MethodsApi.class);
-    when(methodsApi.getMethods(any(), any(), any()))
+    when(methodsApi.getMethods(null, null, null))
         .thenAnswer(errorAnswer)
         .thenReturn(expectedResponse);
 
-    CbasService cbasService = spy(new CbasService(cbasClient, template));
-
-    doReturn(methodsApi).when(cbasClient).methodsApi(any(), any());
+    doReturn(methodsApi).when(cbasClient).methodsApi(cbaseBaseUri, accessToken);
 
     assertEquals(expectedResponse, cbasService.getAllMethods(cbaseBaseUri, accessToken));
   }
@@ -70,17 +73,14 @@ class CbasServiceTest {
     MethodListResponse expectedResponse =
         new MethodListResponse().addMethodsItem(new MethodDetails().name("methodName"));
 
-    CbasClient cbasClient = mock(CbasClient.class);
     MethodsApi methodsApi = mock(MethodsApi.class);
-    when(methodsApi.getMethods(any(), any(), any()))
+    when(methodsApi.getMethods(null, null, null))
         .thenAnswer(errorAnswer)
         .thenAnswer(errorAnswer)
         .thenAnswer(errorAnswer)
         .thenReturn(expectedResponse);
 
-    CbasService cbasService = spy(new CbasService(cbasClient, template));
-
-    doReturn(methodsApi).when(cbasClient).methodsApi(any(), any());
+    doReturn(methodsApi).when(cbasClient).methodsApi(cbaseBaseUri, accessToken);
 
     assertThrows(
         SocketTimeoutException.class,
@@ -96,15 +96,12 @@ class CbasServiceTest {
 
     ApiException expectedException = new ApiException(400, "Bad Cbas");
 
-    CbasClient cbasClient = mock(CbasClient.class);
     MethodsApi methodsApi = mock(MethodsApi.class);
-    when(methodsApi.getMethods(any(), any(), any()))
+    when(methodsApi.getMethods(null, null, null))
         .thenThrow(expectedException)
         .thenReturn(expectedResponse);
 
-    CbasService cbasService = spy(new CbasService(cbasClient, template));
-
-    doReturn(methodsApi).when(cbasClient).methodsApi(any(), any());
+    doReturn(methodsApi).when(cbasClient).methodsApi(cbaseBaseUri, accessToken);
 
     CbasServiceApiException thrown =
         assertThrows(
@@ -130,13 +127,10 @@ class CbasServiceTest {
                     .methodId(UUID.randomUUID())
                     .description("this is my second method"));
 
-    CbasClient cbasClient = mock(CbasClient.class);
     MethodsApi methodsApi = mock(MethodsApi.class);
-    when(methodsApi.getMethods(any(), any(), any())).thenReturn(expectedResponse);
+    when(methodsApi.getMethods(null, null, null)).thenReturn(expectedResponse);
 
-    CbasService cbasService = spy(new CbasService(cbasClient, template));
-
-    doReturn(methodsApi).when(cbasClient).methodsApi(any(), any());
+    doReturn(methodsApi).when(cbasClient).methodsApi(cbaseBaseUri, accessToken);
 
     assertEquals(expectedResponse, cbasService.getAllMethods(cbaseBaseUri, accessToken));
   }
@@ -144,18 +138,14 @@ class CbasServiceTest {
   @Test
   void createMethodTest() throws ApiException {
     PostMethodResponse expectedResponse = new PostMethodResponse().methodId(UUID.randomUUID());
-
-    CbasClient cbasClient = mock(CbasClient.class);
+    PostMethodRequest postMethodRequest = new PostMethodRequest().methodName("hi name");
     MethodsApi methodsApi = mock(MethodsApi.class);
-    when(methodsApi.postMethod(any())).thenReturn(expectedResponse);
+    when(methodsApi.postMethod(postMethodRequest)).thenReturn(expectedResponse);
 
-    CbasService cbasService = spy(new CbasService(cbasClient, template));
-
-    doReturn(methodsApi).when(cbasClient).methodsApi(any(), any());
+    doReturn(methodsApi).when(cbasClient).methodsApi(cbaseBaseUri, accessToken);
 
     assertEquals(
-        expectedResponse,
-        cbasService.createMethod(cbaseBaseUri, accessToken, new PostMethodRequest()));
+        expectedResponse, cbasService.createMethod(cbaseBaseUri, accessToken, postMethodRequest));
   }
 
   @Test
@@ -165,35 +155,30 @@ class CbasServiceTest {
             .state(RunSetState.RUNNING)
             .runSetId(UUID.randomUUID())
             .addRunsItem(new RunStateResponse().runId(UUID.randomUUID()).state(RunState.RUNNING));
+    RunSetRequest runSetRequest = new RunSetRequest().runSetName("hi run ste name");
 
-    CbasClient cbasClient = mock(CbasClient.class);
     RunSetsApi runSetsApi = mock(RunSetsApi.class);
-    when(runSetsApi.postRunSet(any())).thenReturn(expectedResponse);
+    when(runSetsApi.postRunSet(runSetRequest)).thenReturn(expectedResponse);
 
-    CbasService cbasService = spy(new CbasService(cbasClient, template));
-
-    doReturn(runSetsApi).when(cbasClient).runSetsApi(any(), any());
+    doReturn(runSetsApi).when(cbasClient).runSetsApi(cbaseBaseUri, accessToken);
 
     assertEquals(
-        expectedResponse, cbasService.createRunSet(cbaseBaseUri, accessToken, new RunSetRequest()));
+        expectedResponse, cbasService.createRunSet(cbaseBaseUri, accessToken, runSetRequest));
   }
 
   @Test
   void getRunsForRunSetTest() throws ApiException {
     RunLogResponse expectedResponse =
         new RunLogResponse().addRunsItem(new RunLog().state(RunState.RUNNING));
+    UUID runSetId = UUID.randomUUID();
 
-    CbasClient cbasClient = mock(CbasClient.class);
     RunsApi runsApi = mock(RunsApi.class);
-    when(runsApi.getRuns(any())).thenReturn(expectedResponse);
+    when(runsApi.getRuns(runSetId)).thenReturn(expectedResponse);
 
-    CbasService cbasService = spy(new CbasService(cbasClient, template));
-
-    doReturn(runsApi).when(cbasClient).runsApi(any(), any());
+    doReturn(runsApi).when(cbasClient).runsApi(cbaseBaseUri, accessToken);
 
     assertEquals(
-        expectedResponse,
-        cbasService.getRunsForRunSet(cbaseBaseUri, accessToken, UUID.randomUUID()));
+        expectedResponse, cbasService.getRunsForRunSet(cbaseBaseUri, accessToken, runSetId));
   }
 
   @Test
@@ -204,11 +189,12 @@ class CbasServiceTest {
     SystemStatus systemStatus = new SystemStatus();
     systemStatus.setOk(true);
 
-    doReturn(publicApi).when(cbasClient).publicApi(any(), any());
+    doReturn(publicApi).when(cbasClient).publicApi(cbaseBaseUri, accessToken);
     when(publicApi.getStatus()).thenReturn(systemStatus);
 
     CbasService cbasService = spy(new CbasService(cbasClient, template));
-    HealthCheckWorkspaceApps.Result actualResult = cbasService.checkHealth("baseuri", "token");
+    HealthCheckWorkspaceApps.Result actualResult =
+        cbasService.checkHealth(cbaseBaseUri, accessToken);
 
     assertEquals(
         new HealthCheckWorkspaceApps.Result(systemStatus.isOk(), systemStatus.toString()),
@@ -223,7 +209,7 @@ class CbasServiceTest {
     String exceptionMessage = "this is my exception message";
     ApiException apiException = new ApiException(exceptionMessage);
 
-    doReturn(publicApi).when(cbasClient).publicApi(any(), any());
+    doReturn(publicApi).when(cbasClient).publicApi(cbaseBaseUri, accessToken);
     when(publicApi.getStatus()).thenThrow(apiException);
 
     HealthCheckWorkspaceApps.Result expectedResultOnFail =
@@ -231,7 +217,8 @@ class CbasServiceTest {
 
     CbasService cbasService = spy(new CbasService(cbasClient, template));
 
-    HealthCheckWorkspaceApps.Result actualResult = cbasService.checkHealth("baseuri", "token");
+    HealthCheckWorkspaceApps.Result actualResult =
+        cbasService.checkHealth(cbaseBaseUri, accessToken);
 
     assertEquals(expectedResultOnFail, actualResult);
   }

--- a/service/src/test/java/bio/terra/pipelines/dependencies/cbas/CbasServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/dependencies/cbas/CbasServiceTest.java
@@ -183,7 +183,6 @@ class CbasServiceTest extends BaseEmbeddedDbTest {
 
   @Test
   void checkHealth() throws ApiException {
-    CbasClient cbasClient = mock(CbasClient.class);
     PublicApi publicApi = mock(PublicApi.class);
 
     SystemStatus systemStatus = new SystemStatus();
@@ -192,7 +191,6 @@ class CbasServiceTest extends BaseEmbeddedDbTest {
     doReturn(publicApi).when(cbasClient).publicApi(cbaseBaseUri, accessToken);
     when(publicApi.getStatus()).thenReturn(systemStatus);
 
-    CbasService cbasService = spy(new CbasService(cbasClient, template));
     HealthCheckWorkspaceApps.Result actualResult =
         cbasService.checkHealth(cbaseBaseUri, accessToken);
 
@@ -203,7 +201,6 @@ class CbasServiceTest extends BaseEmbeddedDbTest {
 
   @Test
   void checkHealthWithException() throws ApiException {
-    CbasClient cbasClient = mock(CbasClient.class);
     PublicApi publicApi = mock(PublicApi.class);
 
     String exceptionMessage = "this is my exception message";
@@ -214,8 +211,6 @@ class CbasServiceTest extends BaseEmbeddedDbTest {
 
     HealthCheckWorkspaceApps.Result expectedResultOnFail =
         new HealthCheckWorkspaceApps.Result(false, apiException.getMessage());
-
-    CbasService cbasService = spy(new CbasService(cbasClient, template));
 
     HealthCheckWorkspaceApps.Result actualResult =
         cbasService.checkHealth(cbaseBaseUri, accessToken);

--- a/service/src/test/java/bio/terra/pipelines/dependencies/leonardo/LeonardoServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/dependencies/leonardo/LeonardoServiceTest.java
@@ -46,6 +46,8 @@ class LeonardoServiceTest extends BaseEmbeddedDbTest {
     FixedBackOffPolicy smallerBackoff = new FixedBackOffPolicy();
     smallerBackoff.setBackOffPeriod(5L); // 5 ms
     template.setBackOffPolicy(smallerBackoff);
+
+    leonardoService = spy(new LeonardoService(leonardoClient, appUtils, template));
   }
 
   @Test
@@ -56,8 +58,6 @@ class LeonardoServiceTest extends BaseEmbeddedDbTest {
     when(appsApi.listAppsV2(workspaceId, null, null, null))
         .thenAnswer(errorAnswer)
         .thenReturn(expectedResponse);
-
-    leonardoService = spy(new LeonardoService(leonardoClient, appUtils, template));
 
     doReturn(appsApi).when(leonardoService).getAppsApi(authToken);
 
@@ -75,8 +75,6 @@ class LeonardoServiceTest extends BaseEmbeddedDbTest {
         .thenAnswer(errorAnswer)
         .thenAnswer(errorAnswer)
         .thenReturn(expectedResponse);
-
-    leonardoService = spy(new LeonardoService(leonardoClient, appUtils, template));
 
     doReturn(appsApi).when(leonardoService).getAppsApi(authToken);
 
@@ -98,8 +96,6 @@ class LeonardoServiceTest extends BaseEmbeddedDbTest {
         .thenThrow(expectedException)
         .thenReturn(expectedResponse);
 
-    leonardoService = spy(new LeonardoService(leonardoClient, appUtils, template));
-
     doReturn(appsApi).when(leonardoService).getAppsApi(authToken);
 
     LeonardoServiceApiException thrown =
@@ -113,7 +109,6 @@ class LeonardoServiceTest extends BaseEmbeddedDbTest {
 
   @Test
   void getWdsUrlFromApp() {
-    leonardoService = spy(new LeonardoService(leonardoClient, appUtils, template));
 
     List<ListAppResponse> listAppResponseList = List.of(new ListAppResponse().appName("hhaha"));
     doReturn(listAppResponseList).when(leonardoService).getApps(workspaceId, authToken);
@@ -125,7 +120,6 @@ class LeonardoServiceTest extends BaseEmbeddedDbTest {
   @Test
   void getWdsUrlFromAppResponse() {
     List<ListAppResponse> listAppResponseList = List.of(new ListAppResponse().appName("hhaasdha"));
-    leonardoService = spy(new LeonardoService(leonardoClient, appUtils, template));
     doReturn("bestWdsUri").when(appUtils).findUrlForWds(listAppResponseList, workspaceId);
 
     assertEquals(
@@ -135,7 +129,6 @@ class LeonardoServiceTest extends BaseEmbeddedDbTest {
 
   @Test
   void getCbasUrlFromApp() {
-    leonardoService = spy(new LeonardoService(leonardoClient, appUtils, template));
 
     List<ListAppResponse> listAppResponseList = List.of(new ListAppResponse().appName("hhaasdha"));
     doReturn(listAppResponseList).when(leonardoService).getApps(workspaceId, authToken);
@@ -146,7 +139,6 @@ class LeonardoServiceTest extends BaseEmbeddedDbTest {
 
   @Test
   void getCbasUrlFromAppResponse() {
-    leonardoService = spy(new LeonardoService(leonardoClient, appUtils, template));
 
     List<ListAppResponse> listAppResponseList = List.of(new ListAppResponse().appName("hhaasdha"));
     doReturn("bestCbasUri").when(appUtils).findUrlForCbas(listAppResponseList, workspaceId);
@@ -158,7 +150,6 @@ class LeonardoServiceTest extends BaseEmbeddedDbTest {
 
   @Test
   void createAppV2() {
-    leonardoService = spy(new LeonardoService(leonardoClient, appUtils, template));
     Map map = Map.of("blah", "ok");
     String appName = UUID.randomUUID().toString();
 
@@ -179,8 +170,6 @@ class LeonardoServiceTest extends BaseEmbeddedDbTest {
 
     when(serviceInfoApi.getSystemStatus()).thenReturn(systemStatus);
 
-    leonardoService = spy(new LeonardoService(leonardoClient, appUtils, template));
-
     doReturn(serviceInfoApi).when(leonardoService).getServiceInfoApi();
     HealthCheck.Result actualResult = leonardoService.checkHealth();
 
@@ -198,7 +187,6 @@ class LeonardoServiceTest extends BaseEmbeddedDbTest {
 
     HealthCheck.Result expectedResultOnFail =
         new HealthCheck.Result(false, apiException.getMessage());
-    leonardoService = spy(new LeonardoService(leonardoClient, appUtils, template));
 
     doReturn(serviceInfoApi).when(leonardoService).getServiceInfoApi();
     HealthCheck.Result actualResult = leonardoService.checkHealth();

--- a/service/src/test/java/bio/terra/pipelines/dependencies/leonardo/LeonardoServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/dependencies/leonardo/LeonardoServiceTest.java
@@ -57,7 +57,7 @@ class LeonardoServiceTest extends BaseEmbeddedDbTest {
         .thenAnswer(errorAnswer)
         .thenReturn(expectedResponse);
 
-    LeonardoService leonardoService = spy(new LeonardoService(leonardoClient, appUtils, template));
+    leonardoService = spy(new LeonardoService(leonardoClient, appUtils, template));
 
     doReturn(appsApi).when(leonardoService).getAppsApi(authToken);
 
@@ -76,7 +76,7 @@ class LeonardoServiceTest extends BaseEmbeddedDbTest {
         .thenAnswer(errorAnswer)
         .thenReturn(expectedResponse);
 
-    LeonardoService leonardoService = spy(new LeonardoService(leonardoClient, appUtils, template));
+    leonardoService = spy(new LeonardoService(leonardoClient, appUtils, template));
 
     doReturn(appsApi).when(leonardoService).getAppsApi(authToken);
 
@@ -98,7 +98,7 @@ class LeonardoServiceTest extends BaseEmbeddedDbTest {
         .thenThrow(expectedException)
         .thenReturn(expectedResponse);
 
-    LeonardoService leonardoService = spy(new LeonardoService(leonardoClient, appUtils, template));
+    leonardoService = spy(new LeonardoService(leonardoClient, appUtils, template));
 
     doReturn(appsApi).when(leonardoService).getAppsApi(authToken);
 
@@ -113,7 +113,7 @@ class LeonardoServiceTest extends BaseEmbeddedDbTest {
 
   @Test
   void getWdsUrlFromApp() {
-    LeonardoService leonardoService = spy(new LeonardoService(leonardoClient, appUtils, template));
+    leonardoService = spy(new LeonardoService(leonardoClient, appUtils, template));
 
     List<ListAppResponse> listAppResponseList = List.of(new ListAppResponse().appName("hhaha"));
     doReturn(listAppResponseList).when(leonardoService).getApps(workspaceId, authToken);
@@ -125,7 +125,7 @@ class LeonardoServiceTest extends BaseEmbeddedDbTest {
   @Test
   void getWdsUrlFromAppResponse() {
     List<ListAppResponse> listAppResponseList = List.of(new ListAppResponse().appName("hhaasdha"));
-    LeonardoService leonardoService = spy(new LeonardoService(leonardoClient, appUtils, template));
+    leonardoService = spy(new LeonardoService(leonardoClient, appUtils, template));
     doReturn("bestWdsUri").when(appUtils).findUrlForWds(listAppResponseList, workspaceId);
 
     assertEquals(
@@ -135,7 +135,7 @@ class LeonardoServiceTest extends BaseEmbeddedDbTest {
 
   @Test
   void getCbasUrlFromApp() {
-    LeonardoService leonardoService = spy(new LeonardoService(leonardoClient, appUtils, template));
+    leonardoService = spy(new LeonardoService(leonardoClient, appUtils, template));
 
     List<ListAppResponse> listAppResponseList = List.of(new ListAppResponse().appName("hhaasdha"));
     doReturn(listAppResponseList).when(leonardoService).getApps(workspaceId, authToken);
@@ -146,7 +146,7 @@ class LeonardoServiceTest extends BaseEmbeddedDbTest {
 
   @Test
   void getCbasUrlFromAppResponse() {
-    LeonardoService leonardoService = spy(new LeonardoService(leonardoClient, appUtils, template));
+    leonardoService = spy(new LeonardoService(leonardoClient, appUtils, template));
 
     List<ListAppResponse> listAppResponseList = List.of(new ListAppResponse().appName("hhaasdha"));
     doReturn("bestCbasUri").when(appUtils).findUrlForCbas(listAppResponseList, workspaceId);
@@ -158,7 +158,7 @@ class LeonardoServiceTest extends BaseEmbeddedDbTest {
 
   @Test
   void createAppV2() {
-    LeonardoService leonardoService = spy(new LeonardoService(leonardoClient, appUtils, template));
+    leonardoService = spy(new LeonardoService(leonardoClient, appUtils, template));
     Map map = Map.of("blah", "ok");
     String appName = UUID.randomUUID().toString();
 
@@ -172,7 +172,6 @@ class LeonardoServiceTest extends BaseEmbeddedDbTest {
 
   @Test
   void checkHealth() throws ApiException {
-    LeonardoClient leonardoClient = mock(LeonardoClient.class);
     ServiceInfoApi serviceInfoApi = mock(ServiceInfoApi.class);
 
     SystemStatus systemStatus = new SystemStatus();
@@ -180,7 +179,7 @@ class LeonardoServiceTest extends BaseEmbeddedDbTest {
 
     when(serviceInfoApi.getSystemStatus()).thenReturn(systemStatus);
 
-    LeonardoService leonardoService = spy(new LeonardoService(leonardoClient, appUtils, template));
+    leonardoService = spy(new LeonardoService(leonardoClient, appUtils, template));
 
     doReturn(serviceInfoApi).when(leonardoService).getServiceInfoApi();
     HealthCheck.Result actualResult = leonardoService.checkHealth();
@@ -191,7 +190,6 @@ class LeonardoServiceTest extends BaseEmbeddedDbTest {
 
   @Test
   void checkHealthWithException() throws ApiException {
-    LeonardoClient leonardoClient = mock(LeonardoClient.class);
     ServiceInfoApi serviceInfoApi = mock(ServiceInfoApi.class);
 
     String exceptionMessage = "this is my exception message";
@@ -200,7 +198,7 @@ class LeonardoServiceTest extends BaseEmbeddedDbTest {
 
     HealthCheck.Result expectedResultOnFail =
         new HealthCheck.Result(false, apiException.getMessage());
-    LeonardoService leonardoService = spy(new LeonardoService(leonardoClient, appUtils, template));
+    leonardoService = spy(new LeonardoService(leonardoClient, appUtils, template));
 
     doReturn(serviceInfoApi).when(leonardoService).getServiceInfoApi();
     HealthCheck.Result actualResult = leonardoService.checkHealth();

--- a/service/src/test/java/bio/terra/pipelines/dependencies/sam/SamServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/dependencies/sam/SamServiceTest.java
@@ -113,7 +113,7 @@ class SamServiceTest extends BaseEmbeddedDbTest {
     when(samClient.adminApi("blahToken")).thenReturn(adminApi);
 
     samService.checkAdminAuthz(
-        new SamUser("blahEmail", "blahSubjectId", new BearerToken("blahToken")));
+        new SamUser("blahEmail", "doesnt matter", new BearerToken("blahToken")));
   }
 
   @Test

--- a/service/src/test/java/bio/terra/pipelines/dependencies/sam/SamServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/dependencies/sam/SamServiceTest.java
@@ -88,9 +88,7 @@ class SamServiceTest extends BaseEmbeddedDbTest {
     GoogleCredentials mockCredentials = GoogleCredentials.create(new AccessToken("hi", null));
 
     try (MockedStatic<GoogleCredentials> utilities = Mockito.mockStatic(GoogleCredentials.class)) {
-      SamClient samClient = mock(SamClient.class);
       utilities.when(GoogleCredentials::getApplicationDefault).thenReturn(mockCredentials);
-      SamService samService = new SamService(samClient);
       String token = samService.getTeaspoonsServiceAccountToken();
       assertEquals("hi", token);
     }

--- a/service/src/test/java/bio/terra/pipelines/dependencies/sam/SamServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/dependencies/sam/SamServiceTest.java
@@ -104,7 +104,6 @@ class SamServiceTest extends BaseEmbeddedDbTest {
   @Test
   void getServiceAccountTokenThrows() {
     // this should throw an exception because there are no credentials available by default
-    SamService samService = new SamService(samClient);
     assertThrows(InternalServerErrorException.class, samService::getTeaspoonsServiceAccountToken);
   }
 
@@ -121,13 +120,10 @@ class SamServiceTest extends BaseEmbeddedDbTest {
 
   @Test
   void isAdminNotAdminForbiddenException() throws ApiException {
-    SamClient samClient = mock(SamClient.class);
     AdminApi adminApi = mock(AdminApi.class);
 
     when(adminApi.adminGetUserByEmail("doesnt matter")).thenThrow(ApiException.class);
     when(samClient.adminApi("blah")).thenReturn(adminApi);
-
-    SamService samService = spy(new SamService(samClient));
 
     SamUser samUser = new SamUser("doesnt matter", "really doesnt matter", new BearerToken("blah"));
     assertThrows(

--- a/service/src/test/java/bio/terra/pipelines/dependencies/stairway/JobServiceMockTest.java
+++ b/service/src/test/java/bio/terra/pipelines/dependencies/stairway/JobServiceMockTest.java
@@ -18,7 +18,6 @@ import java.util.UUID;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentMatchers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 
@@ -44,12 +43,12 @@ class JobServiceMockTest extends BaseEmbeddedDbTest {
 
   @Test
   void submitStairwayException() throws InterruptedException {
+    UUID jobId = TestUtils.TEST_NEW_UUID;
     // a MakeFlightException is an instance of StairwayException
     doThrow(new MakeFlightException("test exception"))
         .when(mockStairway)
-        .submitWithDebugInfo(any(), any(), any(), ArgumentMatchers.eq(false), any());
+        .submitWithDebugInfo(jobId.toString(), null, null, false, null);
 
-    UUID jobId = TestUtils.TEST_NEW_UUID;
     assertThrows(InternalStairwayException.class, () -> jobService.submit(null, null, jobId));
   }
 
@@ -64,7 +63,7 @@ class JobServiceMockTest extends BaseEmbeddedDbTest {
         StairwayTestUtils.constructFlightStateWithStatusAndId(
             FlightStatus.SUCCESS, flightId, inputParams, flightMap);
 
-    when(mockStairway.getFlightState(any())).thenReturn(successFlightState);
+    when(mockStairway.getFlightState(flightId.toString())).thenReturn(successFlightState);
 
     JobService.JobResultOrException<String> resultOrException =
         jobService.retrieveJobResult(flightId, String.class);
@@ -82,7 +81,7 @@ class JobServiceMockTest extends BaseEmbeddedDbTest {
         StairwayTestUtils.constructFlightStateWithStatusAndId(
             FlightStatus.SUCCESS, flightId, inputParams, flightMap);
 
-    when(mockStairway.getFlightState(any())).thenReturn(successFlightState);
+    when(mockStairway.getFlightState(flightId.toString())).thenReturn(successFlightState);
 
     JobService.JobResultOrException<String> resultOrException =
         jobService.retrieveJobResult(flightId, null, new TypeReference<>() {});
@@ -99,7 +98,7 @@ class JobServiceMockTest extends BaseEmbeddedDbTest {
         StairwayTestUtils.constructFlightStateWithStatusAndId(
             FlightStatus.SUCCESS, flightId, inputParams, flightMap);
 
-    when(mockStairway.getFlightState(any())).thenReturn(successFlightState);
+    when(mockStairway.getFlightState(flightId.toString())).thenReturn(successFlightState);
 
     assertThrows(
         InvalidResultStateException.class,
@@ -113,7 +112,7 @@ class JobServiceMockTest extends BaseEmbeddedDbTest {
         StairwayTestUtils.constructFlightStateWithStatusAndId(FlightStatus.FATAL, flightId);
     fatalFlightState.setException(new RuntimeException("test exception"));
 
-    when(mockStairway.getFlightState(any())).thenReturn(fatalFlightState);
+    when(mockStairway.getFlightState(flightId.toString())).thenReturn(fatalFlightState);
 
     JobService.JobResultOrException result =
         jobService.retrieveJobResult(flightId, JobService.JobResultOrException.class);
@@ -128,7 +127,7 @@ class JobServiceMockTest extends BaseEmbeddedDbTest {
     // non-runtime exception should be caught and stored as an InternalServerErrorException
     fatalFlightState.setException(new InterruptedException());
 
-    when(mockStairway.getFlightState(any())).thenReturn(fatalFlightState);
+    when(mockStairway.getFlightState(flightId.toString())).thenReturn(fatalFlightState);
 
     JobService.JobResultOrException result =
         jobService.retrieveJobResult(flightId, JobService.JobResultOrException.class);
@@ -142,7 +141,7 @@ class JobServiceMockTest extends BaseEmbeddedDbTest {
         StairwayTestUtils.constructFlightStateWithStatusAndId(FlightStatus.ERROR, flightId);
     errorFlightState.setException(new RuntimeException("test exception"));
 
-    when(mockStairway.getFlightState(any())).thenReturn(errorFlightState);
+    when(mockStairway.getFlightState(flightId.toString())).thenReturn(errorFlightState);
 
     JobService.JobResultOrException result =
         jobService.retrieveJobResult(flightId, JobService.JobResultOrException.class);
@@ -153,7 +152,8 @@ class JobServiceMockTest extends BaseEmbeddedDbTest {
   void retrieveJobResultStairwayException() throws InterruptedException {
     UUID flightId = TestUtils.TEST_NEW_UUID;
     // a MakeFlightException is an instance of StairwayException
-    when(mockStairway.getFlightState(any())).thenThrow(new MakeFlightException("test exception"));
+    when(mockStairway.getFlightState(flightId.toString()))
+        .thenThrow(new MakeFlightException("test exception"));
 
     assertThrows(
         InternalStairwayException.class,
@@ -166,7 +166,7 @@ class JobServiceMockTest extends BaseEmbeddedDbTest {
     FlightState runningFlightState =
         StairwayTestUtils.constructFlightStateWithStatusAndId(FlightStatus.RUNNING, flightId);
 
-    when(mockStairway.getFlightState(any())).thenReturn(runningFlightState);
+    when(mockStairway.getFlightState(flightId.toString())).thenReturn(runningFlightState);
 
     assertThrows(
         JobNotCompleteException.class,
@@ -176,7 +176,8 @@ class JobServiceMockTest extends BaseEmbeddedDbTest {
   @Test
   void retrieveJobResultInterrupted() throws InterruptedException {
     UUID flightId = TestUtils.TEST_NEW_UUID;
-    when(mockStairway.getFlightState(any())).thenThrow(new InterruptedException("test exception"));
+    when(mockStairway.getFlightState(flightId.toString()))
+        .thenThrow(new InterruptedException("test exception"));
 
     assertThrows(
         InternalStairwayException.class,
@@ -188,7 +189,8 @@ class JobServiceMockTest extends BaseEmbeddedDbTest {
     UUID flightId = TestUtils.TEST_NEW_UUID;
     String userId = "testUserId";
     // a MakeFlightException is an instance of StairwayException
-    when(mockStairway.getFlightState(any())).thenThrow(new MakeFlightException("test exception"));
+    when(mockStairway.getFlightState(flightId.toString()))
+        .thenThrow(new MakeFlightException("test exception"));
 
     assertThrows(
         InternalStairwayException.class, () -> jobService.retrieveJob(flightId, userId, null));
@@ -199,7 +201,7 @@ class JobServiceMockTest extends BaseEmbeddedDbTest {
     UUID flightId = TestUtils.TEST_NEW_UUID;
     String userId = "testUserId";
 
-    when(mockStairway.getFlightState(any())).thenThrow(new InterruptedException());
+    when(mockStairway.getFlightState(flightId.toString())).thenThrow(new InterruptedException());
 
     // InterruptedException should be caught and re-thrown as an InternalStairwayException
     assertThrows(
@@ -210,7 +212,7 @@ class JobServiceMockTest extends BaseEmbeddedDbTest {
   void enumerateJobsStairwayException() throws InterruptedException {
     String userId = "testUserId";
     // a MakeFlightException is an instance of StairwayException
-    when(mockStairway.getFlights(any(), any(), any()))
+    when(mockStairway.getFlights((String) eq(null), eq(10), any(FlightFilter.class)))
         .thenThrow(new MakeFlightException("test exception"));
 
     assertThrows(
@@ -221,7 +223,8 @@ class JobServiceMockTest extends BaseEmbeddedDbTest {
   void enumerateJobsInterruptedException() throws InterruptedException {
     String userId = "testUserId";
 
-    when(mockStairway.getFlights(any(), any(), any())).thenThrow(new InterruptedException());
+    when(mockStairway.getFlights((String) eq(null), eq(10), any(FlightFilter.class)))
+        .thenThrow(new InterruptedException());
 
     // InterruptedException should be caught and re-thrown as an InternalStairwayException
     assertThrows(
@@ -236,7 +239,7 @@ class JobServiceMockTest extends BaseEmbeddedDbTest {
         StairwayTestUtils.constructFlightStateWithStatusAndId(
             FlightStatus.RUNNING, jobId, inputParameters, new FlightMap());
 
-    when(mockStairway.getFlightState(any())).thenReturn(flightState);
+    when(mockStairway.getFlightState(jobId.toString())).thenReturn(flightState);
 
     JobApiUtils.AsyncJobResult<String> result =
         jobService.retrieveAsyncJobResult(jobId, TestUtils.TEST_USER_ID_1, String.class, null);
@@ -258,7 +261,7 @@ class JobServiceMockTest extends BaseEmbeddedDbTest {
         StairwayTestUtils.constructFlightStateWithStatusAndId(
             FlightStatus.SUCCESS, jobId, inputParameters, workingMap);
 
-    when(mockStairway.getFlightState(any())).thenReturn(flightState);
+    when(mockStairway.getFlightState(jobId.toString())).thenReturn(flightState);
 
     JobApiUtils.AsyncJobResult<String> result =
         jobService.retrieveAsyncJobResult(jobId, TestUtils.TEST_USER_ID_1, String.class, null);
@@ -284,7 +287,7 @@ class JobServiceMockTest extends BaseEmbeddedDbTest {
     RuntimeException exception = new RuntimeException(testErrorMsg);
     flightState.setException(exception);
 
-    when(mockStairway.getFlightState(any())).thenReturn(flightState);
+    when(mockStairway.getFlightState(jobId.toString())).thenReturn(flightState);
 
     JobApiUtils.AsyncJobResult<String> result =
         jobService.retrieveAsyncJobResult(jobId, TestUtils.TEST_USER_ID_1, String.class, null);
@@ -299,7 +302,8 @@ class JobServiceMockTest extends BaseEmbeddedDbTest {
   void retrieveAsyncJobResultStairwayException() throws InterruptedException {
     UUID flightId = TestUtils.TEST_NEW_UUID;
     // a MakeFlightException is an instance of StairwayException
-    when(mockStairway.getFlightState(any())).thenThrow(new MakeFlightException("test exception"));
+    when(mockStairway.getFlightState(flightId.toString()))
+        .thenThrow(new MakeFlightException("test exception"));
 
     assertThrows(
         InternalStairwayException.class,

--- a/service/src/test/java/bio/terra/pipelines/dependencies/wds/WdsServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/dependencies/wds/WdsServiceTest.java
@@ -4,33 +4,45 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
-import bio.terra.pipelines.app.configuration.external.WdsServerConfiguration;
 import bio.terra.pipelines.app.configuration.internal.RetryConfiguration;
 import bio.terra.pipelines.dependencies.common.DependencyNotAvailableException;
 import bio.terra.pipelines.dependencies.common.HealthCheckWorkspaceApps;
+import bio.terra.pipelines.testutils.BaseEmbeddedDbTest;
 import java.net.SocketTimeoutException;
 import java.util.List;
 import org.databiosphere.workspacedata.api.GeneralWdsInformationApi;
 import org.databiosphere.workspacedata.api.RecordsApi;
 import org.databiosphere.workspacedata.api.SchemaApi;
 import org.databiosphere.workspacedata.client.ApiException;
+import org.databiosphere.workspacedata.model.RecordRequest;
 import org.databiosphere.workspacedata.model.RecordResponse;
 import org.databiosphere.workspacedata.model.RecordTypeSchema;
 import org.databiosphere.workspacedata.model.StatusResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.stubbing.Answer;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.retry.backoff.FixedBackOffPolicy;
 import org.springframework.retry.support.RetryTemplate;
 
 @ExtendWith(MockitoExtension.class)
-class WdsServiceTest {
+class WdsServiceTest extends BaseEmbeddedDbTest {
+  @Autowired @InjectMocks WdsService wdsService;
+  @MockBean WdsClient wdsClient;
+
   final RetryConfiguration retryConfig = new RetryConfiguration();
   RetryTemplate template = retryConfig.listenerResetRetryTemplate();
 
-  final WdsServerConfiguration wdsServerConfiguration = new WdsServerConfiguration("v0.2", false);
+  private final String workspaceId = "workspaceId";
+  private final String wdsApiVersion = "testapiv"; // matches value in test application.yaml
+  private final String recordType = "recordType";
+  private final String recordId = "recordId";
+  private final String baseUri = "wdsUri";
+  private final String bearerToken = "bearerToken";
 
   final Answer<Object> errorAnswer =
       invocation -> {
@@ -47,18 +59,16 @@ class WdsServiceTest {
   @Test
   void socketExceptionRetriesEventuallySucceed() throws Exception {
     RecordResponse expectedResponse = new RecordResponse().id("idTest").type("typeTest");
-
-    WdsClient wdsClient = mock(WdsClient.class);
     RecordsApi recordsApi = mock(RecordsApi.class);
-    when(recordsApi.getRecord(any(), any(), any(), any()))
+    when(recordsApi.getRecord(workspaceId, wdsApiVersion, recordType, recordId))
         .thenAnswer(errorAnswer)
         .thenReturn(expectedResponse);
 
-    WdsService wdsService = spy(new WdsService(wdsClient, wdsServerConfiguration, template));
+    doReturn(recordsApi).when(wdsClient).recordsApi(baseUri, bearerToken);
 
-    doReturn(recordsApi).when(wdsClient).recordsApi(any(), any());
-
-    assertEquals(expectedResponse, wdsService.getRecord(any(), any(), any(), any(), any()));
+    assertEquals(
+        expectedResponse,
+        wdsService.getRecord(baseUri, bearerToken, recordType, workspaceId, recordId));
   }
 
   // our retry template only attempts a retryable call 3 total times
@@ -66,22 +76,19 @@ class WdsServiceTest {
   void socketExceptionRetriesEventuallyFail() throws Exception {
     RecordResponse expectedResponse = new RecordResponse().id("idTest").type("typeTest");
 
-    WdsClient wdsClient = mock(WdsClient.class);
     RecordsApi recordsApi = mock(RecordsApi.class);
-    when(recordsApi.getRecord(any(), any(), any(), any()))
+    when(recordsApi.getRecord(workspaceId, wdsApiVersion, recordType, recordId))
         .thenAnswer(errorAnswer)
         .thenAnswer(errorAnswer)
         .thenAnswer(errorAnswer)
         .thenReturn(expectedResponse);
 
-    WdsService wdsService = spy(new WdsService(wdsClient, wdsServerConfiguration, template));
-
-    doReturn(recordsApi).when(wdsClient).recordsApi(any(), any());
+    doReturn(recordsApi).when(wdsClient).recordsApi(baseUri, bearerToken);
 
     assertThrows(
         SocketTimeoutException.class,
         () -> {
-          wdsService.getRecord(any(), any(), any(), any(), any());
+          wdsService.getRecord(baseUri, bearerToken, recordType, workspaceId, recordId);
         });
   }
 
@@ -91,21 +98,18 @@ class WdsServiceTest {
 
     ApiException expectedException = new ApiException(400, "Bad Wds");
 
-    WdsClient wdsClient = mock(WdsClient.class);
     RecordsApi recordsApi = mock(RecordsApi.class);
-    when(recordsApi.getRecord(any(), any(), any(), any()))
+    when(recordsApi.getRecord(workspaceId, wdsApiVersion, recordType, recordId))
         .thenThrow(expectedException)
         .thenReturn(expectedResponse);
 
-    WdsService wdsService = spy(new WdsService(wdsClient, wdsServerConfiguration, template));
-
-    doReturn(recordsApi).when(wdsClient).recordsApi(any(), any());
+    doReturn(recordsApi).when(wdsClient).recordsApi(baseUri, bearerToken);
 
     WdsServiceApiException thrown =
         assertThrows(
             WdsServiceApiException.class,
             () -> {
-              wdsService.getRecord(any(), any(), any(), any(), any());
+              wdsService.getRecord(baseUri, bearerToken, recordType, workspaceId, recordId);
             });
     assertEquals(expectedException, thrown.getCause());
   }
@@ -118,58 +122,56 @@ class WdsServiceTest {
         DependencyNotAvailableException.formatDependencyNotAvailableExceptionHelper(
             "WDS", "Bad Wds");
 
-    WdsClient wdsClient = mock(WdsClient.class);
     RecordsApi recordsApi = mock(RecordsApi.class);
-    when(recordsApi.getRecord(any(), any(), any(), any()))
+    when(recordsApi.getRecord(workspaceId, wdsApiVersion, recordType, recordId))
         .thenThrow(expectedException)
         .thenReturn(expectedResponse);
 
-    WdsService wdsService = spy(new WdsService(wdsClient, wdsServerConfiguration, template));
-
-    doReturn(recordsApi).when(wdsClient).recordsApi(any(), any());
+    doReturn(recordsApi).when(wdsClient).recordsApi(baseUri, bearerToken);
 
     WdsServiceNotAvailableException thrown =
         assertThrows(
             WdsServiceNotAvailableException.class,
             () -> {
-              wdsService.getRecord(any(), any(), any(), any(), any());
+              wdsService.getRecord(baseUri, bearerToken, recordType, workspaceId, recordId);
             });
     assertEquals(expectedException, thrown.getCause());
   }
 
   @Test
   void updateRecord() throws Exception {
+    RecordRequest recordRequest = new RecordRequest().putAdditionalProperty("foo", "bar");
     RecordResponse expectedResponse = new RecordResponse().id("idTest").type("updateRecordTest");
 
-    WdsClient wdsClient = mock(WdsClient.class);
     RecordsApi recordsApi = mock(RecordsApi.class);
-    when(recordsApi.updateRecord(any(), any(), any(), any(), any())).thenReturn(expectedResponse);
+    when(recordsApi.updateRecord(recordRequest, workspaceId, wdsApiVersion, recordType, recordId))
+        .thenReturn(expectedResponse);
 
-    WdsService wdsService = spy(new WdsService(wdsClient, wdsServerConfiguration, template));
-
-    doReturn(recordsApi).when(wdsClient).recordsApi(any(), any());
+    doReturn(recordsApi).when(wdsClient).recordsApi(baseUri, bearerToken);
 
     assertEquals(
-        expectedResponse, wdsService.updateRecord(any(), any(), any(), any(), any(), any()));
+        expectedResponse,
+        wdsService.updateRecord(
+            baseUri, bearerToken, recordRequest, workspaceId, recordType, recordId));
   }
 
   @Test
   void createOrReplaceRecord() throws Exception {
+    RecordRequest recordRequest = new RecordRequest().putAdditionalProperty("foo", "baz");
     RecordResponse expectedResponse =
         new RecordResponse().id("idTest").type("createOrReplaceRecordTest");
 
-    WdsClient wdsClient = mock(WdsClient.class);
     RecordsApi recordsApi = mock(RecordsApi.class);
-    when(recordsApi.createOrReplaceRecord(any(), any(), any(), any(), any(), any()))
+    when(recordsApi.createOrReplaceRecord(
+            recordRequest, workspaceId, wdsApiVersion, recordType, recordId, "primaryKey"))
         .thenReturn(expectedResponse);
 
-    WdsService wdsService = spy(new WdsService(wdsClient, wdsServerConfiguration, template));
-
-    doReturn(recordsApi).when(wdsClient).recordsApi(any(), any());
+    doReturn(recordsApi).when(wdsClient).recordsApi(baseUri, bearerToken);
 
     assertEquals(
         expectedResponse,
-        wdsService.createOrReplaceRecord(any(), any(), any(), any(), any(), any(), any()));
+        wdsService.createOrReplaceRecord(
+            baseUri, bearerToken, recordRequest, workspaceId, recordType, recordId, "primaryKey"));
   }
 
   @Test
@@ -178,30 +180,25 @@ class WdsServiceTest {
         List.of(
             new RecordTypeSchema().name("schemaTest"), new RecordTypeSchema().name("schemaTest2"));
 
-    WdsClient wdsClient = mock(WdsClient.class);
     SchemaApi schemaApi = mock(SchemaApi.class);
-    when(schemaApi.describeAllRecordTypes(any(), any())).thenReturn(expectedResponse);
+    when(schemaApi.describeAllRecordTypes(workspaceId, wdsApiVersion)).thenReturn(expectedResponse);
 
-    WdsService wdsService = spy(new WdsService(wdsClient, wdsServerConfiguration, template));
+    doReturn(schemaApi).when(wdsClient).schemaApi(baseUri, bearerToken);
 
-    doReturn(schemaApi).when(wdsClient).schemaApi(any(), any());
-
-    assertEquals(2, wdsService.querySchema(any(), any(), any()).size());
+    assertEquals(2, wdsService.querySchema(baseUri, bearerToken, workspaceId).size());
   }
 
   @Test
   void checkHealth() throws ApiException {
-    WdsClient wdsClient = mock(WdsClient.class);
     GeneralWdsInformationApi generalWdsInformationApi = mock(GeneralWdsInformationApi.class);
 
     StatusResponse statusResponse = new StatusResponse().status("UP");
 
-    when(wdsClient.generalWdsInformationApi(any(), any())).thenReturn(generalWdsInformationApi);
+    when(wdsClient.generalWdsInformationApi(baseUri, bearerToken))
+        .thenReturn(generalWdsInformationApi);
     when(generalWdsInformationApi.statusGet()).thenReturn(statusResponse);
 
-    WdsService wdsService = spy(new WdsService(wdsClient, wdsServerConfiguration, template));
-
-    HealthCheckWorkspaceApps.Result actualResult = wdsService.checkHealth("baseuri", "token");
+    HealthCheckWorkspaceApps.Result actualResult = wdsService.checkHealth(baseUri, bearerToken);
 
     assertEquals(
         new HealthCheckWorkspaceApps.Result(true, statusResponse.toString()), actualResult);
@@ -209,19 +206,18 @@ class WdsServiceTest {
 
   @Test
   void checkHealthWithException() throws ApiException {
-    WdsClient wdsClient = mock(WdsClient.class);
     GeneralWdsInformationApi generalWdsInformationApi = mock(GeneralWdsInformationApi.class);
 
     String exceptionMessage = "this is my exception message";
     ApiException apiException = new ApiException(exceptionMessage);
-    when(wdsClient.generalWdsInformationApi(any(), any())).thenReturn(generalWdsInformationApi);
+    when(wdsClient.generalWdsInformationApi(baseUri, bearerToken))
+        .thenReturn(generalWdsInformationApi);
     when(generalWdsInformationApi.statusGet()).thenThrow(apiException);
 
     HealthCheckWorkspaceApps.Result expectedResultOnFail =
         new HealthCheckWorkspaceApps.Result(false, apiException.getMessage());
-    WdsService wdsService = spy(new WdsService(wdsClient, wdsServerConfiguration, template));
 
-    HealthCheckWorkspaceApps.Result actualResult = wdsService.checkHealth("baseuri", "token");
+    HealthCheckWorkspaceApps.Result actualResult = wdsService.checkHealth(baseUri, bearerToken);
 
     assertEquals(expectedResultOnFail, actualResult);
   }

--- a/service/src/test/java/bio/terra/pipelines/dependencies/workspacemanager/WorkspaceManagerServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/dependencies/workspacemanager/WorkspaceManagerServiceTest.java
@@ -2,8 +2,6 @@ package bio.terra.pipelines.dependencies.workspacemanager;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -17,10 +15,7 @@ import bio.terra.workspace.api.ControlledAzureResourceApi;
 import bio.terra.workspace.api.ResourceApi;
 import bio.terra.workspace.api.UnauthenticatedApi;
 import bio.terra.workspace.client.ApiException;
-import bio.terra.workspace.model.CreatedAzureStorageContainerSasToken;
-import bio.terra.workspace.model.ResourceDescription;
-import bio.terra.workspace.model.ResourceList;
-import bio.terra.workspace.model.ResourceMetadata;
+import bio.terra.workspace.model.*;
 import java.net.SocketTimeoutException;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -97,7 +92,12 @@ class WorkspaceManagerServiceTest extends BaseEmbeddedDbTest {
                 new ResourceDescription().metadata(new ResourceMetadata().resourceId(resourceId)));
 
     ResourceApi resourceApi = mock(ResourceApi.class);
-    when(resourceApi.enumerateResources(eq(workspaceId), any(), any(), any(), any()))
+    when(resourceApi.enumerateResources(
+            workspaceId,
+            null,
+            null,
+            ResourceType.AZURE_STORAGE_CONTAINER,
+            StewardshipType.CONTROLLED))
         .thenAnswer(errorAnswer)
         .thenReturn(expectedResponse);
 
@@ -117,7 +117,12 @@ class WorkspaceManagerServiceTest extends BaseEmbeddedDbTest {
                 new ResourceDescription().metadata(new ResourceMetadata().resourceId(resourceId)));
 
     ResourceApi resourceApi = mock(ResourceApi.class);
-    when(resourceApi.enumerateResources(eq(workspaceId), any(), any(), any(), any()))
+    when(resourceApi.enumerateResources(
+            workspaceId,
+            null,
+            null,
+            ResourceType.AZURE_STORAGE_CONTAINER,
+            StewardshipType.CONTROLLED))
         .thenAnswer(errorAnswer)
         .thenAnswer(errorAnswer)
         .thenAnswer(errorAnswer)
@@ -135,7 +140,12 @@ class WorkspaceManagerServiceTest extends BaseEmbeddedDbTest {
     ApiException expectedException = new ApiException(400, "Bad Workspace manager");
 
     ResourceApi resourceApi = mock(ResourceApi.class);
-    when(resourceApi.enumerateResources(eq(workspaceId), any(), any(), any(), any()))
+    when(resourceApi.enumerateResources(
+            workspaceId,
+            null,
+            null,
+            ResourceType.AZURE_STORAGE_CONTAINER,
+            StewardshipType.CONTROLLED))
         .thenThrow(expectedException);
 
     doReturn(resourceApi).when(workspaceManagerClient).getResourceApi(authToken);
@@ -156,7 +166,12 @@ class WorkspaceManagerServiceTest extends BaseEmbeddedDbTest {
                 new ResourceDescription().metadata(new ResourceMetadata().resourceId(resourceId)));
 
     ResourceApi resourceApi = mock(ResourceApi.class);
-    when(resourceApi.enumerateResources(eq(workspaceId), any(), any(), any(), any()))
+    when(resourceApi.enumerateResources(
+            workspaceId,
+            null,
+            null,
+            ResourceType.AZURE_STORAGE_CONTAINER,
+            StewardshipType.CONTROLLED))
         .thenReturn(expectedResponse);
 
     doReturn(resourceApi).when(workspaceManagerClient).getResourceApi(authToken);
@@ -177,7 +192,12 @@ class WorkspaceManagerServiceTest extends BaseEmbeddedDbTest {
                     .metadata(new ResourceMetadata().resourceId(UUID.randomUUID())));
 
     ResourceApi resourceApi = mock(ResourceApi.class);
-    when(resourceApi.enumerateResources(eq(workspaceId), any(), any(), any(), any()))
+    when(resourceApi.enumerateResources(
+            workspaceId,
+            null,
+            null,
+            ResourceType.AZURE_STORAGE_CONTAINER,
+            StewardshipType.CONTROLLED))
         .thenReturn(expectedResponse);
 
     doReturn(resourceApi).when(workspaceManagerClient).getResourceApi(authToken);
@@ -197,7 +217,7 @@ class WorkspaceManagerServiceTest extends BaseEmbeddedDbTest {
 
     ControlledAzureResourceApi controlledAzureResourceApi = mock(ControlledAzureResourceApi.class);
     when(controlledAzureResourceApi.createAzureStorageContainerSasToken(
-            eq(workspaceId), eq(resourceId), any(), any(), eq("r"), any()))
+            workspaceId, resourceId, null, 86400L, "r", "some/blob/path"))
         .thenReturn(expectedSasToken);
 
     doReturn(controlledAzureResourceApi)
@@ -220,7 +240,7 @@ class WorkspaceManagerServiceTest extends BaseEmbeddedDbTest {
 
     ControlledAzureResourceApi controlledAzureResourceApi = mock(ControlledAzureResourceApi.class);
     when(controlledAzureResourceApi.createAzureStorageContainerSasToken(
-            eq(workspaceId), eq(resourceId), any(), any(), eq("w"), any()))
+            workspaceId, resourceId, null, 86400L, "w", "some/blob/path"))
         .thenReturn(expectedSasToken);
 
     doReturn(controlledAzureResourceApi)

--- a/service/src/test/java/bio/terra/pipelines/stairway/imputation/steps/azure/CheckCbasHealthStepTest.java
+++ b/service/src/test/java/bio/terra/pipelines/stairway/imputation/steps/azure/CheckCbasHealthStepTest.java
@@ -1,7 +1,6 @@
 package bio.terra.pipelines.stairway.imputation.steps.azure;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import bio.terra.pipelines.dependencies.cbas.CbasService;
@@ -31,12 +30,13 @@ class CheckCbasHealthStepTest extends BaseEmbeddedDbTest {
 
     when(flightContext.getInputParameters()).thenReturn(inputParameters);
     when(flightContext.getWorkingMap()).thenReturn(workingMap);
+    when(samService.getTeaspoonsServiceAccountToken()).thenReturn("thisToken");
   }
 
   @Test
   void doStepSuccess() {
     // setup
-    when(cbasService.checkHealth(any(), any()))
+    when(cbasService.checkHealth("cbasUri", "thisToken"))
         .thenReturn(new HealthCheckWorkspaceApps.Result(true, "cbas is healthy"));
 
     // do the step
@@ -50,7 +50,7 @@ class CheckCbasHealthStepTest extends BaseEmbeddedDbTest {
   @Test
   void doStepUnhealthyCbas() {
     // setup
-    when(cbasService.checkHealth(any(), any()))
+    when(cbasService.checkHealth("cbasUri", "thisToken"))
         .thenReturn(new HealthCheckWorkspaceApps.Result(false, "wds is not healthy"));
 
     StairwayTestUtils.constructCreateJobInputs(flightContext.getInputParameters());

--- a/service/src/test/java/bio/terra/pipelines/stairway/imputation/steps/azure/CheckWdsHealthStepTest.java
+++ b/service/src/test/java/bio/terra/pipelines/stairway/imputation/steps/azure/CheckWdsHealthStepTest.java
@@ -1,7 +1,6 @@
 package bio.terra.pipelines.stairway.imputation.steps.azure;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import bio.terra.pipelines.dependencies.common.HealthCheckWorkspaceApps;
@@ -31,12 +30,13 @@ class CheckWdsHealthStepTest extends BaseEmbeddedDbTest {
 
     when(flightContext.getInputParameters()).thenReturn(inputParameters);
     when(flightContext.getWorkingMap()).thenReturn(workingMap);
+    when(samService.getTeaspoonsServiceAccountToken()).thenReturn("thisToken");
   }
 
   @Test
   void doStepSuccess() {
     // setup
-    when(wdsService.checkHealth(any(), any()))
+    when(wdsService.checkHealth("wdsUri", "thisToken"))
         .thenReturn(new HealthCheckWorkspaceApps.Result(true, "wds is healthy"));
 
     StairwayTestUtils.constructCreateJobInputs(flightContext.getInputParameters());
@@ -52,7 +52,7 @@ class CheckWdsHealthStepTest extends BaseEmbeddedDbTest {
   @Test
   void doStepUnhealthyWds() {
     // setup
-    when(wdsService.checkHealth(any(), any()))
+    when(wdsService.checkHealth("wdsUri", "thisToken"))
         .thenReturn(new HealthCheckWorkspaceApps.Result(false, "wds is not healthy"));
 
     StairwayTestUtils.constructCreateJobInputs(flightContext.getInputParameters());

--- a/service/src/test/java/bio/terra/pipelines/stairway/imputation/steps/azure/FetchOutputsFromWdsStepTest.java
+++ b/service/src/test/java/bio/terra/pipelines/stairway/imputation/steps/azure/FetchOutputsFromWdsStepTest.java
@@ -1,9 +1,9 @@
 package bio.terra.pipelines.stairway.imputation.steps.azure;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
+import bio.terra.pipelines.common.utils.PipelinesEnum;
 import bio.terra.pipelines.dependencies.sam.SamService;
 import bio.terra.pipelines.dependencies.wds.WdsService;
 import bio.terra.pipelines.dependencies.wds.WdsServiceApiException;
@@ -11,6 +11,7 @@ import bio.terra.pipelines.dependencies.wds.WdsServiceException;
 import bio.terra.pipelines.stairway.imputation.RunImputationJobFlightMapKeys;
 import bio.terra.pipelines.testutils.BaseEmbeddedDbTest;
 import bio.terra.pipelines.testutils.StairwayTestUtils;
+import bio.terra.pipelines.testutils.TestUtils;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.StepResult;
@@ -38,6 +39,8 @@ class FetchOutputsFromWdsStepTest extends BaseEmbeddedDbTest {
 
     when(flightContext.getInputParameters()).thenReturn(inputParameters);
     when(flightContext.getWorkingMap()).thenReturn(workingMap);
+    when(flightContext.getFlightId()).thenReturn(TestUtils.TEST_NEW_UUID.toString());
+    when(samService.getTeaspoonsServiceAccountToken()).thenReturn("thisToken");
   }
 
   @Test
@@ -51,7 +54,13 @@ class FetchOutputsFromWdsStepTest extends BaseEmbeddedDbTest {
     recordAttributes.putAll(expectedOutputsFromWds);
     RecordResponse recordResponse = new RecordResponse().attributes(recordAttributes);
 
-    when(wdsService.getRecord(any(), any(), any(), any(), any())).thenReturn(recordResponse);
+    when(wdsService.getRecord(
+            "wdsUri",
+            "thisToken",
+            PipelinesEnum.IMPUTATION_BEAGLE.getValue(),
+            TestUtils.CONTROL_WORKSPACE_ID.toString(),
+            TestUtils.TEST_NEW_UUID.toString()))
+        .thenReturn(recordResponse);
 
     FetchOutputsFromWdsStep fetchOutputsFromWdsStep =
         new FetchOutputsFromWdsStep(wdsService, samService);
@@ -74,7 +83,12 @@ class FetchOutputsFromWdsStepTest extends BaseEmbeddedDbTest {
     // setup
     StairwayTestUtils.constructCreateJobInputs(flightContext.getInputParameters());
 
-    when(wdsService.getRecord(any(), any(), any(), any(), any()))
+    when(wdsService.getRecord(
+            "wdsUri",
+            "thisToken",
+            PipelinesEnum.IMPUTATION_BEAGLE.getValue(),
+            TestUtils.CONTROL_WORKSPACE_ID.toString(),
+            TestUtils.TEST_NEW_UUID.toString()))
         .thenThrow(new WdsServiceApiException(new ApiException("WDS Service Api Exception")));
 
     FetchOutputsFromWdsStep fetchOutputsFromWdsStep =

--- a/service/src/test/java/bio/terra/pipelines/stairway/imputation/steps/azure/GetAppUrisStepTest.java
+++ b/service/src/test/java/bio/terra/pipelines/stairway/imputation/steps/azure/GetAppUrisStepTest.java
@@ -1,7 +1,6 @@
 package bio.terra.pipelines.stairway.imputation.steps.azure;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import bio.terra.pipelines.dependencies.leonardo.LeonardoService;
@@ -9,10 +8,13 @@ import bio.terra.pipelines.dependencies.sam.SamService;
 import bio.terra.pipelines.stairway.imputation.RunImputationJobFlightMapKeys;
 import bio.terra.pipelines.testutils.BaseEmbeddedDbTest;
 import bio.terra.pipelines.testutils.StairwayTestUtils;
+import bio.terra.pipelines.testutils.TestUtils;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
+import java.util.List;
+import org.broadinstitute.dsde.workbench.client.leonardo.model.ListAppResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -30,13 +32,22 @@ class GetAppUrisStepTest extends BaseEmbeddedDbTest {
 
     when(flightContext.getInputParameters()).thenReturn(inputParameters);
     when(flightContext.getWorkingMap()).thenReturn(workingMap);
+    when(samService.getTeaspoonsServiceAccountToken()).thenReturn("thisToken");
   }
 
   @Test
   void doStepSuccess() {
     // setup
-    when(leonardoService.getCbasUrlFromGetAppResponse(any(), any())).thenReturn("cbasUriRetrieved");
-    when(leonardoService.getWdsUrlFromGetAppResponse(any(), any())).thenReturn("wdsUriRetrieved");
+    List<ListAppResponse> returnedListAppListResponse =
+        List.of(new ListAppResponse().appName("justSomething"));
+    when(leonardoService.getApps(TestUtils.CONTROL_WORKSPACE_ID.toString(), "thisToken"))
+        .thenReturn(returnedListAppListResponse);
+    when(leonardoService.getCbasUrlFromGetAppResponse(
+            returnedListAppListResponse, TestUtils.CONTROL_WORKSPACE_ID.toString()))
+        .thenReturn("cbasUriRetrieved");
+    when(leonardoService.getWdsUrlFromGetAppResponse(
+            returnedListAppListResponse, TestUtils.CONTROL_WORKSPACE_ID.toString()))
+        .thenReturn("wdsUriRetrieved");
 
     StairwayTestUtils.constructCreateJobInputs(flightContext.getInputParameters());
 

--- a/service/src/test/java/bio/terra/pipelines/stairway/imputation/steps/gcp/SubmitCromwellSubmissionStepTest.java
+++ b/service/src/test/java/bio/terra/pipelines/stairway/imputation/steps/gcp/SubmitCromwellSubmissionStepTest.java
@@ -3,9 +3,11 @@ package bio.terra.pipelines.stairway.imputation.steps.gcp;
 import static bio.terra.pipelines.testutils.TestUtils.VALID_METHOD_CONFIGURATION;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import bio.terra.pipelines.app.configuration.internal.ImputationConfiguration;
+import bio.terra.pipelines.common.utils.PipelinesEnum;
 import bio.terra.pipelines.dependencies.rawls.RawlsService;
 import bio.terra.pipelines.dependencies.rawls.RawlsServiceApiException;
 import bio.terra.pipelines.dependencies.sam.SamService;
@@ -44,6 +46,7 @@ class SubmitCromwellSubmissionStepTest extends BaseEmbeddedDbTest {
 
     when(flightContext.getInputParameters()).thenReturn(inputParameters);
     when(flightContext.getWorkingMap()).thenReturn(workingMap);
+    when(samService.getTeaspoonsServiceAccountToken()).thenReturn("thisToken");
   }
 
   @Test
@@ -51,11 +54,26 @@ class SubmitCromwellSubmissionStepTest extends BaseEmbeddedDbTest {
     // setup
     StairwayTestUtils.constructCreateJobInputs(flightContext.getInputParameters());
     when(flightContext.getFlightId()).thenReturn(testJobId.toString());
-    when(rawlsService.getCurrentMethodConfigForMethod(any(), any(), any(), any()))
-        .thenReturn(new MethodConfiguration());
-    when(rawlsService.validateMethodConfig(any(), any(), any(), any(), any(), any()))
+    MethodConfiguration returnedMethodConfiguration = new MethodConfiguration();
+    when(rawlsService.getCurrentMethodConfigForMethod(
+            "thisToken",
+            TestUtils.CONTROL_WORKSPACE_BILLING_PROJECT,
+            TestUtils.CONTROL_WORKSPACE_NAME,
+            TestUtils.TEST_WDL_METHOD_NAME_1))
+        .thenReturn(returnedMethodConfiguration);
+    when(rawlsService.validateMethodConfig(
+            returnedMethodConfiguration,
+            PipelinesEnum.IMPUTATION_BEAGLE.getValue(),
+            TestUtils.TEST_WDL_METHOD_NAME_1,
+            TestUtils.TEST_PIPELINE_INPUTS_DEFINITION_LIST,
+            TestUtils.TEST_PIPELINE_OUTPUTS_DEFINITION_LIST,
+            TestUtils.TEST_WDL_METHOD_VERSION_1))
         .thenReturn(true);
-    when(rawlsService.submitWorkflow(any(), submissionRequestCaptor.capture(), any(), any()))
+    when(rawlsService.submitWorkflow(
+            eq("thisToken"),
+            submissionRequestCaptor.capture(),
+            eq(TestUtils.CONTROL_WORKSPACE_BILLING_PROJECT),
+            eq(TestUtils.CONTROL_WORKSPACE_NAME)))
         .thenReturn(new SubmissionReport().submissionId(testJobId.toString()));
 
     // do the step
@@ -83,22 +101,44 @@ class SubmitCromwellSubmissionStepTest extends BaseEmbeddedDbTest {
     StairwayTestUtils.constructCreateJobInputs(flightContext.getInputParameters());
     when(flightContext.getFlightId()).thenReturn(testJobId.toString());
     // set up "current" method config to be version 1.1.1 with the corresponding method uri
-    when(rawlsService.getCurrentMethodConfigForMethod(any(), any(), any(), any()))
-        .thenReturn(
-            new MethodConfiguration()
-                .methodRepoMethod(
-                    new MethodRepoMethod()
-                        .methodUri("http/path/to/wdl/1.1.1")
-                        .methodVersion("1.1.1")));
-    when(rawlsService.validateMethodConfig(any(), any(), any(), any(), any(), any()))
+    MethodConfiguration returnedMethodConfiguration =
+        new MethodConfiguration()
+            .methodRepoMethod(
+                new MethodRepoMethod().methodUri("http/path/to/wdl/1.1.1").methodVersion("1.1.1"));
+    when(rawlsService.getCurrentMethodConfigForMethod(
+            "thisToken",
+            TestUtils.CONTROL_WORKSPACE_BILLING_PROJECT,
+            TestUtils.CONTROL_WORKSPACE_NAME,
+            TestUtils.TEST_WDL_METHOD_NAME_1))
+        .thenReturn(returnedMethodConfiguration);
+    when(rawlsService.validateMethodConfig(
+            returnedMethodConfiguration,
+            PipelinesEnum.IMPUTATION_BEAGLE.getValue(),
+            TestUtils.TEST_WDL_METHOD_NAME_1,
+            TestUtils.TEST_PIPELINE_INPUTS_DEFINITION_LIST,
+            TestUtils.TEST_PIPELINE_OUTPUTS_DEFINITION_LIST,
+            TestUtils.TEST_WDL_METHOD_VERSION_1))
         .thenReturn(false);
     when(rawlsService.updateMethodConfigToBeValid(
-            updateMethodConfigCaptor.capture(), any(), any(), any(), any(), any()))
+            updateMethodConfigCaptor.capture(),
+            eq(PipelinesEnum.IMPUTATION_BEAGLE.getValue()),
+            eq(TestUtils.TEST_WDL_METHOD_NAME_1),
+            eq(TestUtils.TEST_PIPELINE_INPUTS_DEFINITION_LIST),
+            eq(TestUtils.TEST_PIPELINE_OUTPUTS_DEFINITION_LIST),
+            eq(TestUtils.TEST_WDL_METHOD_VERSION_1)))
         .thenReturn(VALID_METHOD_CONFIGURATION);
     when(rawlsService.setMethodConfigForMethod(
-            any(), setMethodConfigCaptor.capture(), any(), any(), any()))
+            eq("thisToken"),
+            setMethodConfigCaptor.capture(),
+            eq(TestUtils.CONTROL_WORKSPACE_BILLING_PROJECT),
+            eq(TestUtils.CONTROL_WORKSPACE_NAME),
+            eq(TestUtils.TEST_WDL_METHOD_NAME_1)))
         .thenReturn(null);
-    when(rawlsService.submitWorkflow(any(), any(), any(), any()))
+    when(rawlsService.submitWorkflow(
+            eq("thisToken"),
+            any(SubmissionRequest.class),
+            eq(TestUtils.CONTROL_WORKSPACE_BILLING_PROJECT),
+            eq(TestUtils.CONTROL_WORKSPACE_NAME)))
         .thenReturn(new SubmissionReport().submissionId(testJobId.toString()));
 
     // do the step
@@ -121,13 +161,28 @@ class SubmitCromwellSubmissionStepTest extends BaseEmbeddedDbTest {
     // setup
     StairwayTestUtils.constructCreateJobInputs(flightContext.getInputParameters());
     when(flightContext.getFlightId()).thenReturn(testJobId.toString());
-    when(rawlsService.getCurrentMethodConfigForMethod(any(), any(), any(), any()))
-        .thenReturn(new MethodConfiguration());
-    when(rawlsService.validateMethodConfig(any(), any(), any(), any(), any(), any()))
+    MethodConfiguration returnedMethodConfiguration = new MethodConfiguration();
+    when(rawlsService.getCurrentMethodConfigForMethod(
+            "thisToken",
+            TestUtils.CONTROL_WORKSPACE_BILLING_PROJECT,
+            TestUtils.CONTROL_WORKSPACE_NAME,
+            TestUtils.TEST_WDL_METHOD_NAME_1))
+        .thenReturn(returnedMethodConfiguration);
+    when(rawlsService.validateMethodConfig(
+            returnedMethodConfiguration,
+            PipelinesEnum.IMPUTATION_BEAGLE.getValue(),
+            TestUtils.TEST_WDL_METHOD_NAME_1,
+            TestUtils.TEST_PIPELINE_INPUTS_DEFINITION_LIST,
+            TestUtils.TEST_PIPELINE_OUTPUTS_DEFINITION_LIST,
+            TestUtils.TEST_WDL_METHOD_VERSION_1))
         .thenReturn(true);
 
     // throw exception on submitting workflow
-    when(rawlsService.submitWorkflow(any(), any(), any(), any()))
+    when(rawlsService.submitWorkflow(
+            eq("thisToken"),
+            any(SubmissionRequest.class),
+            eq(TestUtils.CONTROL_WORKSPACE_BILLING_PROJECT),
+            eq(TestUtils.CONTROL_WORKSPACE_NAME)))
         .thenThrow(new RawlsServiceApiException("rawls is bad"));
     // do the step
     SubmitCromwellSubmissionStep submitCromwellSubmissionStep =
@@ -137,9 +192,20 @@ class SubmitCromwellSubmissionStepTest extends BaseEmbeddedDbTest {
     assertEquals(StepStatus.STEP_RESULT_FAILURE_RETRY, result.getStepStatus());
 
     // throw exception on setting method config to be valid
-    when(rawlsService.validateMethodConfig(any(), any(), any(), any(), any(), any()))
+    when(rawlsService.validateMethodConfig(
+            returnedMethodConfiguration,
+            PipelinesEnum.IMPUTATION_BEAGLE.getValue(),
+            TestUtils.TEST_WDL_METHOD_NAME_1,
+            TestUtils.TEST_PIPELINE_INPUTS_DEFINITION_LIST,
+            TestUtils.TEST_PIPELINE_OUTPUTS_DEFINITION_LIST,
+            TestUtils.TEST_WDL_METHOD_VERSION_1))
         .thenReturn(false);
-    when(rawlsService.setMethodConfigForMethod(any(), any(), any(), any(), any()))
+    when(rawlsService.setMethodConfigForMethod(
+            "thisToken",
+            null,
+            TestUtils.CONTROL_WORKSPACE_BILLING_PROJECT,
+            TestUtils.CONTROL_WORKSPACE_NAME,
+            TestUtils.TEST_WDL_METHOD_NAME_1))
         .thenThrow(new RawlsServiceApiException("rawls is bad"));
     // do the step
     submitCromwellSubmissionStep =
@@ -149,7 +215,11 @@ class SubmitCromwellSubmissionStepTest extends BaseEmbeddedDbTest {
     assertEquals(StepStatus.STEP_RESULT_FAILURE_RETRY, result.getStepStatus());
 
     // throw exception getting method config
-    when(rawlsService.getCurrentMethodConfigForMethod(any(), any(), any(), any()))
+    when(rawlsService.getCurrentMethodConfigForMethod(
+            "thisToken",
+            TestUtils.CONTROL_WORKSPACE_BILLING_PROJECT,
+            TestUtils.CONTROL_WORKSPACE_NAME,
+            TestUtils.TEST_WDL_METHOD_NAME_1))
         .thenThrow(new RawlsServiceApiException("rawls is bad"));
     // do the step
     submitCromwellSubmissionStep =


### PR DESCRIPTION
### Description 

I got rid of pretty much all of them and I probably went overboard with some tests because we dont need to test all arguments match EVERY single time but it was easier to copy paste once i was in there.  Especially for the methods that are testing for exceptions being thrown you can use `any()` cuz you don't really care.  Basically anytime you do a positive test it should try to not use `any()` as much as possible

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-316
