### PR TITLE
TSPS-280 e2e test fix - auto-pull lastest git release tag if not specified

### DIFF
--- a/.github/workflows/run-e2e-tests.yaml
+++ b/.github/workflows/run-e2e-tests.yaml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       delete-bee: '${{ steps.extract-inputs-and-generate-params.outputs.delete-bee }}'
-      e2e-test-version-ref: '${{ steps.extract-inputs-and-generate-params.outputs.e2e-test-version-ref }}'
+      custom-app-version-formatted: '${{ steps.extract-inputs-and-generate-params.outputs.custom-app-version-formatted }}'
       project-name: '${{ steps.extract-inputs-and-generate-params.outputs.project_name }}'
       bee-name: '${{ env.BEE_NAME }}'
       wdl-method-version: '${{ steps.extract-inputs-and-generate-params.outputs.wdl-method-version }}'
@@ -40,9 +40,9 @@ jobs:
         run: |
           echo "delete-bee=${{ inputs.delete-bee || true }}" >> $GITHUB_OUTPUT
           if [ -z ${{ inputs.custom-app-version }} ]; then
-            echo "e2e-test-version-ref={}" >> $GITHUB_OUTPUT
+            echo "custom-app-version-formatted={}" >> $GITHUB_OUTPUT
           else
-            echo "e2e-test-version-ref={\\\"tsps\\\": {\\\"appVersion\\\":\\\"${{ inputs.custom-app-version }}\\\"} }" >> $GITHUB_OUTPUT
+            echo "custom-app-version-formatted={\\\"tsps\\\": {\\\"appVersion\\\":\\\"${{ inputs.custom-app-version }}\\\"} }" >> $GITHUB_OUTPUT
           fi
           project_name=$(echo "tmp-billing-project-$(uuidgen)" | cut -c -30)
           echo "project_name=${project_name}" >> $GITHUB_OUTPUT
@@ -71,7 +71,7 @@ jobs:
           run_name: "bee-create-${{ env.BEE_NAME }}"
           bee_name: ${{ env.BEE_NAME }}
           token: '${{ env.TOKEN }}'
-          custom_version_json: ${{ needs.init-github-context-and-params-gen.outputs.e2e-test-version-ref }}
+          custom_version_json: ${{ needs.init-github-context-and-params-gen.outputs.custom-app-version-formatted }}
 
       - name: retry dispatch to terra-github-workflows in case of failure
         if: steps.FirstAttemptCreateBee.outcome == 'failure'
@@ -80,7 +80,7 @@ jobs:
           run_name: "bee-create-retry-${{ env.BEE_NAME }}"
           bee_name: ${{ env.BEE_NAME }}
           token: ${{ env.TOKEN }}
-          custom_version_json: ${{ needs.init-github-context-and-params-gen.outputs.e2e-test-version-ref }}
+          custom_version_json: ${{ needs.init-github-context-and-params-gen.outputs.custom-app-version-formatted }}
 
   run-e2e-test-job:
     needs:
@@ -93,7 +93,7 @@ jobs:
     with:
       billing-project-name: '${{ needs.init-github-context-and-params-gen.outputs.project-name }}'
       bee-name: '${{ needs.init-github-context-and-params-gen.outputs.bee-name }}'
-      e2e-test-version-ref: '${{ needs.init-github-context-and-params-gen.outputs.e2e-test-version-ref }}'
+      e2e-test-version-ref: '${{ github.event.inputs.e2e-test-version-ref }}'
       wdl-method-version: '${{ needs.init-github-context-and-params-gen.outputs.wdl-method-version }}'
 
   destroy-bee-workflow:

--- a/.github/workflows/run-e2e-tests.yaml
+++ b/.github/workflows/run-e2e-tests.yaml
@@ -47,13 +47,13 @@ jobs:
       wdl-method-version: '${{ steps.gen.outputs.wdl-method-version }}'
     steps:
       - uses: actions/checkout@v4
-      - name: Generate a random billing project name
+      - name: Generate a random billing project name and fetch latest git release tag
         id: gen
         run: |
           project_name=$(echo "tmp-billing-project-$(uuidgen)" | cut -c -30)
           echo "project_name=${project_name}" >> $GITHUB_OUTPUT
           if [ -z ${{ inputs.wdl-method-version }} ]; then
-            git fetch --tags
+            git fetch --prune --unshallow
             echo "wdl-method-version=$(git describe --tags --abbrev=0)" >> $GITHUB_OUTPUT
           else
             echo "wdl-method-version=${{ inputs.wdl-method-version }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/run-e2e-tests.yaml
+++ b/.github/workflows/run-e2e-tests.yaml
@@ -104,7 +104,7 @@ jobs:
       billing-project-name: '${{ needs.params-gen.outputs.project-name }}'
       bee-name: '${{ needs.params-gen.outputs.bee-name }}'
       e2e-test-version-ref: '${{ github.event.inputs.e2e-test-version-ref }}'
-      wdl-method-version: '${{ steps.get-latest-release-tag.outputs.latest_release_tag }}'
+      wdl-method-version: '${{ needs.get-latest-release-tag.outputs.latest_release_tag }}'
 
   destroy-bee-workflow:
     runs-on: ubuntu-latest

--- a/.github/workflows/run-e2e-tests.yaml
+++ b/.github/workflows/run-e2e-tests.yaml
@@ -95,6 +95,7 @@ jobs:
   run-e2e-test-job:
     needs:
       - create-bee-workflow
+      - get-latest-release-tag
       - params-gen
     permissions:
       contents: read

--- a/.github/workflows/run-e2e-tests.yaml
+++ b/.github/workflows/run-e2e-tests.yaml
@@ -54,7 +54,8 @@ jobs:
           echo "project_name=${project_name}" >> $GITHUB_OUTPUT
           if [ -z ${{ inputs.wdl-method-version }} ]; then
             git fetch --prune --unshallow
-            echo "wdl-method-version=$(git describe --tags --abbrev=0)" >> $GITHUB_OUTPUT
+            echo "found latest git tag: $(git describe --tags $(git rev-list --tags --max-count=1))"
+            echo "wdl-method-version=$(git describe --tags $(git rev-list --tags --max-count=1))" >> $GITHUB_OUTPUT
           else
             echo "wdl-method-version=${{ inputs.wdl-method-version }}" >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/run-e2e-tests.yaml
+++ b/.github/workflows/run-e2e-tests.yaml
@@ -23,35 +23,27 @@ env:
   TOKEN: '${{ secrets.BROADBOT_TOKEN }}'
   RUN_NAME_SUFFIX: ${{ github.event.repository.name }}-${{ github.run_id }}-${{github.run_attempt }}
 jobs:
-  init-github-context:
+  init-github-context-and-params-gen:
     runs-on: ubuntu-latest
     outputs:
-      delete-bee: '${{ steps.extract-inputs.outputs.delete-bee }}'
-      e2e-test-version-ref: '${{ steps.extract-inputs.outputs.e2e-test-version-ref }}'
-    steps:
-      - name: Get inputs or use defaults
-        id: extract-inputs
-        run: |
-          echo "delete-bee=${{ inputs.delete-bee || true }}" >> "$GITHUB_OUTPUT"
-          if [ -z ${{ inputs.custom-app-version }} ]; then
-            echo "e2e-test-version-ref={}" >> "$GITHUB_OUTPUT"
-          else
-            echo "e2e-test-version-ref={\\\"tsps\\\": {\\\"appVersion\\\":\\\"${{ inputs.custom-app-version }}\\\"} }" >> "$GITHUB_OUTPUT"
-          fi
-
-  params-gen:
-    runs-on: ubuntu-latest
-    outputs:
-      project-name: '${{ steps.gen.outputs.project_name }}'
+      delete-bee: '${{ steps.extract-inputs-and-generate-params.outputs.delete-bee }}'
+      e2e-test-version-ref: '${{ steps.extract-inputs-and-generate-params.outputs.e2e-test-version-ref }}'
+      project-name: '${{ steps.extract-inputs-and-generate-params.outputs.project_name }}'
       bee-name: '${{ env.BEE_NAME }}'
-      wdl-method-version: '${{ steps.gen.outputs.wdl-method-version }}'
+      wdl-method-version: '${{ steps.extract-inputs-and-generate-params.outputs.wdl-method-version }}'
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Generate a random billing project name and fetch latest git release tag
-        id: gen
+      - name: Get inputs or use defaults, generate other parameters
+        id: extract-inputs-and-generate-params
         run: |
+          echo "delete-bee=${{ inputs.delete-bee || true }}" >> $GITHUB_OUTPUT
+          if [ -z ${{ inputs.custom-app-version }} ]; then
+            echo "e2e-test-version-ref={}" >> $GITHUB_OUTPUT
+          else
+            echo "e2e-test-version-ref={\\\"tsps\\\": {\\\"appVersion\\\":\\\"${{ inputs.custom-app-version }}\\\"} }" >> $GITHUB_OUTPUT
+          fi
           project_name=$(echo "tmp-billing-project-$(uuidgen)" | cut -c -30)
           echo "project_name=${project_name}" >> $GITHUB_OUTPUT
           if [ -z ${{ inputs.wdl-method-version }} ]; then
@@ -63,7 +55,7 @@ jobs:
 
   create-bee-workflow:
     runs-on: ubuntu-latest
-    needs: [ init-github-context ]
+    needs: [ init-github-context-and-params-gen ]
     permissions:
       contents: read
       id-token: write
@@ -79,7 +71,7 @@ jobs:
           run_name: "bee-create-${{ env.BEE_NAME }}"
           bee_name: ${{ env.BEE_NAME }}
           token: '${{ env.TOKEN }}'
-          custom_version_json: ${{ needs.init-github-context.outputs.e2e-test-version-ref }}
+          custom_version_json: ${{ needs.init-github-context-and-params-gen.outputs.e2e-test-version-ref }}
 
       - name: retry dispatch to terra-github-workflows in case of failure
         if: steps.FirstAttemptCreateBee.outcome == 'failure'
@@ -88,27 +80,27 @@ jobs:
           run_name: "bee-create-retry-${{ env.BEE_NAME }}"
           bee_name: ${{ env.BEE_NAME }}
           token: ${{ env.TOKEN }}
-          custom_version_json: ${{ needs.init-github-context.outputs.e2e-test-version-ref }}
+          custom_version_json: ${{ needs.init-github-context-and-params-gen.outputs.e2e-test-version-ref }}
 
   run-e2e-test-job:
     needs:
       - create-bee-workflow
-      - params-gen
+      - init-github-context-and-params-gen
     permissions:
       contents: read
       id-token: write
     uses: broadinstitute/dsp-reusable-workflows/.github/workflows/run_tsps_e2e_tests.yaml@main
     with:
-      billing-project-name: '${{ needs.params-gen.outputs.project-name }}'
-      bee-name: '${{ needs.params-gen.outputs.bee-name }}'
-      e2e-test-version-ref: '${{ github.event.inputs.e2e-test-version-ref }}'
-      wdl-method-version: '${{ needs.params-gen.outputs.wdl-method-version }}'
+      billing-project-name: '${{ needs.init-github-context-and-params-gen.outputs.project-name }}'
+      bee-name: '${{ needs.init-github-context-and-params-gen.outputs.bee-name }}'
+      e2e-test-version-ref: '${{ needs.init-github-context-and-params-gen.outputs.e2e-test-version-ref }}'
+      wdl-method-version: '${{ needs.init-github-context-and-params-gen.outputs.wdl-method-version }}'
 
   destroy-bee-workflow:
     runs-on: ubuntu-latest
     needs:
       - run-e2e-test-job
-    if: '${{ needs.init-github-context.outputs.delete-bee && always() }}'
+    if: '${{ needs.init-github-context-and-params-gen.outputs.delete-bee && always() }}'
     steps:
       - name: dispatch to terra-github-workflows
         uses: broadinstitute/workflow-dispatch@v3

--- a/.github/workflows/run-e2e-tests.yaml
+++ b/.github/workflows/run-e2e-tests.yaml
@@ -52,6 +52,17 @@ jobs:
           project_name=$(echo "tmp-billing-project-$(uuidgen)" | cut -c -30)
           echo "project_name=${project_name}" >> $GITHUB_OUTPUT
 
+  get-latest-release-tag:
+    runs-on: ubuntu-latest
+    outputs:
+      latest_release_tag: ${{ steps.get-latest-release-tag.outputs.latest_release_tag }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Get the latest release tag
+        id: get-release-tag
+        run: |
+          echo "latest_release_tag=$(git describe --tags --abbrev=0)" >> $GITHUB_OUTPUT
+
   create-bee-workflow:
     runs-on: ubuntu-latest
     needs: [ init-github-context ]
@@ -93,7 +104,7 @@ jobs:
       billing-project-name: '${{ needs.params-gen.outputs.project-name }}'
       bee-name: '${{ needs.params-gen.outputs.bee-name }}'
       e2e-test-version-ref: '${{ github.event.inputs.e2e-test-version-ref }}'
-      wdl-method-version: '${{ github.event.inputs.wdl-method-version }}'
+      wdl-method-version: '${{ steps.get-latest-release-tag.outputs.latest_release_tag }}'
 
   destroy-bee-workflow:
     runs-on: ubuntu-latest

--- a/.github/workflows/run-e2e-tests.yaml
+++ b/.github/workflows/run-e2e-tests.yaml
@@ -15,8 +15,8 @@ on:
         default: 'main'
         type: string
       wdl-method-version:
-        description: 'Name of branch or release tag in the terra-scientific-pipelines-service repo to use for the test WDL'
-        required: true
+        description: 'Name of branch or release tag in the terra-scientific-pipelines-service repo to use for the test WDL. defaults to latest git release tag if not specified.'
+        required: false
         type: string
 env:
   BEE_NAME: 'teaspoons-${{ github.run_id }}-${{ github.run_attempt}}-dev'

--- a/.github/workflows/run-e2e-tests.yaml
+++ b/.github/workflows/run-e2e-tests.yaml
@@ -44,6 +44,7 @@ jobs:
     outputs:
       project-name: '${{ steps.gen.outputs.project_name }}'
       bee-name: '${{ env.BEE_NAME }}'
+      wdl-method-version: '${{ steps.gen.outputs.wdl-method-version }}'
     steps:
       - uses: actions/checkout@v4
       - name: Generate a random billing project name
@@ -51,17 +52,11 @@ jobs:
         run: |
           project_name=$(echo "tmp-billing-project-$(uuidgen)" | cut -c -30)
           echo "project_name=${project_name}" >> $GITHUB_OUTPUT
-
-  get-latest-release-tag:
-    runs-on: ubuntu-latest
-    outputs:
-      latest_release_tag: ${{ steps.get-latest-release-tag.outputs.latest_release_tag }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Get the latest release tag
-        id: get-release-tag
-        run: |
-          echo "latest_release_tag=$(git describe --tags --abbrev=0)" >> $GITHUB_OUTPUT
+          if [ -z ${{ inputs.wdl-method-version }} ]; then
+            echo "wdl-method-version=$(git describe --tags --abbrev=0)" >> $GITHUB_OUTPUT
+          else
+            echo "wdl-method-version=${{ inputs.wdl-method-version }}" >> $GITHUB_OUTPUT
+          fi
 
   create-bee-workflow:
     runs-on: ubuntu-latest
@@ -95,7 +90,6 @@ jobs:
   run-e2e-test-job:
     needs:
       - create-bee-workflow
-      - get-latest-release-tag
       - params-gen
     permissions:
       contents: read
@@ -105,7 +99,7 @@ jobs:
       billing-project-name: '${{ needs.params-gen.outputs.project-name }}'
       bee-name: '${{ needs.params-gen.outputs.bee-name }}'
       e2e-test-version-ref: '${{ github.event.inputs.e2e-test-version-ref }}'
-      wdl-method-version: '${{ needs.get-latest-release-tag.outputs.latest_release_tag }}'
+      wdl-method-version: '${{ needs.params-gen.outputs.wdl-method-version }}'
 
   destroy-bee-workflow:
     runs-on: ubuntu-latest

--- a/.github/workflows/run-e2e-tests.yaml
+++ b/.github/workflows/run-e2e-tests.yaml
@@ -47,13 +47,14 @@ jobs:
       wdl-method-version: '${{ steps.gen.outputs.wdl-method-version }}'
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Generate a random billing project name and fetch latest git release tag
         id: gen
         run: |
           project_name=$(echo "tmp-billing-project-$(uuidgen)" | cut -c -30)
           echo "project_name=${project_name}" >> $GITHUB_OUTPUT
           if [ -z ${{ inputs.wdl-method-version }} ]; then
-            git fetch --prune --unshallow
             echo "found latest git tag: $(git describe --tags $(git rev-list --tags --max-count=1))"
             echo "wdl-method-version=$(git describe --tags $(git rev-list --tags --max-count=1))" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/run-e2e-tests.yaml
+++ b/.github/workflows/run-e2e-tests.yaml
@@ -53,6 +53,7 @@ jobs:
           project_name=$(echo "tmp-billing-project-$(uuidgen)" | cut -c -30)
           echo "project_name=${project_name}" >> $GITHUB_OUTPUT
           if [ -z ${{ inputs.wdl-method-version }} ]; then
+            git fetch --tags
             echo "wdl-method-version=$(git describe --tags --abbrev=0)" >> $GITHUB_OUTPUT
           else
             echo "wdl-method-version=${{ inputs.wdl-method-version }}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
### Description 

Successful run without specifying a wdl method version: https://github.com/DataBiosphere/terra-scientific-pipelines-service/actions/runs/10948530034

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-280
