### PR TITLE
TSPS-367 Use tag for builds

### DIFF
--- a/.github/workflows/release-python-client.yml
+++ b/.github/workflows/release-python-client.yml
@@ -12,19 +12,28 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       new-tag: ${{ steps.generate-params.outputs.new-tag }}
+      checkout-ref: ${{ steps.generate-params.outputs.checkout-ref }}
     steps:
       - name: Get inputs or use defaults
         id: generate-params
         run: |
           if [ -z ${{ inputs.new-tag }} ]; then
+            # This workflow was called on a PR, without a new-tag input
             echo "No new tag provided; will run through tasks, but ultimately will not overwrite PyPi version '0.0.0'"
             echo "new-tag='0.0.0'" >> $GITHUB_OUTPUT
+          
+            echo "Will use checkout-ref: $GITHUB_REF"
+            echo "checkout-ref=$GITHUB_REF" >> $GITHUB_OUTPUT
           else
+            # This workflow was called on a workflow_dispatch from tag-publish, with a new-tag input
             echo "New tag provided: ${{ inputs.new-tag }}"
             echo "new-tag=${{ inputs.new-tag }}" >> $GITHUB_OUTPUT
+          
+            echo "Will use checkout-ref: ${{ inputs.new-tag }}"
+            echo "checkout-ref=${{ inputs.new-tag }}" >> $GITHUB_OUTPUT
           fi
 
-  build-n-publish:
+  build-and-publish:
     name: Build and publish Python client to PyPI
     needs: [ params-gen ]
     runs-on: ubuntu-latest
@@ -36,7 +45,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          ref: ${{ needs.params-gen.outputs.checkout-ref }}
 
       - name: Set up Python 3.12
         uses: actions/setup-python@v5

--- a/.github/workflows/tag-publish.yml
+++ b/.github/workflows/tag-publish.yml
@@ -133,7 +133,7 @@ jobs:
       - name: Checkout current code
         uses: actions/checkout@v2
         with:
-          ref: ${{ steps.controls.outputs.checkout-branch }}
+          ref: ${{ needs.tag-job.outputs.tag }}
           token: ${{ secrets.BROADBOT_TOKEN }}
 
       - name: Cache Gradle packages

--- a/.github/workflows/tag-publish.yml
+++ b/.github/workflows/tag-publish.yml
@@ -26,12 +26,10 @@ on:
     paths-ignore:
       - 'README.md'
       - '.github/**'
-      - 'local-dev/**'
   pull_request:
     paths-ignore:
       - 'README.md'
       - '.github/**'
-      - 'local-dev/**'
   workflow_dispatch:
     inputs:
       bump:


### PR DESCRIPTION
### Description 

Build the jar, docker, and python thin client off of the main branch as tagged by tag-job, rather than the latest main, which could have new commits after the tag was made.

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-367