### PR TITLE
TSPS-343 increase disk for comparevcfs task 

### DIFF
--- a/pipelines/imputation/testing/CompareVcfs.wdl
+++ b/pipelines/imputation/testing/CompareVcfs.wdl
@@ -21,7 +21,7 @@ task CompareVcfs {
         File file2
         String patternForLinesToExcludeFromComparison
     }
-    Int disk_size_gb = ceil(3 * size(file1, "GiB")) + ceil(3 * size(file2, "GiB")) + 50
+    Int disk_size_gb = ceil(10 * size(file1, "GiB")) + ceil(10 * size(file2, "GiB")) + 50
     command {
         set -eo pipefail
 


### PR DESCRIPTION
### Description 

When trying to verify if the results were the same between the 5MB and 2MB overlap values, the task failed due to disk.  This  allowed it to succeed

failed - https://bvdp-saturn-dev.appspot.com/#workspaces/teaspoons-imputation-dev/teaspoons_imputation_dev_control_workspace_20240726/job_history/b53431c5-4c52-4efe-bb2d-68b266fd565b

succeeded - https://bvdp-saturn-dev.appspot.com/#workspaces/teaspoons-imputation-dev/teaspoons_imputation_dev_control_workspace_20240726/job_history/90342454-2886-4d9e-9669-333df0c022d4

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-343