### PR TITLE
TSPS-367 fix: choose checkout-ref and tags based on github event type

### DIFF
--- a/.github/workflows/release-python-client.yml
+++ b/.github/workflows/release-python-client.yml
@@ -4,35 +4,13 @@ on:
   pull_request:
   workflow_call:
     inputs:
-      new-tag:
+      python-version:
+        required: true
+        type: string
+      checkout-ref:
         required: true
         type: string
 jobs:
-  params-gen:
-    runs-on: ubuntu-latest
-    outputs:
-      new-tag: ${{ steps.generate-params.outputs.new-tag }}
-      checkout-ref: ${{ steps.generate-params.outputs.checkout-ref }}
-    steps:
-      - name: Get inputs or use defaults
-        id: generate-params
-        run: |
-          if [ -z ${{ inputs.new-tag }} ]; then
-            # This workflow was called on a PR, without a new-tag input
-            echo "No new tag provided; will run through tasks, but ultimately will not overwrite PyPi version '0.0.0'"
-            echo "new-tag='0.0.0'" >> $GITHUB_OUTPUT
-          
-            echo "Will use checkout-ref: $GITHUB_REF"
-            echo "checkout-ref=$GITHUB_REF" >> $GITHUB_OUTPUT
-          else
-            # This workflow was called on a workflow_dispatch from tag-publish, with a new-tag input
-            echo "New tag provided: ${{ inputs.new-tag }}"
-            echo "new-tag=${{ inputs.new-tag }}" >> $GITHUB_OUTPUT
-          
-            echo "Will use checkout-ref: ${{ inputs.new-tag }}"
-            echo "checkout-ref=${{ inputs.new-tag }}" >> $GITHUB_OUTPUT
-          fi
-
   build-and-publish:
     name: Build and publish Python client to PyPI
     needs: [ params-gen ]
@@ -45,7 +23,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ needs.params-gen.outputs.checkout-ref }}
+          ref: ${{ github.event.inputs.checkout-ref }}
 
       - name: Set up Python 3.12
         uses: actions/setup-python@v5
@@ -60,12 +38,12 @@ jobs:
 
       - name: Generate Python client
         run: |
-          echo "Generating Python client for version ${{ needs.params-gen.outputs.new-tag }}"
+          echo "Generating Python client for version ${{ github.event.inputs.python-version }}"
           openapi-generator-cli generate \
           -i common/openapi.yml \
           -g python \
           -o teaspoons-client \
-          --additional-properties=projectName=terra-scientific-pipelines-service-api-client,packageName=teaspoons_client,packageVersion=${{ needs.params-gen.outputs.new-tag }},httpUserAgent=terra-scientific-pipelines-service-api-client/${{ needs.params-gen.outputs.new-tag }}/python
+          --additional-properties=projectName=terra-scientific-pipelines-service-api-client,packageName=teaspoons_client,packageVersion=${{ github.event.inputs.python-version }},httpUserAgent=terra-scientific-pipelines-service-api-client/${{ github.event.inputs.python-version }}/python
 
       - name: Install pypa/build
         working-directory: ./teaspoons-client

--- a/.github/workflows/tag-publish.yml
+++ b/.github/workflows/tag-publish.yml
@@ -71,6 +71,8 @@ jobs:
     if: needs.bump-check.outputs.is-bump == 'no'
     outputs:
       tag: ${{ steps.tag.outputs.new_tag }}
+      python-version: ${{ steps.generate-params.outputs.python-version }}
+      checkout-ref: ${{ steps.generate-params.outputs.checkout-ref }}
     steps:
       - name: Set part of semantic version to bump
         id: controls
@@ -106,13 +108,35 @@ jobs:
           VERSION_LINE_MATCH: "^gradle.ext.releaseVersion\\s*=\\s*\".*\""
           VERSION_SUFFIX: SNAPSHOT
 
+      - name: Generate tag for Java resources, version for Python, and checkout-ref to use in subsequent jobs
+        id: generate-params
+        run: |
+          if [ ${{ github.event_name != 'pull_request' }} ]; then
+            # This workflow was called on a push to main or manually, i.e. a PR merge / new release
+            echo "New tag provided: ${{ inputs.new-tag }}"
+            echo "Will use python version: ${{ inputs.new-tag }}"
+            echo "python-version=${{ inputs.new-tag }}" >> $GITHUB_OUTPUT
+
+            echo "Will use checkout-ref: ${{ inputs.new-tag }}"
+            echo "checkout-ref=${{ inputs.new-tag }}" >> $GITHUB_OUTPUT
+          else
+            # This workflow was called on a PR, without a new-tag input
+            echo "New tag provided: ${{ inputs.new-tag }}"
+            echo "Will use python version '0.0.0'. This will not overwrite the existing PyPi version '0.0.0'"
+            echo "python-version='0.0.0'" >> $GITHUB_OUTPUT
+
+            echo "Will use checkout-ref: $GITHUB_REF"
+            echo "checkout-ref=$GITHUB_REF" >> $GITHUB_OUTPUT
+          fi
+
    # Publish Python client to PyPI
   python-client-job:
     needs: [ tag-job ]
     uses: ./.github/workflows/release-python-client.yml
     if: ${{ github.event_name != 'pull_request' }}
     with:
-      new-tag: ${{ needs.tag-job.outputs.tag }}
+      python-version: ${{ needs.tag-job.outputs.python-version }}
+      checkout-ref: ${{ needs.tag-job.outputs.checkout-ref }}
 
   # Publish the Java client to Artifactory and deploy the docker image to GCR
   publish-docker-deploy:
@@ -131,7 +155,7 @@ jobs:
       - name: Checkout current code
         uses: actions/checkout@v2
         with:
-          ref: ${{ needs.tag-job.outputs.tag }}
+          ref: ${{ needs.tag-job.outputs.checkout-ref }}
           token: ${{ secrets.BROADBOT_TOKEN }}
 
       - name: Cache Gradle packages


### PR DESCRIPTION
### Description 

This is a fix to resolve the error we ran into [here](https://github.com/DataBiosphere/terra-scientific-pipelines-service/actions/runs/11690111192/job/32554380033?pr=153), where a run of Bump, Tag, Publish, Deploy on a PR failed because it tried to access a checkout-ref of a tag that was not actually created.

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-367