### PR TITLE
TSPS-342 Update reheader seq dict wdl for better efficiency

### DIFF
--- a/pipelines/imputation/scientificValidation/UpdateVcfDictionaryHeader.wdl
+++ b/pipelines/imputation/scientificValidation/UpdateVcfDictionaryHeader.wdl
@@ -52,7 +52,7 @@ task UpdateVcfDictionaryHeader {
         UpdateVCFSequenceDictionary \
         -O new_header.vcf \
         --source-dictionary ~{ref_dict} \
-        --replace -V input.vcf.gz \
+        --replace -V old_header.vcf \
         --disable-sequence-dictionary-validation
 
         bcftools reheader -h new_header.vcf -o ~{basename}.vcf.gz input.vcf.gz

--- a/pipelines/imputation/scientificValidation/UpdateVcfDictionaryHeader.wdl
+++ b/pipelines/imputation/scientificValidation/UpdateVcfDictionaryHeader.wdl
@@ -45,7 +45,7 @@ task UpdateVcfDictionaryHeader {
         ln -sf ~{vcf_index} input.vcf.gz.tbi
 
         bcftools view -h --no-version input.vcf.gz > old_header.vcf
-        java -jar /picard.jar UpdateVcfSequenceDictionary -I old_header.vcf --SD ~{ref_dict} -O new_header.vcf
+#        java -jar /picard.jar UpdateVcfSequenceDictionary -I old_header.vcf --SD ~{ref_dict} -O new_header.vcf
 
         ## update the header
         gatk --java-options "-Xms~{command_mem}m -Xmx~{max_heap}m" \

--- a/pipelines/imputation/scientificValidation/UpdateVcfDictionaryHeader.wdl
+++ b/pipelines/imputation/scientificValidation/UpdateVcfDictionaryHeader.wdl
@@ -52,9 +52,8 @@ task UpdateVcfDictionaryHeader {
         UpdateVCFSequenceDictionary \
         -O new_header.vcf \
         --source-dictionary ~{ref_dict} \
-        -I old_header.vcf
-#        --replace -V input.vcf.gz \
-#        --disable-sequence-dictionary-validation
+        --replace -V input.vcf.gz \
+        --disable-sequence-dictionary-validation
 
         bcftools reheader -h new_header.vcf -o ~{basename}.vcf.gz input.vcf.gz
         tabix ~{basename}.vcf.gz

--- a/pipelines/imputation/scientificValidation/UpdateVcfDictionaryHeader.wdl
+++ b/pipelines/imputation/scientificValidation/UpdateVcfDictionaryHeader.wdl
@@ -44,10 +44,11 @@ task UpdateVcfDictionaryHeader {
         ln -sf ~{vcf} input.vcf.gz
         ln -sf ~{vcf_index} input.vcf.gz.tbi
 
+        # extract only the original header into old_header.vcf
         bcftools view -h --no-version input.vcf.gz > old_header.vcf
 #        java -jar /picard.jar UpdateVcfSequenceDictionary -I old_header.vcf --SD ~{ref_dict} -O new_header.vcf
 
-        ## update the header
+        # update the header in old_header.vcf, producing output new_header.vcf
         gatk --java-options "-Xms~{command_mem}m -Xmx~{max_heap}m" \
         UpdateVCFSequenceDictionary \
         -O new_header.vcf \
@@ -55,7 +56,10 @@ task UpdateVcfDictionaryHeader {
         --replace -V old_header.vcf \
         --disable-sequence-dictionary-validation
 
+        # reheader the input VCF using new_header.vcf
         bcftools reheader -h new_header.vcf -o ~{basename}.vcf.gz input.vcf.gz
+
+        # create index
         tabix ~{basename}.vcf.gz
     >>>
     runtime {

--- a/pipelines/imputation/scientificValidation/UpdateVcfDictionaryHeader.wdl
+++ b/pipelines/imputation/scientificValidation/UpdateVcfDictionaryHeader.wdl
@@ -44,10 +44,10 @@ task UpdateVcfDictionaryHeader {
         ln -sf ~{vcf} input.vcf.gz
         ln -sf ~{vcf_index} input.vcf.gz.tbi
 
-        echo "Extracting original header from VCF into old_header.vcf"
+        echo "$(date) Extracting original header from VCF into old_header.vcf"
         bcftools view -h --no-version input.vcf.gz > old_header.vcf
 
-        echo "Updating header from old_header.vcf to produce header-only VCF new_header.vcf"
+        echo "$(date) Updating header from old_header.vcf to produce header-only VCF new_header.vcf"
         gatk --java-options "-Xms~{command_mem}m -Xmx~{max_heap}m" \
         UpdateVCFSequenceDictionary \
         -O new_header.vcf \
@@ -55,10 +55,10 @@ task UpdateVcfDictionaryHeader {
         --replace -V old_header.vcf \
         --disable-sequence-dictionary-validation
 
-        echo "Reheadering input VCF with updated header new_header.vcf"
+        echo "$(date) Reheadering input VCF with updated header new_header.vcf"
         bcftools reheader -h new_header.vcf -o ~{basename}.vcf.gz input.vcf.gz
 
-        echo "Creating index for reheadered VCF"
+        echo "$(date) Creating index for reheadered VCF"
         bcftools index -t ~{basename}.vcf.gz
     >>>
     runtime {

--- a/pipelines/imputation/scientificValidation/UpdateVcfDictionaryHeader.wdl
+++ b/pipelines/imputation/scientificValidation/UpdateVcfDictionaryHeader.wdl
@@ -59,7 +59,7 @@ task UpdateVcfDictionaryHeader {
         bcftools reheader -h new_header.vcf -o ~{basename}.vcf.gz input.vcf.gz
 
         echo "Creating index for reheadered VCF"
-        tabix ~{basename}.vcf.gz
+        bcftools index -t ~{basename}.vcf.gz
     >>>
     runtime {
         docker: gatk_docker

--- a/pipelines/imputation/scientificValidation/UpdateVcfDictionaryHeader.wdl
+++ b/pipelines/imputation/scientificValidation/UpdateVcfDictionaryHeader.wdl
@@ -44,11 +44,10 @@ task UpdateVcfDictionaryHeader {
         ln -sf ~{vcf} input.vcf.gz
         ln -sf ~{vcf_index} input.vcf.gz.tbi
 
-        # extract only the original header into old_header.vcf
+        echo "Extracting original header from VCF into old_header.vcf"
         bcftools view -h --no-version input.vcf.gz > old_header.vcf
-#        java -jar /picard.jar UpdateVcfSequenceDictionary -I old_header.vcf --SD ~{ref_dict} -O new_header.vcf
 
-        # update the header in old_header.vcf, producing output new_header.vcf
+        echo "Updating header from old_header.vcf to produce header-only VCF new_header.vcf"
         gatk --java-options "-Xms~{command_mem}m -Xmx~{max_heap}m" \
         UpdateVCFSequenceDictionary \
         -O new_header.vcf \
@@ -56,10 +55,10 @@ task UpdateVcfDictionaryHeader {
         --replace -V old_header.vcf \
         --disable-sequence-dictionary-validation
 
-        # reheader the input VCF using new_header.vcf
+        echo "Reheadering input VCF with updated header new_header.vcf"
         bcftools reheader -h new_header.vcf -o ~{basename}.vcf.gz input.vcf.gz
 
-        # create index
+        echo "Creating index for reheadered VCF"
         tabix ~{basename}.vcf.gz
     >>>
     runtime {


### PR DESCRIPTION
### Description 

Make reheadering of VCFs with correct sequence dictionary more efficient, since we'll need to run it on the AoU+AnVIL reference panel VCFs and that will take a long time.

Changes:
- extract the header, fix it, then reheader the original, rather than fixing it in the original in one step
- use bcftools to create index instead of tabix
- add echos with dates for better progress tracking 

Some learnings about timing:
- the vast majority of this task is spent creating the index
- next longest step is localization of the files (1 hour for chr20 vcf)

Note we ran this with a monitoring script and found that the task was not close to using all the memory available (memory utilization did not exceed 11%), so we don't think an optimization there would help. We also weren't pegged on iops (didn't exceed 40 MiB/s, and the max on the machine is >200 MiB/s). 

Evaluation:
Before these changes, this wdl run on the AoU-only chr20 vcf took 29+ hours, cost $2.37.
After these changes, the same input took 23 hours (20% improvement), cost $1.87 (21% improvement).

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-342