### PR TITLE
fix ref panel prefix

### DIFF
--- a/service/src/main/resources/db/changelog.xml
+++ b/service/src/main/resources/db/changelog.xml
@@ -28,6 +28,7 @@
   <include file="changesets/20240906_add_wdl_version_to_pipeline_run.yaml" relativeToChangelogFile="true"/>
   <include file="changesets/20240911_remove_isSuccess.yaml" relativeToChangelogFile="true"/>
   <include file="changesets/20240923_update_input_defs_bucket_paths.yaml" relativeToChangelogFile="true"/>
+  <include file="changesets/20240925_update_ref_panel_prefix_input.yaml" relativeToChangelogFile="true"/>
 
   <include file="changesets/20240412-testdata.yaml" relativeToChangelogFile="true"/>
 

--- a/service/src/main/resources/db/changesets/20240925_update_ref_panel_prefix_input.yaml
+++ b/service/src/main/resources/db/changesets/20240925_update_ref_panel_prefix_input.yaml
@@ -1,0 +1,14 @@
+# Update ref panel input definition default_value
+databaseChangeLog:
+  - changeSet:
+      id: Update ref panel input definition default_value
+      author: mma
+      changes:
+        # update referencePanelPathPrefix default_value from /hg38/ref_panels/1000G_HGDP_no_singletons/hgdp.tgp.gwaspy.merged.merged.AN_added.bcf.ac2
+        - update:
+            tableName: pipeline_input_definitions
+            where: name='referencePanelPathPrefix' AND pipeline_id=(SELECT id FROM pipelines WHERE name='imputation_beagle')
+            columns:
+              - column:
+                  name: default_value
+                  value: "/hg38/ref_panels/1000G_HGDP_no_singletons/hgdp.tgp.gwaspy.AN_added.bcf.ac2"


### PR DESCRIPTION
### Description 

We're looking for the wrong files. Running the pipeline gave errors like this: 
`FileNotFoundException: gs://fc-secure-10efd4d7-392a-4e9e-89ea-d6629fbb06cc/hg38/ref_panels/1000G_HGDP_no_singletons/hgdp.tgp.gwaspy.merged.merged.AN_added.bcf.ac2.chr1.bed`

Whereas the files are actually located at `gs://fc-secure-10efd4d7-392a-4e9e-89ea-d6629fbb06cc/hg38/ref_panels/1000G_HGDP_no_singletons/hgdp.tgp.gwaspy.AN_added.bcf.ac2.chr1.bed`

i.e. we need the ref panel prefix default_value to be updated from `/hg38/ref_panels/1000G_HGDP_no_singletons/hgdp.tgp.gwaspy.merged.merged.AN_added.bcf.ac2` to `/hg38/ref_panels/1000G_HGDP_no_singletons/hgdp.tgp.gwaspy.AN_added.bcf.ac2`

### Jira Ticket
none