### PR TITLE
[TSPS-322] make explicit storage container url in PrepareImputationInputsStep

### DIFF
--- a/service/src/main/java/bio/terra/pipelines/app/controller/PipelineRunsApiController.java
+++ b/service/src/main/java/bio/terra/pipelines/app/controller/PipelineRunsApiController.java
@@ -12,6 +12,7 @@ import bio.terra.pipelines.db.entities.PipelineRun;
 import bio.terra.pipelines.dependencies.stairway.JobService;
 import bio.terra.pipelines.generated.api.PipelineRunsApi;
 import bio.terra.pipelines.generated.model.*;
+import bio.terra.pipelines.service.PipelineInputsOutputsService;
 import bio.terra.pipelines.service.PipelineRunsService;
 import bio.terra.pipelines.service.PipelinesService;
 import io.swagger.annotations.Api;
@@ -40,6 +41,7 @@ public class PipelineRunsApiController implements PipelineRunsApi {
   private final JobService jobService;
   private final PipelinesService pipelinesService;
   private final PipelineRunsService pipelineRunsService;
+  private final PipelineInputsOutputsService pipelineInputsOutputsService;
   private final IngressConfiguration ingressConfiguration;
 
   @Autowired
@@ -50,13 +52,15 @@ public class PipelineRunsApiController implements PipelineRunsApi {
       JobService jobService,
       PipelinesService pipelinesService,
       PipelineRunsService pipelineRunsService,
+      PipelineInputsOutputsService pipelineInputsOutputsService,
       IngressConfiguration ingressConfiguration) {
     this.samConfiguration = samConfiguration;
     this.samUserFactory = samUserFactory;
     this.request = request;
+    this.jobService = jobService;
     this.pipelinesService = pipelinesService;
     this.pipelineRunsService = pipelineRunsService;
-    this.jobService = jobService;
+    this.pipelineInputsOutputsService = pipelineInputsOutputsService;
     this.ingressConfiguration = ingressConfiguration;
   }
 
@@ -241,7 +245,7 @@ public class PipelineRunsApiController implements PipelineRunsApi {
           .pipelineRunReport(
               response
                   .getPipelineRunReport()
-                  .outputs(pipelineRunsService.formatPipelineRunOutputs(pipelineRun)));
+                  .outputs(pipelineInputsOutputsService.formatPipelineRunOutputs(pipelineRun)));
     } else {
       JobApiUtils.AsyncJobResult<String> jobResult =
           jobService.retrieveAsyncJobResult(

--- a/service/src/main/java/bio/terra/pipelines/common/utils/FlightBeanBag.java
+++ b/service/src/main/java/bio/terra/pipelines/common/utils/FlightBeanBag.java
@@ -8,6 +8,7 @@ import bio.terra.pipelines.dependencies.rawls.RawlsService;
 import bio.terra.pipelines.dependencies.sam.SamService;
 import bio.terra.pipelines.dependencies.wds.WdsService;
 import bio.terra.pipelines.dependencies.workspacemanager.WorkspaceManagerService;
+import bio.terra.pipelines.service.PipelineInputsOutputsService;
 import bio.terra.pipelines.service.PipelineRunsService;
 import bio.terra.pipelines.service.PipelinesService;
 import lombok.Getter;
@@ -27,6 +28,7 @@ import org.springframework.stereotype.Component;
 public class FlightBeanBag {
   private final PipelinesService pipelinesService;
   private final PipelineRunsService pipelineRunsService;
+  private final PipelineInputsOutputsService pipelineInputsOutputsService;
   private final SamService samService;
   private final LeonardoService leonardoService;
   private final WdsService wdsService;
@@ -41,6 +43,7 @@ public class FlightBeanBag {
   public FlightBeanBag(
       PipelinesService pipelinesService,
       PipelineRunsService pipelineRunsService,
+      PipelineInputsOutputsService pipelineInputsOutputsService,
       SamService samService,
       LeonardoService leonardoService,
       WdsService wdsService,
@@ -51,6 +54,7 @@ public class FlightBeanBag {
       CbasConfiguration cbasConfiguration) {
     this.pipelinesService = pipelinesService;
     this.pipelineRunsService = pipelineRunsService;
+    this.pipelineInputsOutputsService = pipelineInputsOutputsService;
     this.samService = samService;
     this.leonardoService = leonardoService;
     this.wdsService = wdsService;

--- a/service/src/main/java/bio/terra/pipelines/service/PipelineInputsOutputsService.java
+++ b/service/src/main/java/bio/terra/pipelines/service/PipelineInputsOutputsService.java
@@ -33,16 +33,18 @@ public class PipelineInputsOutputsService {
 
   private final PipelineInputsRepository pipelineInputsRepository;
   private final PipelineOutputsRepository pipelineOutputsRepository;
-  private final ObjectMapper objectMapper = new ObjectMapper();
+  private final ObjectMapper objectMapper;
 
   @Autowired
   public PipelineInputsOutputsService(
       GcsService gcsService,
       PipelineInputsRepository pipelineInputsRepository,
-      PipelineOutputsRepository pipelineOutputsRepository) {
+      PipelineOutputsRepository pipelineOutputsRepository,
+      ObjectMapper objectMapper) {
     this.gcsService = gcsService;
     this.pipelineInputsRepository = pipelineInputsRepository;
     this.pipelineOutputsRepository = pipelineOutputsRepository;
+    this.objectMapper = objectMapper;
   }
 
   /**

--- a/service/src/main/java/bio/terra/pipelines/service/PipelineInputsOutputsService.java
+++ b/service/src/main/java/bio/terra/pipelines/service/PipelineInputsOutputsService.java
@@ -1,0 +1,216 @@
+package bio.terra.pipelines.service;
+
+import static bio.terra.pipelines.common.utils.FileUtils.constructDestinationBlobNameForUserInputFile;
+import static bio.terra.pipelines.common.utils.FileUtils.getBlobNameFromTerraWorkspaceStorageUrlGcp;
+
+import bio.terra.common.exception.InternalServerErrorException;
+import bio.terra.pipelines.common.utils.PipelineVariableTypesEnum;
+import bio.terra.pipelines.db.entities.Pipeline;
+import bio.terra.pipelines.db.entities.PipelineInput;
+import bio.terra.pipelines.db.entities.PipelineInputDefinition;
+import bio.terra.pipelines.db.entities.PipelineOutput;
+import bio.terra.pipelines.db.entities.PipelineOutputDefinition;
+import bio.terra.pipelines.db.entities.PipelineRun;
+import bio.terra.pipelines.db.repositories.PipelineInputsRepository;
+import bio.terra.pipelines.db.repositories.PipelineOutputsRepository;
+import bio.terra.pipelines.dependencies.gcs.GcsService;
+import bio.terra.pipelines.generated.model.ApiPipelineRunOutputs;
+import bio.terra.rawls.model.Entity;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+/* Service to encapsulate the logic for processing pipeline inputs and outputs */
+@Service
+public class PipelineInputsOutputsService {
+  private static final Logger logger = LoggerFactory.getLogger(PipelineInputsOutputsService.class);
+
+  private final GcsService gcsService;
+
+  private final PipelineInputsRepository pipelineInputsRepository;
+  private final PipelineOutputsRepository pipelineOutputsRepository;
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  @Autowired
+  public PipelineInputsOutputsService(
+      GcsService gcsService,
+      PipelineInputsRepository pipelineInputsRepository,
+      PipelineOutputsRepository pipelineOutputsRepository) {
+    this.gcsService = gcsService;
+    this.pipelineInputsRepository = pipelineInputsRepository;
+    this.pipelineOutputsRepository = pipelineOutputsRepository;
+  }
+
+  /**
+   * Generate signed PUT urls and curl commands for each user-provided file input in the pipeline.
+   *
+   * <p>Each user-provided file input (assumed to be a path to a local file) is translated into a
+   * write-only (PUT) signed url in a location in the pipeline workspace storage container, in a
+   * directory defined by the jobId.
+   *
+   * <p>This signed url along with the source file path provided by the user are used to generate a
+   * curl command that the user can run to upload the file to the location in the pipeline workspace
+   * storage container.
+   */
+  public Map<String, Map<String, String>> prepareFileInputs(
+      Pipeline pipeline, UUID jobId, Map<String, Object> userProvidedInputs) {
+    // get the list of files that the user needs to upload
+    List<String> fileInputNames =
+        pipeline.getPipelineInputDefinitions().stream()
+            .filter(PipelineInputDefinition::getUserProvided)
+            .filter(p -> p.getType().equals(PipelineVariableTypesEnum.FILE))
+            .map(PipelineInputDefinition::getName)
+            .toList();
+
+    String googleProjectId = pipeline.getWorkspaceGoogleProject();
+    String bucketName = pipeline.getWorkspaceStorageContainerName();
+    // generate a map where the key is the input name, and the value is a map containing the
+    // write-only PUT signed url for the file and the full curl command to upload the file
+
+    Map<String, Map<String, String>> fileInputsMap = new HashMap<>();
+    for (String fileInputName : fileInputNames) {
+      String fileInputValue = (String) userProvidedInputs.get(fileInputName);
+      String objectName = constructDestinationBlobNameForUserInputFile(jobId, fileInputValue);
+      String signedUrl =
+          gcsService.generatePutObjectSignedUrl(googleProjectId, bucketName, objectName).toString();
+
+      fileInputsMap.put(
+          fileInputName,
+          Map.of(
+              "signedUrl",
+              signedUrl,
+              "curlCommand",
+              "curl -X PUT -H 'Content-Type: application/octet-stream' --upload-file %s '%s'"
+                  .formatted(fileInputValue, signedUrl)));
+    }
+
+    return fileInputsMap;
+  }
+
+  /** Convert pipelineInputs map to string and save to the pipelineInputs table */
+  public void savePipelineInputs(Long pipelineRunId, Map<String, Object> pipelineInputs) {
+    String pipelineInputsAsString;
+    try {
+      // do this to write the pipeline inputs without writing the class name
+      pipelineInputsAsString = objectMapper.writeValueAsString(pipelineInputs);
+    } catch (JsonProcessingException e) {
+      // this should never happen
+      throw new InternalServerErrorException("Internal error processing pipeline inputs", e);
+    }
+
+    // save related pipeline inputs
+    PipelineInput pipelineInput = new PipelineInput();
+    pipelineInput.setJobId(pipelineRunId);
+    pipelineInput.setInputs(pipelineInputsAsString);
+    pipelineInputsRepository.save(pipelineInput);
+  }
+
+  /** Retrieve pipeline inputs from the pipelineInputs table and convert to a map */
+  public Map<String, Object> retrievePipelineInputs(PipelineRun pipelineRun) {
+    PipelineInput pipelineInput =
+        pipelineInputsRepository
+            .findById(pipelineRun.getId())
+            .orElseThrow(
+                () ->
+                    new InternalServerErrorException(
+                        "Pipeline inputs not found for jobId %s"
+                            .formatted(pipelineRun.getJobId())));
+    try {
+      return objectMapper.readValue(pipelineInput.getInputs(), new TypeReference<>() {});
+    } catch (JsonProcessingException e) {
+      throw new InternalServerErrorException("Error reading pipeline inputs", e);
+    }
+  }
+
+  // methods to interact with and format pipeline run outputs
+
+  /**
+   * Extract pipeline outputs from a Rawls entity object, converting wdlVariableName (typically
+   * snake_case) to outputName (camelCase). Throw an error if any outputs are missing from the
+   * entity or empty.
+   *
+   * @param pipelineOutputDefinitions
+   * @param entity
+   * @return a map of pipeline outputs
+   */
+  public Map<String, String> extractPipelineOutputsFromEntity(
+      List<PipelineOutputDefinition> pipelineOutputDefinitions, Entity entity) {
+    Map<String, String> outputs = new HashMap<>();
+    for (PipelineOutputDefinition outputDefinition : pipelineOutputDefinitions) {
+      String keyName = outputDefinition.getName();
+      String wdlVariableName = outputDefinition.getWdlVariableName();
+      String outputValue =
+          (String)
+              entity
+                  .getAttributes()
+                  .get(wdlVariableName); // .get() returns null if the key is missing, or if the
+      // value is empty
+      if (outputValue == null) {
+        throw new InternalServerErrorException(
+            "Output %s is empty or missing".formatted(wdlVariableName));
+      }
+      outputs.put(keyName, outputValue);
+    }
+    return outputs;
+  }
+
+  /**
+   * Extract the pipeline outputs from a pipelineRun object, create signed GET (read-only) urls for
+   * each file, and return an ApiPipelineRunOutputs object with the outputs.
+   *
+   * @param pipelineRun object from the pipelineRunsRepository
+   * @return ApiPipelineRunOutputs
+   */
+  public ApiPipelineRunOutputs formatPipelineRunOutputs(PipelineRun pipelineRun) {
+    Map<String, String> outputsMap =
+        stringToMap(
+            pipelineOutputsRepository.findPipelineOutputsByJobId(pipelineRun.getId()).getOutputs());
+
+    // currently all outputs are paths that will need a signed url
+    String workspaceStorageContainerName = pipelineRun.getWorkspaceStorageContainerName();
+    outputsMap.replaceAll(
+        (k, v) ->
+            gcsService
+                .generateGetObjectSignedUrl(
+                    pipelineRun.getWorkspaceGoogleProject(),
+                    workspaceStorageContainerName,
+                    getBlobNameFromTerraWorkspaceStorageUrlGcp(v, workspaceStorageContainerName))
+                .toString());
+
+    ApiPipelineRunOutputs apiPipelineRunOutputs = new ApiPipelineRunOutputs();
+    apiPipelineRunOutputs.putAll(outputsMap);
+    return apiPipelineRunOutputs;
+  }
+
+  /** Convert pipelineOutputs map to string and save to the pipelineOutputs table */
+  public void savePipelineOutputs(Long pipelineRunId, Map<String, String> pipelineOutputs) {
+    PipelineOutput pipelineOutput = new PipelineOutput();
+    pipelineOutput.setJobId(pipelineRunId);
+    pipelineOutput.setOutputs(mapToString(pipelineOutputs));
+    pipelineOutputsRepository.save(pipelineOutput);
+  }
+
+  public String mapToString(Map<String, ?> outputsMap) {
+    try {
+      return objectMapper.writeValueAsString(outputsMap);
+    } catch (JsonProcessingException e) {
+      throw new InternalServerErrorException("Error converting map to string", e);
+    }
+  }
+
+  public Map<String, String> stringToMap(String outputsString) {
+    try {
+      return objectMapper.readValue(outputsString, new TypeReference<>() {});
+    } catch (JsonProcessingException e) {
+      throw new InternalServerErrorException("Error converting string to map", e);
+    }
+  }
+}

--- a/service/src/main/java/bio/terra/pipelines/service/PipelineRunsService.java
+++ b/service/src/main/java/bio/terra/pipelines/service/PipelineRunsService.java
@@ -239,6 +239,9 @@ public class PipelineRunsService {
                 RunImputationJobFlightMapKeys.CONTROL_WORKSPACE_STORAGE_CONTAINER_NAME,
                 pipelineRun.getWorkspaceStorageContainerName())
             .addParameter(
+                RunImputationJobFlightMapKeys.CONTROL_WORKSPACE_STORAGE_CONTAINER_PROTOCOL,
+                "gs://") // this is the GCP storage url protocol
+            .addParameter(
                 RunImputationJobFlightMapKeys.WDL_METHOD_NAME, pipeline.getWdlMethodName())
             .addParameter(
                 RunImputationJobFlightMapKeys.WDL_METHOD_VERSION, pipeline.getWdlMethodVersion())

--- a/service/src/main/java/bio/terra/pipelines/service/PipelineRunsService.java
+++ b/service/src/main/java/bio/terra/pipelines/service/PipelineRunsService.java
@@ -23,7 +23,6 @@ import bio.terra.pipelines.dependencies.stairway.JobService;
 import bio.terra.pipelines.stairway.imputation.RunImputationGcpJobFlight;
 import bio.terra.pipelines.stairway.imputation.RunImputationJobFlightMapKeys;
 import bio.terra.stairway.Flight;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -42,8 +41,6 @@ public class PipelineRunsService {
   private final JobService jobService;
   private final PipelineInputsOutputsService pipelineInputsOutputsService;
   private final PipelineRunsRepository pipelineRunsRepository;
-
-  private final ObjectMapper objectMapper = new ObjectMapper();
 
   @Autowired
   public PipelineRunsService(

--- a/service/src/main/java/bio/terra/pipelines/service/PipelineRunsService.java
+++ b/service/src/main/java/bio/terra/pipelines/service/PipelineRunsService.java
@@ -1,7 +1,5 @@
 package bio.terra.pipelines.service;
 
-import static bio.terra.pipelines.common.utils.FileUtils.constructDestinationBlobNameForUserInputFile;
-import static bio.terra.pipelines.common.utils.FileUtils.getBlobNameFromTerraWorkspaceStorageUrlGcp;
 import static java.util.Collections.emptyList;
 import static org.springframework.data.domain.PageRequest.ofSize;
 
@@ -10,35 +8,22 @@ import bio.terra.common.exception.BadRequestException;
 import bio.terra.common.exception.InternalServerErrorException;
 import bio.terra.pipelines.app.common.MetricsUtils;
 import bio.terra.pipelines.common.utils.CommonPipelineRunStatusEnum;
-import bio.terra.pipelines.common.utils.PipelineVariableTypesEnum;
 import bio.terra.pipelines.common.utils.PipelinesEnum;
 import bio.terra.pipelines.common.utils.pagination.CursorBasedPageable;
 import bio.terra.pipelines.common.utils.pagination.FieldEqualsSpecification;
 import bio.terra.pipelines.common.utils.pagination.PageResponse;
 import bio.terra.pipelines.common.utils.pagination.PageSpecification;
 import bio.terra.pipelines.db.entities.Pipeline;
-import bio.terra.pipelines.db.entities.PipelineInput;
-import bio.terra.pipelines.db.entities.PipelineInputDefinition;
-import bio.terra.pipelines.db.entities.PipelineOutput;
-import bio.terra.pipelines.db.entities.PipelineOutputDefinition;
 import bio.terra.pipelines.db.entities.PipelineRun;
 import bio.terra.pipelines.db.exception.DuplicateObjectException;
-import bio.terra.pipelines.db.repositories.PipelineInputsRepository;
-import bio.terra.pipelines.db.repositories.PipelineOutputsRepository;
 import bio.terra.pipelines.db.repositories.PipelineRunsRepository;
-import bio.terra.pipelines.dependencies.gcs.GcsService;
 import bio.terra.pipelines.dependencies.stairway.JobBuilder;
 import bio.terra.pipelines.dependencies.stairway.JobMapKeys;
 import bio.terra.pipelines.dependencies.stairway.JobService;
-import bio.terra.pipelines.generated.model.ApiPipelineRunOutputs;
 import bio.terra.pipelines.stairway.imputation.RunImputationGcpJobFlight;
 import bio.terra.pipelines.stairway.imputation.RunImputationJobFlightMapKeys;
-import bio.terra.rawls.model.Entity;
 import bio.terra.stairway.Flight;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -55,25 +40,19 @@ public class PipelineRunsService {
   private static final Logger logger = LoggerFactory.getLogger(PipelineRunsService.class);
 
   private final JobService jobService;
-  private final GcsService gcsService;
+  private final PipelineInputsOutputsService pipelineInputsOutputsService;
   private final PipelineRunsRepository pipelineRunsRepository;
-  private final PipelineInputsRepository pipelineInputsRepository;
-  private final PipelineOutputsRepository pipelineOutputsRepository;
 
   private final ObjectMapper objectMapper = new ObjectMapper();
 
   @Autowired
   public PipelineRunsService(
       JobService jobService,
-      GcsService gcsService,
-      PipelineRunsRepository pipelineRunsRepository,
-      PipelineInputsRepository pipelineInputsRepository,
-      PipelineOutputsRepository pipelineOutputsRepository) {
+      PipelineInputsOutputsService pipelineInputsOutputsService,
+      PipelineRunsRepository pipelineRunsRepository) {
     this.jobService = jobService;
-    this.gcsService = gcsService;
+    this.pipelineInputsOutputsService = pipelineInputsOutputsService;
     this.pipelineRunsRepository = pipelineRunsRepository;
-    this.pipelineInputsRepository = pipelineInputsRepository;
-    this.pipelineOutputsRepository = pipelineOutputsRepository;
   }
 
   /**
@@ -110,7 +89,7 @@ public class PipelineRunsService {
 
     // return a map of signed PUT urls and curl commands for the user to upload their input files
     Map<String, Map<String, String>> pipelineFileInputs =
-        prepareFileInputs(pipeline, jobId, userProvidedInputs);
+        pipelineInputsOutputsService.prepareFileInputs(pipeline, jobId, userProvidedInputs);
 
     // save the pipeline run to the database
     writeNewPipelineRunToDb(
@@ -128,52 +107,6 @@ public class PipelineRunsService {
     MetricsUtils.incrementPipelinePrepareRun(pipelineName);
 
     return pipelineFileInputs;
-  }
-
-  /**
-   * Generate signed PUT urls and curl commands for each user-provided file input in the pipeline.
-   *
-   * <p>Each user-provided file input (assumed to be a path to a local file) is translated into a
-   * write-only (PUT) signed url in a location in the pipeline workspace storage container, in a
-   * directory defined by the jobId.
-   *
-   * <p>This signed url along with the source file path provided by the user are used to generate a
-   * curl command that the user can run to upload the file to the location in the pipeline workspace
-   * storage container.
-   */
-  private Map<String, Map<String, String>> prepareFileInputs(
-      Pipeline pipeline, UUID jobId, Map<String, Object> userProvidedInputs) {
-    // get the list of files that the user needs to upload
-    List<String> fileInputNames =
-        pipeline.getPipelineInputDefinitions().stream()
-            .filter(PipelineInputDefinition::getUserProvided)
-            .filter(p -> p.getType().equals(PipelineVariableTypesEnum.FILE))
-            .map(PipelineInputDefinition::getName)
-            .toList();
-
-    String googleProjectId = pipeline.getWorkspaceGoogleProject();
-    String bucketName = pipeline.getWorkspaceStorageContainerName();
-    // generate a map where the key is the input name, and the value is a map containing the
-    // write-only PUT signed url for the file and the full curl command to upload the file
-
-    Map<String, Map<String, String>> fileInputsMap = new HashMap<>();
-    for (String fileInputName : fileInputNames) {
-      String fileInputValue = (String) userProvidedInputs.get(fileInputName);
-      String objectName = constructDestinationBlobNameForUserInputFile(jobId, fileInputValue);
-      String signedUrl =
-          gcsService.generatePutObjectSignedUrl(googleProjectId, bucketName, objectName).toString();
-
-      fileInputsMap.put(
-          fileInputName,
-          Map.of(
-              "signedUrl",
-              signedUrl,
-              "curlCommand",
-              "curl -X PUT -H 'Content-Type: application/octet-stream' --upload-file %s '%s'"
-                  .formatted(fileInputValue, signedUrl)));
-    }
-
-    return fileInputsMap;
   }
 
   /**
@@ -199,7 +132,8 @@ public class PipelineRunsService {
 
     PipelineRun pipelineRun = startPipelineRunInDb(jobId, userId, description, resultPath);
 
-    Map<String, Object> userProvidedInputs = retrievePipelineInputs(pipelineRun);
+    Map<String, Object> userProvidedInputs =
+        pipelineInputsOutputsService.retrievePipelineInputs(pipelineRun);
 
     logger.info("Starting new {} job for user {}", pipelineName, userId);
 
@@ -254,22 +188,6 @@ public class PipelineRunsService {
     return pipelineRun;
   }
 
-  private Map<String, Object> retrievePipelineInputs(PipelineRun pipelineRun) {
-    PipelineInput pipelineInput =
-        pipelineInputsRepository
-            .findById(pipelineRun.getId())
-            .orElseThrow(
-                () ->
-                    new InternalServerErrorException(
-                        "Pipeline inputs not found for jobId %s"
-                            .formatted(pipelineRun.getJobId())));
-    try {
-      return objectMapper.readValue(pipelineInput.getInputs(), new TypeReference<>() {});
-    } catch (JsonProcessingException e) {
-      throw new InternalServerErrorException("Error reading pipeline inputs", e);
-    }
-  }
-
   // methods to write and update PipelineRuns in the database
 
   /**
@@ -306,20 +224,7 @@ public class PipelineRunsService {
             CommonPipelineRunStatusEnum.PREPARING);
     PipelineRun createdPipelineRun = writePipelineRunToDbThrowsDuplicateException(pipelineRun);
 
-    String pipelineInputsAsString;
-    try {
-      // do this to write the pipeline inputs without writing the class name
-      pipelineInputsAsString = objectMapper.writeValueAsString(pipelineInputs);
-    } catch (JsonProcessingException e) {
-      // this should never happen
-      throw new InternalServerErrorException("Internal error processing pipeline inputs", e);
-    }
-
-    // save related pipeline inputs
-    PipelineInput pipelineInput = new PipelineInput();
-    pipelineInput.setJobId(createdPipelineRun.getId());
-    pipelineInput.setInputs(pipelineInputsAsString);
-    pipelineInputsRepository.save(pipelineInput);
+    pipelineInputsOutputsService.savePipelineInputs(createdPipelineRun.getId(), pipelineInputs);
 
     return createdPipelineRun;
   }
@@ -395,10 +300,7 @@ public class PipelineRunsService {
       UUID jobId, String userId, Map<String, String> outputs) {
     PipelineRun pipelineRun = getPipelineRun(jobId, userId);
 
-    PipelineOutput pipelineOutput = new PipelineOutput();
-    pipelineOutput.setJobId(pipelineRun.getId());
-    pipelineOutput.setOutputs(pipelineRunOutputsAsString(outputs));
-    pipelineOutputsRepository.save(pipelineOutput);
+    pipelineInputsOutputsService.savePipelineOutputs(pipelineRun.getId(), outputs);
 
     pipelineRun.setStatus(CommonPipelineRunStatusEnum.SUCCEEDED);
 
@@ -415,82 +317,6 @@ public class PipelineRunsService {
     PipelineRun pipelineRun = getPipelineRun(jobId, userId);
     pipelineRun.setStatus(CommonPipelineRunStatusEnum.FAILED);
     pipelineRunsRepository.save(pipelineRun);
-  }
-
-  // methods to interact with and format pipeline run outputs
-
-  /**
-   * Extract pipeline outputs from a Rawls entity object, converting wdlVariableName (typically
-   * snake_case) to outputName (camelCase). Throw an error if any outputs are missing from the
-   * entity or empty.
-   *
-   * @param pipelineOutputDefinitions
-   * @param entity
-   * @return a map of pipeline outputs
-   */
-  public Map<String, String> extractPipelineOutputsFromEntity(
-      List<PipelineOutputDefinition> pipelineOutputDefinitions, Entity entity) {
-    Map<String, String> outputs = new HashMap<>();
-    for (PipelineOutputDefinition outputDefinition : pipelineOutputDefinitions) {
-      String keyName = outputDefinition.getName();
-      String wdlVariableName = outputDefinition.getWdlVariableName();
-      String outputValue =
-          (String)
-              entity
-                  .getAttributes()
-                  .get(wdlVariableName); // .get() returns null if the key is missing, or if the
-      // value is empty
-      if (outputValue == null) {
-        throw new InternalServerErrorException(
-            "Output %s is empty or missing".formatted(wdlVariableName));
-      }
-      outputs.put(keyName, outputValue);
-    }
-    return outputs;
-  }
-
-  /**
-   * Extract the pipeline outputs from a pipelineRun object, create signed GET (read-only) urls for
-   * each file, and return an ApiPipelineRunOutputs object with the outputs.
-   *
-   * @param pipelineRun object from the pipelineRunsRepository
-   * @return ApiPipelineRunOutputs
-   */
-  public ApiPipelineRunOutputs formatPipelineRunOutputs(PipelineRun pipelineRun) {
-    Map<String, String> outputsMap =
-        pipelineRunOutputsAsMap(
-            pipelineOutputsRepository.findPipelineOutputsByJobId(pipelineRun.getId()).getOutputs());
-
-    // currently all outputs are paths that will need a signed url
-    String workspaceStorageContainerName = pipelineRun.getWorkspaceStorageContainerName();
-    outputsMap.replaceAll(
-        (k, v) ->
-            gcsService
-                .generateGetObjectSignedUrl(
-                    pipelineRun.getWorkspaceGoogleProject(),
-                    workspaceStorageContainerName,
-                    getBlobNameFromTerraWorkspaceStorageUrlGcp(v, workspaceStorageContainerName))
-                .toString());
-
-    ApiPipelineRunOutputs apiPipelineRunOutputs = new ApiPipelineRunOutputs();
-    apiPipelineRunOutputs.putAll(outputsMap);
-    return apiPipelineRunOutputs;
-  }
-
-  public String pipelineRunOutputsAsString(Map<String, String> outputsMap) {
-    try {
-      return objectMapper.writeValueAsString(outputsMap);
-    } catch (JsonProcessingException e) {
-      throw new InternalServerErrorException("Error converting pipeline run outputs to string", e);
-    }
-  }
-
-  public Map<String, String> pipelineRunOutputsAsMap(String outputsString) {
-    try {
-      return objectMapper.readValue(outputsString, new TypeReference<>() {});
-    } catch (JsonProcessingException e) {
-      throw new InternalServerErrorException("Error reading pipeline run outputs", e);
-    }
   }
 
   /**

--- a/service/src/main/java/bio/terra/pipelines/stairway/imputation/RunImputationAzureJobFlight.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/imputation/RunImputationAzureJobFlight.java
@@ -40,6 +40,7 @@ public class RunImputationAzureJobFlight extends Flight {
         RunImputationJobFlightMapKeys.USER_PROVIDED_PIPELINE_INPUTS,
         RunImputationJobFlightMapKeys.CONTROL_WORKSPACE_ID,
         RunImputationJobFlightMapKeys.CONTROL_WORKSPACE_STORAGE_CONTAINER_NAME,
+        RunImputationJobFlightMapKeys.CONTROL_WORKSPACE_STORAGE_CONTAINER_PROTOCOL,
         RunImputationJobFlightMapKeys.WDL_METHOD_NAME,
         JobMapKeys.RESULT_PATH.getKeyName());
 

--- a/service/src/main/java/bio/terra/pipelines/stairway/imputation/RunImputationGcpJobFlight.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/imputation/RunImputationGcpJobFlight.java
@@ -94,7 +94,7 @@ public class RunImputationGcpJobFlight extends Flight {
         new FetchOutputsFromDataTableStep(
             flightBeanBag.getRawlsService(),
             flightBeanBag.getSamService(),
-            flightBeanBag.getPipelineRunsService()),
+            flightBeanBag.getPipelineInputsOutputsService()),
         externalServiceRetryRule);
 
     addStep(new CompletePipelineRunStep(flightBeanBag.getPipelineRunsService()), dbRetryRule);

--- a/service/src/main/java/bio/terra/pipelines/stairway/imputation/RunImputationGcpJobFlight.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/imputation/RunImputationGcpJobFlight.java
@@ -55,6 +55,7 @@ public class RunImputationGcpJobFlight extends Flight {
         RunImputationJobFlightMapKeys.CONTROL_WORKSPACE_BILLING_PROJECT,
         RunImputationJobFlightMapKeys.CONTROL_WORKSPACE_NAME,
         RunImputationJobFlightMapKeys.CONTROL_WORKSPACE_STORAGE_CONTAINER_NAME,
+        RunImputationJobFlightMapKeys.CONTROL_WORKSPACE_STORAGE_CONTAINER_PROTOCOL,
         RunImputationJobFlightMapKeys.WDL_METHOD_NAME,
         RunImputationJobFlightMapKeys.WDL_METHOD_VERSION,
         JobMapKeys.RESULT_PATH.getKeyName());

--- a/service/src/main/java/bio/terra/pipelines/stairway/imputation/RunImputationJobFlightMapKeys.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/imputation/RunImputationJobFlightMapKeys.java
@@ -8,6 +8,8 @@ public abstract class RunImputationJobFlightMapKeys {
   public static final String ALL_PIPELINE_INPUTS = "all_pipeline_inputs";
   public static final String CONTROL_WORKSPACE_STORAGE_CONTAINER_NAME =
       "control_workspace_storage_container_name";
+  public static final String CONTROL_WORKSPACE_STORAGE_CONTAINER_PROTOCOL =
+      "control_workspace_storage_container_protocol";
   public static final String WDL_METHOD_NAME = "wdl_method_name";
   public static final String WDL_METHOD_VERSION = "wdl_method_version";
   public static final String PIPELINE_RUN_OUTPUTS = "pipeline_run_outputs";

--- a/service/src/main/java/bio/terra/pipelines/stairway/imputation/steps/PrepareImputationInputsStep.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/imputation/steps/PrepareImputationInputsStep.java
@@ -59,7 +59,8 @@ public class PrepareImputationInputsStep implements Step {
         JobMapKeys.PIPELINE_NAME.getKeyName(),
         RunImputationJobFlightMapKeys.PIPELINE_INPUT_DEFINITIONS,
         RunImputationJobFlightMapKeys.USER_PROVIDED_PIPELINE_INPUTS,
-        RunImputationJobFlightMapKeys.CONTROL_WORKSPACE_STORAGE_CONTAINER_NAME);
+        RunImputationJobFlightMapKeys.CONTROL_WORKSPACE_STORAGE_CONTAINER_NAME,
+        RunImputationJobFlightMapKeys.CONTROL_WORKSPACE_STORAGE_CONTAINER_PROTOCOL);
 
     PipelinesEnum pipelineEnum =
         PipelinesEnum.valueOf(
@@ -73,11 +74,17 @@ public class PrepareImputationInputsStep implements Step {
     String controlWorkspaceStorageContainerName =
         inputParameters.get(
             RunImputationJobFlightMapKeys.CONTROL_WORKSPACE_STORAGE_CONTAINER_NAME, String.class);
+    String controlWorkspaceStorageContainerProtocol =
+        inputParameters.get(
+            RunImputationJobFlightMapKeys.CONTROL_WORKSPACE_STORAGE_CONTAINER_PROTOCOL,
+            String.class);
     UUID jobId = UUID.fromString(flightContext.getFlightId());
 
     // construct the control workspace storage URL
     String controlWorkspaceStorageContainerUrl =
-        "gs://%s".formatted(controlWorkspaceStorageContainerName);
+        "%s%s"
+            .formatted(
+                controlWorkspaceStorageContainerProtocol, controlWorkspaceStorageContainerName);
 
     Map<String, Object> allPipelineInputs =
         pipelinesService.constructRawInputs(allInputDefinitions, userProvidedPipelineInputs);

--- a/service/src/main/java/bio/terra/pipelines/stairway/imputation/steps/PrepareImputationInputsStep.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/imputation/steps/PrepareImputationInputsStep.java
@@ -70,10 +70,14 @@ public class PrepareImputationInputsStep implements Step {
     Map<String, Object> userProvidedPipelineInputs =
         inputParameters.get(
             RunImputationJobFlightMapKeys.USER_PROVIDED_PIPELINE_INPUTS, new TypeReference<>() {});
-    String controlWorkspaceStorageContainerUrl =
+    String controlWorkspaceStorageContainerName =
         inputParameters.get(
             RunImputationJobFlightMapKeys.CONTROL_WORKSPACE_STORAGE_CONTAINER_NAME, String.class);
     UUID jobId = UUID.fromString(flightContext.getFlightId());
+
+    // construct the control workspace storage URL
+    String controlWorkspaceStorageContainerUrl =
+        "gs://%s".formatted(controlWorkspaceStorageContainerName);
 
     Map<String, Object> allPipelineInputs =
         pipelinesService.constructRawInputs(allInputDefinitions, userProvidedPipelineInputs);

--- a/service/src/main/java/bio/terra/pipelines/stairway/imputation/steps/gcp/FetchOutputsFromDataTableStep.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/imputation/steps/gcp/FetchOutputsFromDataTableStep.java
@@ -7,7 +7,7 @@ import bio.terra.pipelines.dependencies.rawls.RawlsService;
 import bio.terra.pipelines.dependencies.rawls.RawlsServiceApiException;
 import bio.terra.pipelines.dependencies.sam.SamService;
 import bio.terra.pipelines.dependencies.stairway.JobMapKeys;
-import bio.terra.pipelines.service.PipelineRunsService;
+import bio.terra.pipelines.service.PipelineInputsOutputsService;
 import bio.terra.pipelines.stairway.imputation.RunImputationJobFlightMapKeys;
 import bio.terra.rawls.model.Entity;
 import bio.terra.stairway.FlightContext;
@@ -28,13 +28,15 @@ public class FetchOutputsFromDataTableStep implements Step {
 
   private final RawlsService rawlsService;
   private final SamService samService;
-  private final PipelineRunsService pipelineRunsService;
+  private final PipelineInputsOutputsService pipelineInputsOutputsService;
 
   public FetchOutputsFromDataTableStep(
-      RawlsService rawlsService, SamService samService, PipelineRunsService pipelineRunsService) {
+      RawlsService rawlsService,
+      SamService samService,
+      PipelineInputsOutputsService pipelineInputsOutputsService) {
     this.rawlsService = rawlsService;
     this.samService = samService;
-    this.pipelineRunsService = pipelineRunsService;
+    this.pipelineInputsOutputsService = pipelineInputsOutputsService;
   }
 
   @Override
@@ -81,7 +83,7 @@ public class FetchOutputsFromDataTableStep implements Step {
     // are
     // missing or empty
     Map<String, String> outputs =
-        pipelineRunsService.extractPipelineOutputsFromEntity(outputDefinitions, entity);
+        pipelineInputsOutputsService.extractPipelineOutputsFromEntity(outputDefinitions, entity);
 
     FlightMap workingMap = flightContext.getWorkingMap();
     workingMap.put(RunImputationJobFlightMapKeys.PIPELINE_RUN_OUTPUTS, outputs);

--- a/service/src/test/java/bio/terra/pipelines/common/utils/FlightBeanBagTest.java
+++ b/service/src/test/java/bio/terra/pipelines/common/utils/FlightBeanBagTest.java
@@ -10,6 +10,7 @@ import bio.terra.pipelines.dependencies.rawls.RawlsService;
 import bio.terra.pipelines.dependencies.sam.SamService;
 import bio.terra.pipelines.dependencies.wds.WdsService;
 import bio.terra.pipelines.dependencies.workspacemanager.WorkspaceManagerService;
+import bio.terra.pipelines.service.PipelineInputsOutputsService;
 import bio.terra.pipelines.service.PipelineRunsService;
 import bio.terra.pipelines.service.PipelinesService;
 import bio.terra.pipelines.testutils.BaseEmbeddedDbTest;
@@ -20,6 +21,7 @@ class FlightBeanBagTest extends BaseEmbeddedDbTest {
 
   @Autowired private PipelinesService pipelinesService;
   @Autowired private PipelineRunsService pipelineRunsService;
+  @Autowired private PipelineInputsOutputsService pipelineInputsOutputsService;
   @Autowired private SamService samService;
   @Autowired private LeonardoService leonardoService;
   @Autowired private WdsService wdsService;
@@ -35,6 +37,7 @@ class FlightBeanBagTest extends BaseEmbeddedDbTest {
         new FlightBeanBag(
             pipelinesService,
             pipelineRunsService,
+            pipelineInputsOutputsService,
             samService,
             leonardoService,
             wdsService,
@@ -45,6 +48,7 @@ class FlightBeanBagTest extends BaseEmbeddedDbTest {
             cbasConfiguration);
     assertEquals(pipelinesService, flightBeanBag.getPipelinesService());
     assertEquals(pipelineRunsService, flightBeanBag.getPipelineRunsService());
+    assertEquals(pipelineInputsOutputsService, flightBeanBag.getPipelineInputsOutputsService());
     assertEquals(samService, flightBeanBag.getSamService());
     assertEquals(leonardoService, flightBeanBag.getLeonardoService());
     assertEquals(wdsService, flightBeanBag.getWdsService());

--- a/service/src/test/java/bio/terra/pipelines/controller/PipelineRunsApiControllerTest.java
+++ b/service/src/test/java/bio/terra/pipelines/controller/PipelineRunsApiControllerTest.java
@@ -30,6 +30,7 @@ import bio.terra.pipelines.db.entities.PipelineRun;
 import bio.terra.pipelines.dependencies.stairway.JobService;
 import bio.terra.pipelines.dependencies.stairway.exception.InternalStairwayException;
 import bio.terra.pipelines.generated.model.*;
+import bio.terra.pipelines.service.PipelineInputsOutputsService;
 import bio.terra.pipelines.service.PipelineRunsService;
 import bio.terra.pipelines.service.PipelinesService;
 import bio.terra.pipelines.testutils.MockMvcUtils;
@@ -66,6 +67,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 class PipelineRunsApiControllerTest {
   @MockBean PipelinesService pipelinesServiceMock;
   @MockBean PipelineRunsService pipelineRunsServiceMock;
+  @MockBean PipelineInputsOutputsService pipelineInputsOutputsServiceMock;
   @MockBean JobService jobServiceMock;
   @MockBean SamUserFactory samUserFactoryMock;
   @MockBean BearerTokenFactory bearerTokenFactory;
@@ -399,7 +401,7 @@ class PipelineRunsApiControllerTest {
     // db
     when(pipelineRunsServiceMock.getPipelineRun(newJobId, testUser.getSubjectId()))
         .thenReturn(pipelineRun);
-    when(pipelineRunsServiceMock.formatPipelineRunOutputs(pipelineRun))
+    when(pipelineInputsOutputsServiceMock.formatPipelineRunOutputs(pipelineRun))
         .thenReturn(apiPipelineRunOutputs);
 
     MvcResult result =

--- a/service/src/test/java/bio/terra/pipelines/service/PipelineInputsOutputsServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/PipelineInputsOutputsServiceTest.java
@@ -1,0 +1,115 @@
+package bio.terra.pipelines.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import bio.terra.common.exception.InternalServerErrorException;
+import bio.terra.pipelines.db.entities.PipelineOutput;
+import bio.terra.pipelines.db.entities.PipelineOutputDefinition;
+import bio.terra.pipelines.db.entities.PipelineRun;
+import bio.terra.pipelines.db.repositories.PipelineInputsRepository;
+import bio.terra.pipelines.db.repositories.PipelineOutputsRepository;
+import bio.terra.pipelines.db.repositories.PipelineRunsRepository;
+import bio.terra.pipelines.dependencies.gcs.GcsService;
+import bio.terra.pipelines.generated.model.ApiPipelineRunOutputs;
+import bio.terra.pipelines.testutils.BaseEmbeddedDbTest;
+import bio.terra.pipelines.testutils.TestUtils;
+import bio.terra.rawls.model.Entity;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+class PipelineInputsOutputsServiceTest extends BaseEmbeddedDbTest {
+  @Autowired @InjectMocks PipelineInputsOutputsService pipelineInputsOutputsService;
+
+  @Autowired PipelineInputsRepository pipelineInputsRepository;
+  @Autowired PipelineOutputsRepository pipelineOutputsRepository;
+
+  @Autowired PipelineRunsRepository pipelineRunsRepository;
+
+  @MockBean private GcsService mockGcsService;
+
+  private final UUID testJobId = TestUtils.TEST_NEW_UUID;
+
+  @Test
+  void extractPipelineOutputsFromEntity() {
+    // test that the method correctly extracts the outputs from the entity
+    List<PipelineOutputDefinition> outputDefinitions =
+        TestUtils.TEST_PIPELINE_OUTPUTS_DEFINITION_LIST;
+    Entity entity = new Entity();
+    entity.setAttributes(
+        Map.of("output_name", "gs://bucket/file1", "testNonOutputKey", "doesn't matter"));
+
+    Map<String, String> extractedOutputs =
+        pipelineInputsOutputsService.extractPipelineOutputsFromEntity(outputDefinitions, entity);
+
+    assertEquals(1, extractedOutputs.size());
+    // the meethod should also have converted the wdlVariableName key to the camelCase outputName
+    // key
+    assertEquals("gs://bucket/file1", extractedOutputs.get("outputName"));
+  }
+
+  @Test
+  void extractPipelineOutputsFromEntityMissingOutput() {
+    // test that the method correctly throws an error if an output is missing
+    List<PipelineOutputDefinition> outputDefinitions =
+        TestUtils.TEST_PIPELINE_OUTPUTS_DEFINITION_LIST;
+    Entity entity = new Entity();
+    entity.setAttributes(Map.of("testNonOutputKey", "doesn't matter"));
+
+    assertThrows(
+        InternalServerErrorException.class,
+        () ->
+            pipelineInputsOutputsService.extractPipelineOutputsFromEntity(
+                outputDefinitions, entity));
+  }
+
+  @Test
+  void extractPipelineOutputsFromEntityEmptyOutput() {
+    // test that the method correctly throws an error if an output is empty
+    List<PipelineOutputDefinition> outputDefinitions =
+        TestUtils.TEST_PIPELINE_OUTPUTS_DEFINITION_LIST;
+    Entity entity = new Entity();
+    entity.setAttributes(Map.of("outputName", ""));
+
+    assertThrows(
+        InternalServerErrorException.class,
+        () ->
+            pipelineInputsOutputsService.extractPipelineOutputsFromEntity(
+                outputDefinitions, entity));
+  }
+
+  @Test
+  void formatPipelineRunOutputs() throws MalformedURLException {
+    PipelineRun pipelineRun = TestUtils.createNewPipelineRunWithJobId(testJobId);
+    pipelineRunsRepository.save(pipelineRun);
+
+    PipelineOutput pipelineOutput = new PipelineOutput();
+    pipelineOutput.setJobId(pipelineRun.getId());
+    pipelineOutput.setOutputs(
+        pipelineInputsOutputsService.mapToString(TestUtils.TEST_PIPELINE_OUTPUTS));
+    pipelineOutputsRepository.save(pipelineOutput);
+
+    URL fakeUrl = new URL("https://storage.googleapis.com/signed-url-stuff");
+    // mock GCS service
+    when(mockGcsService.generateGetObjectSignedUrl(
+            eq(pipelineRun.getWorkspaceGoogleProject()),
+            eq(pipelineRun.getWorkspaceStorageContainerName()),
+            anyString()))
+        .thenReturn(fakeUrl);
+
+    ApiPipelineRunOutputs apiPipelineRunOutputs =
+        pipelineInputsOutputsService.formatPipelineRunOutputs(pipelineRun);
+
+    assertEquals(fakeUrl.toString(), apiPipelineRunOutputs.get("testFileOutputKey"));
+  }
+}

--- a/service/src/test/java/bio/terra/pipelines/service/PipelineRunsServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/PipelineRunsServiceTest.java
@@ -545,7 +545,7 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
 
     PipelineOutput pipelineOutput =
         pipelineOutputsRepository.findPipelineOutputsByJobId(pipelineRun.getId());
-    Map<String, String> extractedOutput =
+    Map<String, Object> extractedOutput =
         pipelineInputsOutputsService.stringToMap(pipelineOutput.getOutputs());
 
     for (Map.Entry<String, String> entry : TestUtils.TEST_PIPELINE_OUTPUTS.entrySet()) {

--- a/service/src/test/java/bio/terra/pipelines/service/PipelineRunsServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/PipelineRunsServiceTest.java
@@ -1,5 +1,8 @@
 package bio.terra.pipelines.service;
 
+import static bio.terra.pipelines.testutils.TestUtils.createNewPipelineRunWithJobId;
+import static bio.terra.pipelines.testutils.TestUtils.createNewPipelineRunWithJobIdAndUser;
+import static bio.terra.pipelines.testutils.TestUtils.createTestPipelineWithId;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -72,28 +75,6 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
 
   private SimpleMeterRegistry meterRegistry;
 
-  private Pipeline createTestPipelineWithId() {
-    Pipeline pipeline =
-        new Pipeline(
-            TestUtils.TEST_PIPELINE_1.getName(),
-            TestUtils.TEST_PIPELINE_1.getVersion(),
-            TestUtils.TEST_PIPELINE_1.getDisplayName(),
-            TestUtils.TEST_PIPELINE_1.getDescription(),
-            TestUtils.TEST_PIPELINE_1.getPipelineType(),
-            TestUtils.TEST_PIPELINE_1.getWdlUrl(),
-            TestUtils.TEST_PIPELINE_1.getWdlMethodName(),
-            TestUtils.TEST_PIPELINE_1.getWdlMethodVersion(),
-            TestUtils.TEST_PIPELINE_1.getWorkspaceId(),
-            TestUtils.TEST_PIPELINE_1.getWorkspaceBillingProject(),
-            TestUtils.TEST_PIPELINE_1.getWorkspaceName(),
-            TestUtils.TEST_PIPELINE_1.getWorkspaceStorageContainerName(),
-            TestUtils.TEST_PIPELINE_1.getWorkspaceGoogleProject(),
-            TestUtils.TEST_PIPELINE_1.getPipelineInputDefinitions(),
-            TestUtils.TEST_PIPELINE_1.getPipelineOutputDefinitions());
-    pipeline.setId(3L);
-    return pipeline;
-  }
-
   @BeforeEach
   void initMocks() {
     // stairway submit method returns a good flightId
@@ -163,13 +144,13 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
   void writeRunToDbDuplicateRun() {
     // try to save a run with the same job id two times, the second time it should throw duplicate
     // exception error
-    PipelineRun newPipelineRun = TestUtils.createNewPipelineRunWithJobId(testJobId);
+    PipelineRun newPipelineRun = createNewPipelineRunWithJobId(testJobId);
 
     PipelineRun savedJobFirst =
         pipelineRunsService.writePipelineRunToDbThrowsDuplicateException(newPipelineRun);
     assertNotNull(savedJobFirst);
 
-    PipelineRun newPipelineRunSameId = TestUtils.createNewPipelineRunWithJobId(testJobId);
+    PipelineRun newPipelineRunSameId = createNewPipelineRunWithJobId(testJobId);
     assertThrows(
         DuplicateObjectException.class,
         () ->
@@ -183,7 +164,7 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
     assertEquals(1, pipelineRuns.size());
 
     // insert another row and verify that it shows up
-    PipelineRun newPipelineRun = TestUtils.createNewPipelineRunWithJobId(testJobId);
+    PipelineRun newPipelineRun = createNewPipelineRunWithJobId(testJobId);
 
     pipelineRunsRepository.save(newPipelineRun);
     pipelineRuns = pipelineRunsRepository.findAllByUserId(testUserId);
@@ -199,7 +180,7 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
     // insert row for second user and verify that it shows up
     String testUserId2 = TestUtils.TEST_USER_ID_2;
     PipelineRun newPipelineRun =
-        TestUtils.createNewPipelineRunWithJobIdAndUser(UUID.randomUUID(), testUserId2);
+        createNewPipelineRunWithJobIdAndUser(UUID.randomUUID(), testUserId2);
     pipelineRunsRepository.save(newPipelineRun);
 
     // Verify that the old userid still show only 1 record
@@ -534,7 +515,7 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
 
   @Test
   void markPipelineRunSuccess() {
-    PipelineRun pipelineRun = TestUtils.createNewPipelineRunWithJobId(testJobId);
+    PipelineRun pipelineRun = createNewPipelineRunWithJobId(testJobId);
     pipelineRunsRepository.save(pipelineRun);
 
     PipelineRun updatedPipelineRun =
@@ -576,11 +557,11 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
   @Test
   void findPageResultsResultsUseNextPage() {
     // add 3 new jobs so 4 total exist in database
-    PipelineRun pipelineRun = TestUtils.createNewPipelineRunWithJobId(testJobId);
+    PipelineRun pipelineRun = createNewPipelineRunWithJobId(testJobId);
     pipelineRunsRepository.save(pipelineRun);
-    pipelineRun = TestUtils.createNewPipelineRunWithJobId(UUID.randomUUID());
+    pipelineRun = createNewPipelineRunWithJobId(UUID.randomUUID());
     pipelineRunsRepository.save(pipelineRun);
-    pipelineRun = TestUtils.createNewPipelineRunWithJobId(UUID.randomUUID());
+    pipelineRun = createNewPipelineRunWithJobId(UUID.randomUUID());
     pipelineRunsRepository.save(pipelineRun);
 
     // query for first (default) page with page size 2 so there is a next page token that exists

--- a/service/src/test/java/bio/terra/pipelines/stairway/imputation/steps/PrepareImputationInputsStepTest.java
+++ b/service/src/test/java/bio/terra/pipelines/stairway/imputation/steps/PrepareImputationInputsStepTest.java
@@ -91,6 +91,7 @@ class PrepareImputationInputsStepTest extends BaseEmbeddedDbTest {
         TestUtils.CONTROL_WORKSPACE_BILLING_PROJECT,
         TestUtils.CONTROL_WORKSPACE_NAME,
         TestUtils.CONTROL_WORKSPACE_STORAGE_CONTAINER_NAME,
+        TestUtils.GCP_STORAGE_PROTOCOL,
         pipeline.getWdlMethodName(),
         pipeline.getWdlMethodVersion(),
         TestUtils.TEST_RESULT_URL);
@@ -151,17 +152,18 @@ class PrepareImputationInputsStepTest extends BaseEmbeddedDbTest {
       assertTrue(fullInputs.containsKey(wdlInputName));
     }
 
-    // user-provided file inputs should contain the control workspace's storage url
+    // user-provided file inputs should contain the control workspace storage url
+    String controlWorkspaceStorageContainerUrl =
+        "%s%s"
+            .formatted(
+                TestUtils.GCP_STORAGE_PROTOCOL, TestUtils.CONTROL_WORKSPACE_STORAGE_CONTAINER_NAME);
     for (String wdlInputName :
         userProvidedPipelineInputDefinitions.stream()
             .filter(input -> input.getType().equals(PipelineVariableTypesEnum.FILE))
             .map(PipelineInputDefinition::getWdlVariableName)
             .collect(Collectors.toSet())) {
       assertTrue(
-          fullInputs
-              .get(wdlInputName)
-              .toString()
-              .contains(TestUtils.CONTROL_WORKSPACE_STORAGE_CONTAINER_NAME));
+          fullInputs.get(wdlInputName).toString().startsWith(controlWorkspaceStorageContainerUrl));
     }
 
     // make sure each input in the fullInputs map has a populated value

--- a/service/src/test/java/bio/terra/pipelines/stairway/imputation/steps/gcp/FetchOutputsFromDataTableStepTest.java
+++ b/service/src/test/java/bio/terra/pipelines/stairway/imputation/steps/gcp/FetchOutputsFromDataTableStepTest.java
@@ -10,7 +10,7 @@ import bio.terra.pipelines.dependencies.rawls.RawlsService;
 import bio.terra.pipelines.dependencies.rawls.RawlsServiceApiException;
 import bio.terra.pipelines.dependencies.rawls.RawlsServiceException;
 import bio.terra.pipelines.dependencies.sam.SamService;
-import bio.terra.pipelines.service.PipelineRunsService;
+import bio.terra.pipelines.service.PipelineInputsOutputsService;
 import bio.terra.pipelines.stairway.imputation.RunImputationJobFlightMapKeys;
 import bio.terra.pipelines.testutils.BaseEmbeddedDbTest;
 import bio.terra.pipelines.testutils.StairwayTestUtils;
@@ -30,7 +30,7 @@ class FetchOutputsFromDataTableStepTest extends BaseEmbeddedDbTest {
 
   @Mock RawlsService rawlsService;
   @Mock SamService samService;
-  @Mock PipelineRunsService pipelineRunsService;
+  @Mock PipelineInputsOutputsService pipelineInputsOutputsService;
   @Mock private FlightContext flightContext;
 
   @BeforeEach
@@ -62,12 +62,12 @@ class FetchOutputsFromDataTableStepTest extends BaseEmbeddedDbTest {
         .thenReturn(entity);
     Map<String, String> outputsProcessedFromEntity =
         new HashMap<>(Map.of("outputName", "some/file.vcf.gz"));
-    when(pipelineRunsService.extractPipelineOutputsFromEntity(
+    when(pipelineInputsOutputsService.extractPipelineOutputsFromEntity(
             TestUtils.TEST_PIPELINE_OUTPUTS_DEFINITION_LIST, entity))
         .thenReturn(outputsProcessedFromEntity);
 
     FetchOutputsFromDataTableStep fetchOutputsFromDataTableStep =
-        new FetchOutputsFromDataTableStep(rawlsService, samService, pipelineRunsService);
+        new FetchOutputsFromDataTableStep(rawlsService, samService, pipelineInputsOutputsService);
     StepResult result = fetchOutputsFromDataTableStep.doStep(flightContext);
 
     assertEquals(StepStatus.STEP_RESULT_SUCCESS, result.getStepStatus());
@@ -94,7 +94,7 @@ class FetchOutputsFromDataTableStepTest extends BaseEmbeddedDbTest {
         .thenThrow(new RawlsServiceApiException("Rawls Service Api Exception"));
 
     FetchOutputsFromDataTableStep fetchOutputsFromDataTableStep =
-        new FetchOutputsFromDataTableStep(rawlsService, samService, pipelineRunsService);
+        new FetchOutputsFromDataTableStep(rawlsService, samService, pipelineInputsOutputsService);
     StepResult result = fetchOutputsFromDataTableStep.doStep(flightContext);
 
     assertEquals(StepStatus.STEP_RESULT_FAILURE_RETRY, result.getStepStatus());
@@ -116,12 +116,12 @@ class FetchOutputsFromDataTableStepTest extends BaseEmbeddedDbTest {
             PipelinesEnum.IMPUTATION_BEAGLE.getValue(),
             TestUtils.TEST_NEW_UUID.toString()))
         .thenReturn(entity);
-    when(pipelineRunsService.extractPipelineOutputsFromEntity(
+    when(pipelineInputsOutputsService.extractPipelineOutputsFromEntity(
             TestUtils.TEST_PIPELINE_OUTPUTS_DEFINITION_LIST, entity))
         .thenThrow(new InternalServerErrorException("Internal Server Error"));
 
     FetchOutputsFromDataTableStep fetchOutputsFromDataTableStep =
-        new FetchOutputsFromDataTableStep(rawlsService, samService, pipelineRunsService);
+        new FetchOutputsFromDataTableStep(rawlsService, samService, pipelineInputsOutputsService);
     assertThrows(
         InternalServerErrorException.class,
         () -> fetchOutputsFromDataTableStep.doStep(flightContext));
@@ -130,7 +130,7 @@ class FetchOutputsFromDataTableStepTest extends BaseEmbeddedDbTest {
   @Test
   void undoStepSuccess() {
     FetchOutputsFromDataTableStep fetchOutputsFromDataTableStep =
-        new FetchOutputsFromDataTableStep(rawlsService, samService, pipelineRunsService);
+        new FetchOutputsFromDataTableStep(rawlsService, samService, pipelineInputsOutputsService);
     StepResult result = fetchOutputsFromDataTableStep.undoStep(flightContext);
 
     assertEquals(StepStatus.STEP_RESULT_SUCCESS, result.getStepStatus());

--- a/service/src/test/java/bio/terra/pipelines/testutils/StairwayTestUtils.java
+++ b/service/src/test/java/bio/terra/pipelines/testutils/StairwayTestUtils.java
@@ -43,6 +43,7 @@ public class StairwayTestUtils {
           TestUtils.CONTROL_WORKSPACE_BILLING_PROJECT,
           TestUtils.CONTROL_WORKSPACE_NAME,
           TestUtils.CONTROL_WORKSPACE_STORAGE_CONTAINER_NAME,
+          TestUtils.GCP_STORAGE_PROTOCOL,
           TestUtils.TEST_WDL_METHOD_NAME_1,
           TestUtils.TEST_WDL_METHOD_VERSION_1,
           TestUtils.TEST_RESULT_URL);
@@ -143,6 +144,7 @@ public class StairwayTestUtils {
       String controlWorkspaceBillingProject,
       String controlWorkspaceName,
       String controlWorkspaceStorageContainerUrl,
+      String controlWorkspaceStorageContainerProtocol,
       String wdlMethodName,
       String wdlMethodVersion,
       String resultPath) {
@@ -159,6 +161,7 @@ public class StairwayTestUtils {
         controlWorkspaceBillingProject,
         controlWorkspaceName,
         controlWorkspaceStorageContainerUrl,
+        controlWorkspaceStorageContainerProtocol,
         wdlMethodName,
         wdlMethodVersion,
         resultPath);
@@ -176,6 +179,7 @@ public class StairwayTestUtils {
       String controlWorkspaceProject,
       String controlWorkspaceName,
       String controlWorkspaceStorageContainerUrl,
+      String controlWorkspaceStorageContainerProtocol,
       String wdlMethodName,
       String wdlMethodVersion,
       String resultPath) {
@@ -197,6 +201,9 @@ public class StairwayTestUtils {
     inputParameters.put(
         RunImputationJobFlightMapKeys.CONTROL_WORKSPACE_STORAGE_CONTAINER_NAME,
         controlWorkspaceStorageContainerUrl);
+    inputParameters.put(
+        RunImputationJobFlightMapKeys.CONTROL_WORKSPACE_STORAGE_CONTAINER_PROTOCOL,
+        controlWorkspaceStorageContainerProtocol);
     inputParameters.put(RunImputationJobFlightMapKeys.WDL_METHOD_NAME, wdlMethodName);
     inputParameters.put(RunImputationJobFlightMapKeys.WDL_METHOD_VERSION, wdlMethodVersion);
 
@@ -216,6 +223,7 @@ public class StairwayTestUtils {
         TestUtils.CONTROL_WORKSPACE_BILLING_PROJECT,
         TestUtils.CONTROL_WORKSPACE_NAME,
         TestUtils.CONTROL_WORKSPACE_STORAGE_CONTAINER_NAME,
+        TestUtils.GCP_STORAGE_PROTOCOL,
         TestUtils.TEST_WDL_METHOD_NAME_1,
         TestUtils.TEST_WDL_METHOD_VERSION_1,
         TestUtils.TEST_RESULT_URL);

--- a/service/src/test/java/bio/terra/pipelines/testutils/TestUtils.java
+++ b/service/src/test/java/bio/terra/pipelines/testutils/TestUtils.java
@@ -44,6 +44,8 @@ public class TestUtils {
   public static final String CONTROL_WORKSPACE_NAME = "testTerraWorkspaceName";
   public static final String CONTROL_WORKSPACE_STORAGE_CONTAINER_NAME =
       "fc-secure-%s".formatted(CONTROL_WORKSPACE_ID);
+  public static final String AZURE_STORAGE_PROTOCOL = "https://";
+  public static final String GCP_STORAGE_PROTOCOL = "gs://";
   public static final String CONTROL_WORKSPACE_GOOGLE_PROJECT = "testGoogleProject";
   public static final Map<String, String> TEST_PIPELINE_OUTPUTS =
       new HashMap(

--- a/service/src/test/java/bio/terra/pipelines/testutils/TestUtils.java
+++ b/service/src/test/java/bio/terra/pipelines/testutils/TestUtils.java
@@ -1,10 +1,12 @@
 package bio.terra.pipelines.testutils;
 
+import bio.terra.pipelines.common.utils.CommonPipelineRunStatusEnum;
 import bio.terra.pipelines.common.utils.PipelineVariableTypesEnum;
 import bio.terra.pipelines.common.utils.PipelinesEnum;
 import bio.terra.pipelines.db.entities.Pipeline;
 import bio.terra.pipelines.db.entities.PipelineInputDefinition;
 import bio.terra.pipelines.db.entities.PipelineOutputDefinition;
+import bio.terra.pipelines.db.entities.PipelineRun;
 import bio.terra.rawls.model.MethodConfiguration;
 import bio.terra.rawls.model.MethodRepoMethod;
 import java.util.*;
@@ -183,4 +185,21 @@ public class TestUtils {
                   .methodVersion("1.2.3")
                   .methodUri("this/is/a/uri/with/a/version/1.2.3"))
           .rootEntityType("imputation_beagle");
+
+  public static PipelineRun createNewPipelineRunWithJobId(UUID jobId) {
+    return createNewPipelineRunWithJobIdAndUser(jobId, TEST_USER_ID_1);
+  }
+
+  public static PipelineRun createNewPipelineRunWithJobIdAndUser(UUID jobId, String userId) {
+    return new PipelineRun(
+        jobId,
+        userId,
+        TEST_PIPELINE_ID_1,
+        TEST_WDL_METHOD_VERSION_1,
+        CONTROL_WORKSPACE_BILLING_PROJECT,
+        CONTROL_WORKSPACE_NAME,
+        CONTROL_WORKSPACE_STORAGE_CONTAINER_NAME,
+        CONTROL_WORKSPACE_GOOGLE_PROJECT,
+        CommonPipelineRunStatusEnum.PREPARING);
+  }
 }

--- a/service/src/test/java/bio/terra/pipelines/testutils/TestUtils.java
+++ b/service/src/test/java/bio/terra/pipelines/testutils/TestUtils.java
@@ -154,6 +154,28 @@ public class TestUtils {
           TEST_PIPELINE_INPUTS_DEFINITION_LIST,
           TEST_PIPELINE_OUTPUTS_DEFINITION_LIST);
 
+  public static Pipeline createTestPipelineWithId() {
+    Pipeline pipeline =
+        new Pipeline(
+            TestUtils.TEST_PIPELINE_1.getName(),
+            TestUtils.TEST_PIPELINE_1.getVersion(),
+            TestUtils.TEST_PIPELINE_1.getDisplayName(),
+            TestUtils.TEST_PIPELINE_1.getDescription(),
+            TestUtils.TEST_PIPELINE_1.getPipelineType(),
+            TestUtils.TEST_PIPELINE_1.getWdlUrl(),
+            TestUtils.TEST_PIPELINE_1.getWdlMethodName(),
+            TestUtils.TEST_PIPELINE_1.getWdlMethodVersion(),
+            TestUtils.TEST_PIPELINE_1.getWorkspaceId(),
+            TestUtils.TEST_PIPELINE_1.getWorkspaceBillingProject(),
+            TestUtils.TEST_PIPELINE_1.getWorkspaceName(),
+            TestUtils.TEST_PIPELINE_1.getWorkspaceStorageContainerName(),
+            TestUtils.TEST_PIPELINE_1.getWorkspaceGoogleProject(),
+            TestUtils.TEST_PIPELINE_1.getPipelineInputDefinitions(),
+            TestUtils.TEST_PIPELINE_1.getPipelineOutputDefinitions());
+    pipeline.setId(3L);
+    return pipeline;
+  }
+
   public static final String TEST_USER_ID_1 =
       "testUser"; // this matches the job pre-populated in the db for tests
   public static final String TEST_USER_ID_2 = "testUser2";


### PR DESCRIPTION
### Description 

The previous conversion from storageContainerUrl to storageContainerName caused a problem in PreparePipelineInputsStep since it expects that value to be the full Url. Here we add a value to the flight working map to specify the protocol to append to the storageContainerName.

Also did a refactor of a bunch of methods related to input and output formatting and generation into a new PipelineInputsOutputsService.

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-332