### PR TITLE
Redefine service-provided input paths

### DIFF
--- a/service/src/main/resources/db/changelog.xml
+++ b/service/src/main/resources/db/changelog.xml
@@ -27,6 +27,7 @@
   <include file="changesets/20240903_rename_workspace_project.yaml" relativeToChangelogFile="true"/>
   <include file="changesets/20240906_add_wdl_version_to_pipeline_run.yaml" relativeToChangelogFile="true"/>
   <include file="changesets/20240911_remove_isSuccess.yaml" relativeToChangelogFile="true"/>
+  <include file="changesets/20240923_update_input_defs_bucket_paths.yaml" relativeToChangelogFile="true"/>
 
   <include file="changesets/20240412-testdata.yaml" relativeToChangelogFile="true"/>
 

--- a/service/src/main/resources/db/changesets/20240923_update_input_defs_bucket_paths.yaml
+++ b/service/src/main/resources/db/changesets/20240923_update_input_defs_bucket_paths.yaml
@@ -7,7 +7,7 @@ databaseChangeLog:
         # update geneticMapsPath default_value from /plink-genetic-maps/GRCh38_fixed/
         - update:
             tableName: pipeline_input_definitions
-            where: id=3 AND name='geneticMapsPath'
+            where: name='geneticMapsPath' AND pipeline_id=(SELECT id FROM pipelines WHERE name='imputation_beagle')
             columns:
               - column:
                   name: default_value
@@ -15,7 +15,7 @@ databaseChangeLog:
         # update refDict default_value from /hg38/Homo_sapiens_assembly38.dict
         - update:
             tableName: pipeline_input_definitions
-            where: id=4 AND name='refDict'
+            where: name='refDict' AND pipeline_id=(SELECT id FROM pipelines WHERE name='imputation_beagle')
             columns:
               - column:
                   name: default_value
@@ -23,7 +23,7 @@ databaseChangeLog:
         # update referencePanelPathPrefix default_value from /hg38/1000G_HGDP_no_singletons_ref_panel/hgdp.tgp.gwaspy.merged.merged.AN_added.bcf.ac2
         - update:
             tableName: pipeline_input_definitions
-            where: id=5 AND name='referencePanelPathPrefix'
+            where: name='referencePanelPathPrefix' AND pipeline_id=(SELECT id FROM pipelines WHERE name='imputation_beagle')
             columns:
               - column:
                   name: default_value

--- a/service/src/main/resources/db/changesets/20240923_update_input_defs_bucket_paths.yaml
+++ b/service/src/main/resources/db/changesets/20240923_update_input_defs_bucket_paths.yaml
@@ -1,0 +1,30 @@
+# Update input definitions bucket paths for service provided inputs
+databaseChangeLog:
+  - changeSet:
+      id: Update input definitions bucket paths for service provided inputs
+      author: mma
+      changes:
+        # update geneticMapsPath default_value from /plink-genetic-maps/GRCh38_fixed/
+        - update:
+            tableName: pipeline_input_definitions
+            where: id=3 AND name='geneticMapsPath'
+            columns:
+              - column:
+                  name: default_value
+                  value: "/hg38/plink-genetic-maps/"
+        # update refDict default_value from /hg38/Homo_sapiens_assembly38.dict
+        - update:
+            tableName: pipeline_input_definitions
+            where: id=4 AND name='refDict'
+            columns:
+              - column:
+                  name: default_value
+                  value: "/hg38/ref_dict/Homo_sapiens_assembly38.dict"
+        # update referencePanelPathPrefix default_value from /hg38/1000G_HGDP_no_singletons_ref_panel/hgdp.tgp.gwaspy.merged.merged.AN_added.bcf.ac2
+        - update:
+            tableName: pipeline_input_definitions
+            where: id=5 AND name='referencePanelPathPrefix'
+            columns:
+              - column:
+                  name: default_value
+                  value: "/hg38/ref_panels/1000G_HGDP_no_singletons/hgdp.tgp.gwaspy.merged.merged.AN_added.bcf.ac2"


### PR DESCRIPTION
### Description 

Updating the default_value for service-provided input files to match the organization we want. This includes an `hg38` prefix for all, plus different intermediate "directory" files in some cases

Changes:
- geneticMapsPath
  - old value: `/plink-genetic-maps/GRCh38_fixed/`
  - new value: `/hg38/plink-genetic-maps/`
- refDict 
  - old value: `/hg38/Homo_sapiens_assembly38.dict`
  - new value: `/hg38/ref_dict/Homo_sapiens_assembly38.dict`
- referencePanelPathPrefix
  - old value: `/hg38/1000G_HGDP_no_singletons_ref_panel/hgdp.tgp.gwaspy.merged.merged.AN_added.bcf.ac2`
  - new value: `/hg38/ref_panels/1000G_HGDP_no_singletons/hgdp.tgp.gwaspy.merged.merged.AN_added.bcf.ac2`

Also performed the copy of these files in the dev bucket:
```
✗ gcloud storage ls gs://fc-secure-10efd4d7-392a-4e9e-89ea-d6629fbb06cc/hg38/plink-genetic-maps/ | wc -l
      22

✗ gcloud storage ls gs://fc-secure-10efd4d7-392a-4e9e-89ea-d6629fbb06cc/hg38/ref_dict/Homo_sapiens_assembly38.dict
gs://fc-secure-10efd4d7-392a-4e9e-89ea-d6629fbb06cc/hg38/ref_dict/Homo_sapiens_assembly38.dict

✗ gcloud storage ls gs://fc-secure-10efd4d7-392a-4e9e-89ea-d6629fbb06cc/hg38/ref_panels/1000G_HGDP_no_singletons/ | wc -l
      66

✗ gcloud storage ls gs://fc-secure-10efd4d7-392a-4e9e-89ea-d6629fbb06cc/hg38/ref_panels/simulated/500k/ | wc -l
     110

✗ gcloud storage ls gs://fc-secure-10efd4d7-392a-4e9e-89ea-d6629fbb06cc/hg38/ref_panels/simulated/10k/ | wc -l
     110
```

Will need to delete the old copies once the currently running workflows using the old paths have completed. 

### Jira Ticket
none