### PR TITLE
TSPS-368 Update imputation_beagle to array_imputation

### DIFF
--- a/service/src/main/java/bio/terra/pipelines/common/utils/PipelinesEnum.java
+++ b/service/src/main/java/bio/terra/pipelines/common/utils/PipelinesEnum.java
@@ -1,7 +1,7 @@
 package bio.terra.pipelines.common.utils;
 
 public enum PipelinesEnum {
-  IMPUTATION_BEAGLE("imputation_beagle");
+  ARRAY_IMPUTATION("array_imputation");
 
   private final String value;
 

--- a/service/src/main/java/bio/terra/pipelines/service/PipelineRunsService.java
+++ b/service/src/main/java/bio/terra/pipelines/service/PipelineRunsService.java
@@ -136,7 +136,7 @@ public class PipelineRunsService {
 
     Class<? extends Flight> flightClass;
     switch (pipelineName) {
-      case IMPUTATION_BEAGLE:
+      case ARRAY_IMPUTATION:
         flightClass = RunImputationGcpJobFlight.class;
         break;
       default:

--- a/service/src/main/resources/db/changelog.xml
+++ b/service/src/main/resources/db/changelog.xml
@@ -31,6 +31,7 @@
   <include file="changesets/20240925_update_ref_panel_prefix_input.yaml" relativeToChangelogFile="true"/>
   <include file="changesets/20241030_add_pipeline_quotas.yaml" relativeToChangelogFile="true"/>
   <include file="changesets/20241103_add_user_quotas.yaml" relativeToChangelogFile="true"/>
+  <include file="changesets/20241106_array_imputation_rename.yaml" relativeToChangelogFile="true"/>
 
   <include file="changesets/20240412-testdata.yaml" relativeToChangelogFile="true"/>
 

--- a/service/src/main/resources/db/changesets/20240412-testdata.yaml
+++ b/service/src/main/resources/db/changesets/20240412-testdata.yaml
@@ -14,7 +14,7 @@ databaseChangeLog:
                   value: testUser
               - column:
                   name: pipeline_id
-                  valueComputed: (SELECT id FROM pipelines WHERE name='imputation_beagle')
+                  valueComputed: (SELECT id FROM pipelines WHERE name='array_imputation')
               - column:
                   name: description
                   value: "Test Pipeline Description"

--- a/service/src/main/resources/db/changesets/20241106_array_imputation_rename.yaml
+++ b/service/src/main/resources/db/changesets/20241106_array_imputation_rename.yaml
@@ -1,0 +1,27 @@
+databaseChangeLog:
+  - changeSet:
+      id: change imputation_beagle to array_imputation
+      author: mma
+      changes:
+        # update pipelines table
+        - update:
+            tableName: pipelines
+            where: name='imputation_beagle'
+            columns:
+              - column:
+                  name: name
+                  value: 'array_imputation'
+              - column:
+                  name: display_name
+                  value: 'Array Imputation'
+              - column:
+                  name: description
+                  value: 'Phase and impute genotypes using Beagle 5.4 with the AoU/AnVIL reference panel of 515,579 samples.'
+        # update pipeline_quotas table
+        - update:
+            tableName: pipeline_quotas
+            where: pipeline_name='imputation_beagle'
+            columns:
+              - column:
+                  name: pipeline_name
+                  value: array_imputation

--- a/service/src/test/java/bio/terra/pipelines/common/MetricsUtilsTest.java
+++ b/service/src/test/java/bio/terra/pipelines/common/MetricsUtilsTest.java
@@ -31,7 +31,7 @@ class MetricsUtilsTest extends BaseTest {
 
   @Test
   void incrementImputationPipelineRunMetrics() {
-    PipelinesEnum pipelineName = PipelinesEnum.IMPUTATION_BEAGLE;
+    PipelinesEnum pipelineName = PipelinesEnum.ARRAY_IMPUTATION;
 
     // increment counter once
     MetricsUtils.incrementPipelineRun(pipelineName);
@@ -49,7 +49,7 @@ class MetricsUtilsTest extends BaseTest {
 
   @Test
   void incrementInputationPipelineFailedMetrics() {
-    PipelinesEnum pipelineName = PipelinesEnum.IMPUTATION_BEAGLE;
+    PipelinesEnum pipelineName = PipelinesEnum.ARRAY_IMPUTATION;
 
     // increment counter once
     MetricsUtils.incrementPipelineRunFailed(pipelineName);

--- a/service/src/test/java/bio/terra/pipelines/controller/AdminApiControllerTest.java
+++ b/service/src/test/java/bio/terra/pipelines/controller/AdminApiControllerTest.java
@@ -58,7 +58,7 @@ class AdminApiControllerTest {
   @Test
   void updatePipelineWorkspaceOk() throws Exception {
     when(pipelinesServiceMock.updatePipelineWorkspace(
-            PipelinesEnum.IMPUTATION_BEAGLE,
+            PipelinesEnum.ARRAY_IMPUTATION,
             TEST_WORKSPACE_BILLING_PROJECT,
             TEST_WORKSPACE_NAME,
             TEST_WDL_METHOD_VERSION))
@@ -68,8 +68,7 @@ class AdminApiControllerTest {
             .perform(
                 patch(
                         String.format(
-                            "/api/admin/v1/pipeline/%s",
-                            PipelinesEnum.IMPUTATION_BEAGLE.getValue()))
+                            "/api/admin/v1/pipeline/%s", PipelinesEnum.ARRAY_IMPUTATION.getValue()))
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(
                         createTestJobPostBody(
@@ -100,7 +99,7 @@ class AdminApiControllerTest {
         .perform(
             patch(
                     String.format(
-                        "/api/admin/v1/pipeline/%s", PipelinesEnum.IMPUTATION_BEAGLE.getValue()))
+                        "/api/admin/v1/pipeline/%s", PipelinesEnum.ARRAY_IMPUTATION.getValue()))
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(
                     createTestJobPostBody(
@@ -114,7 +113,7 @@ class AdminApiControllerTest {
         .perform(
             patch(
                     String.format(
-                        "/api/admin/v1/pipeline/%s", PipelinesEnum.IMPUTATION_BEAGLE.getValue()))
+                        "/api/admin/v1/pipeline/%s", PipelinesEnum.ARRAY_IMPUTATION.getValue()))
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(createTestJobPostBody(null, TEST_WORKSPACE_NAME, TEST_WDL_METHOD_VERSION)))
         .andExpect(status().isBadRequest());
@@ -126,7 +125,7 @@ class AdminApiControllerTest {
         .perform(
             patch(
                     String.format(
-                        "/api/admin/v1/pipeline/%s", PipelinesEnum.IMPUTATION_BEAGLE.getValue()))
+                        "/api/admin/v1/pipeline/%s", PipelinesEnum.ARRAY_IMPUTATION.getValue()))
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(
                     createTestJobPostBody(
@@ -142,7 +141,7 @@ class AdminApiControllerTest {
         .perform(
             patch(
                     String.format(
-                        "/api/admin/v1/pipeline/%s", PipelinesEnum.IMPUTATION_BEAGLE.getValue()))
+                        "/api/admin/v1/pipeline/%s", PipelinesEnum.ARRAY_IMPUTATION.getValue()))
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(
                     createTestJobPostBody(
@@ -154,14 +153,14 @@ class AdminApiControllerTest {
 
   @Test
   void getAdminPipelineOk() throws Exception {
-    when(pipelinesServiceMock.getPipeline(PipelinesEnum.IMPUTATION_BEAGLE))
+    when(pipelinesServiceMock.getPipeline(PipelinesEnum.ARRAY_IMPUTATION))
         .thenReturn(MockMvcUtils.getTestPipeline());
     MvcResult result =
         mockMvc
             .perform(
                 get(
                     String.format(
-                        "/api/admin/v1/pipeline/%s", PipelinesEnum.IMPUTATION_BEAGLE.getValue())))
+                        "/api/admin/v1/pipeline/%s", PipelinesEnum.ARRAY_IMPUTATION.getValue())))
             .andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON))
             .andReturn();
@@ -172,7 +171,7 @@ class AdminApiControllerTest {
 
     // this is all mocked data so really not worth checking values, really just testing that it's a
     // 200 status with a properly formatted response
-    assertEquals(PipelinesEnum.IMPUTATION_BEAGLE.getValue(), response.getPipelineName());
+    assertEquals(PipelinesEnum.ARRAY_IMPUTATION.getValue(), response.getPipelineName());
   }
 
   @Test
@@ -183,7 +182,7 @@ class AdminApiControllerTest {
         .perform(
             get(
                 String.format(
-                    "/api/admin/v1/pipeline/%s", PipelinesEnum.IMPUTATION_BEAGLE.getValue())))
+                    "/api/admin/v1/pipeline/%s", PipelinesEnum.ARRAY_IMPUTATION.getValue())))
         .andExpect(status().isForbidden());
   }
 

--- a/service/src/test/java/bio/terra/pipelines/controller/PipelineRunsApiControllerTest.java
+++ b/service/src/test/java/bio/terra/pipelines/controller/PipelineRunsApiControllerTest.java
@@ -105,7 +105,7 @@ class PipelineRunsApiControllerTest {
 
   @Test
   void prepareRunImputationPipeline() throws Exception {
-    String pipelineName = PipelinesEnum.IMPUTATION_BEAGLE.getValue();
+    String pipelineName = PipelinesEnum.ARRAY_IMPUTATION.getValue();
     UUID jobId = newJobId;
     String postBodyAsJson = testPreparePipelineRunPostBody(jobId.toString());
 
@@ -144,7 +144,7 @@ class PipelineRunsApiControllerTest {
 
   @Test
   void preparePipelineRunMissingMultipleRequiredFields() throws Exception {
-    String pipelineName = PipelinesEnum.IMPUTATION_BEAGLE.getValue();
+    String pipelineName = PipelinesEnum.ARRAY_IMPUTATION.getValue();
     String stringifiedInputs = MockMvcUtils.convertToJsonString(testPipelineInputs);
     String postBodyAsJson =
         String.format(
@@ -172,7 +172,7 @@ class PipelineRunsApiControllerTest {
 
   @Test
   void preparePipelineRunBadPipelineInputs() throws Exception {
-    String pipelineName = PipelinesEnum.IMPUTATION_BEAGLE.getValue();
+    String pipelineName = PipelinesEnum.ARRAY_IMPUTATION.getValue();
     String postBodyAsJson = testPreparePipelineRunPostBody(newJobId.toString());
 
     // the mocks
@@ -200,7 +200,7 @@ class PipelineRunsApiControllerTest {
 
   @Test
   void startRunImputationPipelineRunning() throws Exception {
-    String pipelineName = PipelinesEnum.IMPUTATION_BEAGLE.getValue();
+    String pipelineName = PipelinesEnum.ARRAY_IMPUTATION.getValue();
     String description = "description for testCreateJobImputationPipelineRunning";
     UUID jobId = newJobId;
     String postBodyAsJson = testStartPipelineRunPostBody(jobId.toString(), description);
@@ -229,8 +229,7 @@ class PipelineRunsApiControllerTest {
             description,
             "https://some-teaspoons-domain.com/result/deadbeef-dead-beef-aaaa-beefdeadbeef"))
         .thenReturn(testPipelineRun);
-    when(jobServiceMock.retrieveJob(
-            jobId, testUser.getSubjectId(), PipelinesEnum.IMPUTATION_BEAGLE))
+    when(jobServiceMock.retrieveJob(jobId, testUser.getSubjectId(), PipelinesEnum.ARRAY_IMPUTATION))
         .thenReturn(flightState);
     when(jobServiceMock.retrieveAsyncJobResult(jobId, testUser.getSubjectId(), String.class, null))
         .thenReturn(new JobApiUtils.AsyncJobResult<String>().jobReport(jobReport).result(null));
@@ -265,7 +264,7 @@ class PipelineRunsApiControllerTest {
 
   @Test
   void startPipelineRunMissingJobControl() throws Exception {
-    String pipelineName = PipelinesEnum.IMPUTATION_BEAGLE.getValue();
+    String pipelineName = PipelinesEnum.ARRAY_IMPUTATION.getValue();
     ApiStartPipelineRunRequestBody postBody =
         new ApiStartPipelineRunRequestBody()
             .description("description for testCreateJobMissingJobId");
@@ -290,7 +289,7 @@ class PipelineRunsApiControllerTest {
 
   @Test
   void startPipelineRunMissingJobId() throws Exception {
-    String pipelineName = PipelinesEnum.IMPUTATION_BEAGLE.getValue();
+    String pipelineName = PipelinesEnum.ARRAY_IMPUTATION.getValue();
     ApiJobControl apiJobControl = new ApiJobControl();
     ApiStartPipelineRunRequestBody postBody =
         new ApiStartPipelineRunRequestBody()
@@ -318,7 +317,7 @@ class PipelineRunsApiControllerTest {
 
   @Test
   void startPipelineRunBadJobId() throws Exception {
-    String pipelineName = PipelinesEnum.IMPUTATION_BEAGLE.getValue();
+    String pipelineName = PipelinesEnum.ARRAY_IMPUTATION.getValue();
     String postBodyAsJson =
         testStartPipelineRunPostBody(
             "this-is-not-a-uuid", "description for testCreateJobMissingJobId");
@@ -343,7 +342,7 @@ class PipelineRunsApiControllerTest {
 
   @Test
   void startPipelineRunDbError() throws Exception {
-    String pipelineName = PipelinesEnum.IMPUTATION_BEAGLE.getValue();
+    String pipelineName = PipelinesEnum.ARRAY_IMPUTATION.getValue();
     String description = "description for startPipelineRunDbError";
     UUID jobId = newJobId;
     String postBodyAsJson = testStartPipelineRunPostBody(jobId.toString(), description);
@@ -365,7 +364,7 @@ class PipelineRunsApiControllerTest {
 
   @Test
   void startImputationRunStairwayError() throws Exception {
-    String pipelineName = PipelinesEnum.IMPUTATION_BEAGLE.getValue();
+    String pipelineName = PipelinesEnum.ARRAY_IMPUTATION.getValue();
     String description = "description for startImputationJobStairwayError";
     UUID jobId = newJobId;
     String postBodyAsJson = testStartPipelineRunPostBody(jobId.toString(), description);
@@ -391,7 +390,7 @@ class PipelineRunsApiControllerTest {
 
   @Test
   void getPipelineRunResultDoneSuccess() throws Exception {
-    String pipelineName = PipelinesEnum.IMPUTATION_BEAGLE.getValue();
+    String pipelineName = PipelinesEnum.ARRAY_IMPUTATION.getValue();
     String jobIdString = newJobId.toString();
     PipelineRun pipelineRun = getPipelineRunWithStatus(CommonPipelineRunStatusEnum.SUCCEEDED);
     ApiPipelineRunOutputs apiPipelineRunOutputs = new ApiPipelineRunOutputs();
@@ -432,7 +431,7 @@ class PipelineRunsApiControllerTest {
 
   @Test
   void getPipelineRunResultDoneFailed() throws Exception {
-    String pipelineName = PipelinesEnum.IMPUTATION_BEAGLE.getValue();
+    String pipelineName = PipelinesEnum.ARRAY_IMPUTATION.getValue();
     String jobIdString = newJobId.toString();
     String errorMessage = "test exception message";
     Integer statusCode = 500;
@@ -482,7 +481,7 @@ class PipelineRunsApiControllerTest {
 
   @Test
   void getPipelineRunResultRunning() throws Exception {
-    String pipelineName = PipelinesEnum.IMPUTATION_BEAGLE.getValue();
+    String pipelineName = PipelinesEnum.ARRAY_IMPUTATION.getValue();
     String jobIdString = newJobId.toString();
     Integer statusCode = 202;
     PipelineRun pipelineRun = getPipelineRunRunning();
@@ -528,7 +527,7 @@ class PipelineRunsApiControllerTest {
 
   @Test
   void getPipelineRunResultNotFound() throws Exception {
-    String pipelineName = PipelinesEnum.IMPUTATION_BEAGLE.getValue();
+    String pipelineName = PipelinesEnum.ARRAY_IMPUTATION.getValue();
     String jobIdString = newJobId.toString();
 
     // the mocks

--- a/service/src/test/java/bio/terra/pipelines/controller/PipelinesApiControllerTest.java
+++ b/service/src/test/java/bio/terra/pipelines/controller/PipelinesApiControllerTest.java
@@ -117,8 +117,8 @@ class PipelinesApiControllerTest {
 
   @Test
   void getPipelineCaseInsensitive() throws Exception {
-    String pipelineName = "ImpuTatioN_bEaGlE";
-    PipelinesEnum pipelineNameEnum = PipelinesEnum.IMPUTATION_BEAGLE;
+    String pipelineName = "aRrAy_ImpuTatioN";
+    PipelinesEnum pipelineNameEnum = PipelinesEnum.ARRAY_IMPUTATION;
 
     when(pipelinesServiceMock.getPipeline(pipelineNameEnum)).thenReturn(TestUtils.TEST_PIPELINE_1);
 

--- a/service/src/test/java/bio/terra/pipelines/controller/PipelinesApiUtilsTest.java
+++ b/service/src/test/java/bio/terra/pipelines/controller/PipelinesApiUtilsTest.java
@@ -15,13 +15,13 @@ class PipelinesApiUtilsTest {
   @Test
   void validatePipelineNameHappy() {
     // give a valid enum and expect no errors
-    PipelineApiUtils.validatePipelineName(PipelinesEnum.IMPUTATION_BEAGLE.getValue(), logger);
+    PipelineApiUtils.validatePipelineName(PipelinesEnum.ARRAY_IMPUTATION.getValue(), logger);
   }
 
   @Test
   void validatePipelineNameCaseInsensitive() {
     // give a valid enum and expect no errors
-    PipelineApiUtils.validatePipelineName("imputation_BEAGLE", logger);
+    PipelineApiUtils.validatePipelineName("ARRAY_imputation", logger);
   }
 
   @Test

--- a/service/src/test/java/bio/terra/pipelines/db/entities/UserQuotaTest.java
+++ b/service/src/test/java/bio/terra/pipelines/db/entities/UserQuotaTest.java
@@ -12,8 +12,8 @@ class UserQuotaTest extends BaseTest {
   @Test
   void testUserQuotaConstructor() {
     UserQuota userQuota =
-        new UserQuota(PipelinesEnum.IMPUTATION_BEAGLE, TestUtils.TEST_USER_ID_1, 1000, 100);
-    assertEquals(PipelinesEnum.IMPUTATION_BEAGLE, userQuota.getPipelineName());
+        new UserQuota(PipelinesEnum.ARRAY_IMPUTATION, TestUtils.TEST_USER_ID_1, 1000, 100);
+    assertEquals(PipelinesEnum.ARRAY_IMPUTATION, userQuota.getPipelineName());
     assertEquals(TestUtils.TEST_USER_ID_1, userQuota.getUserId());
     assertEquals(1000, userQuota.getQuota());
     assertEquals(100, userQuota.getQuotaConsumed());

--- a/service/src/test/java/bio/terra/pipelines/dependencies/stairway/JobServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/dependencies/stairway/JobServiceTest.java
@@ -21,7 +21,7 @@ class JobServiceTest extends BaseEmbeddedDbTest {
 
   @Autowired JobService jobService;
 
-  private static final PipelinesEnum PIPELINE_NAME = PipelinesEnum.IMPUTATION_BEAGLE;
+  private static final PipelinesEnum PIPELINE_NAME = PipelinesEnum.ARRAY_IMPUTATION;
   public static final Long PIPELINE_ID = 1L;
   private static final String TEST_USER_ID = TestUtils.TEST_USER_ID_1;
   private static final UUID TEST_JOB_UUID = TestUtils.TEST_NEW_UUID;

--- a/service/src/test/java/bio/terra/pipelines/service/PipelinesServiceDatabaseTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/PipelinesServiceDatabaseTest.java
@@ -12,7 +12,9 @@ import bio.terra.pipelines.common.utils.PipelinesEnum;
 import bio.terra.pipelines.db.entities.Pipeline;
 import bio.terra.pipelines.db.entities.PipelineInputDefinition;
 import bio.terra.pipelines.db.entities.PipelineOutputDefinition;
+import bio.terra.pipelines.db.entities.PipelineQuota;
 import bio.terra.pipelines.db.repositories.PipelineInputDefinitionsRepository;
+import bio.terra.pipelines.db.repositories.PipelineQuotasRepository;
 import bio.terra.pipelines.db.repositories.PipelinesRepository;
 import bio.terra.pipelines.testutils.BaseEmbeddedDbTest;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -27,6 +29,7 @@ import org.springframework.dao.DataIntegrityViolationException;
 class PipelinesServiceDatabaseTest extends BaseEmbeddedDbTest {
   @Autowired PipelinesRepository pipelinesRepository;
   @Autowired PipelineInputDefinitionsRepository pipelineInputDefinitionsRepository;
+  @Autowired PipelineQuotasRepository pipelineQuotasRepository;
 
   @Test
   void allPipelineEnumsExist() {
@@ -89,7 +92,7 @@ class PipelinesServiceDatabaseTest extends BaseEmbeddedDbTest {
   @Test
   void imputationPipelineHasCorrectInputs() {
     // make sure the imputation pipeline has the correct inputs
-    Pipeline pipeline = pipelinesRepository.findByName(PipelinesEnum.IMPUTATION_BEAGLE);
+    Pipeline pipeline = pipelinesRepository.findByName(PipelinesEnum.ARRAY_IMPUTATION);
 
     List<PipelineInputDefinition> allPipelineInputDefinitions =
         pipeline.getPipelineInputDefinitions();
@@ -156,7 +159,7 @@ class PipelinesServiceDatabaseTest extends BaseEmbeddedDbTest {
 
   @Test
   void addDuplicatePipelineInputThrows() {
-    Pipeline pipeline = pipelinesRepository.findByName(PipelinesEnum.IMPUTATION_BEAGLE);
+    Pipeline pipeline = pipelinesRepository.findByName(PipelinesEnum.ARRAY_IMPUTATION);
 
     // add a pipeline input that already exists
     PipelineInputDefinition newInput = new PipelineInputDefinition();
@@ -185,7 +188,7 @@ class PipelinesServiceDatabaseTest extends BaseEmbeddedDbTest {
   @Test
   void imputationPipelineHasCorrectOutputs() {
     // make sure the imputation pipeline has the correct outputs
-    Pipeline pipeline = pipelinesRepository.findByName(PipelinesEnum.IMPUTATION_BEAGLE);
+    Pipeline pipeline = pipelinesRepository.findByName(PipelinesEnum.ARRAY_IMPUTATION);
 
     List<PipelineOutputDefinition> allPipelineOutputDefinitions =
         pipeline.getPipelineOutputDefinitions();
@@ -215,5 +218,14 @@ class PipelinesServiceDatabaseTest extends BaseEmbeddedDbTest {
         allPipelineOutputDefinitions.stream()
             .map(PipelineOutputDefinition::getPipelineId)
             .collect(Collectors.toSet()));
+  }
+
+  @Test
+  void allPipelinesInPipelineQuotasHaveDefinedPipelines() {
+    // make sure all the pipelines in the pipeline quotas table have defined pipelines in the
+    // pipelines table
+    for (PipelineQuota pq : pipelineQuotasRepository.findAll()) {
+      assertTrue(pipelinesRepository.existsByName(pq.getPipelineName()));
+    }
   }
 }

--- a/service/src/test/java/bio/terra/pipelines/service/PipelinesServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/PipelinesServiceTest.java
@@ -68,7 +68,7 @@ class PipelinesServiceTest extends BaseEmbeddedDbTest {
     // save a new version of the same pipeline
     pipelinesRepository.save(
         new Pipeline(
-            PipelinesEnum.IMPUTATION_BEAGLE,
+            PipelinesEnum.ARRAY_IMPUTATION,
             1,
             "pipelineDisplayName",
             "description",
@@ -87,7 +87,7 @@ class PipelinesServiceTest extends BaseEmbeddedDbTest {
     pipelineList = pipelinesService.getPipelines();
     assertEquals(2, pipelineList.size());
     Pipeline savedPipeline = pipelineList.get(1);
-    assertEquals(PipelinesEnum.IMPUTATION_BEAGLE, savedPipeline.getName());
+    assertEquals(PipelinesEnum.ARRAY_IMPUTATION, savedPipeline.getName());
     assertEquals(1, savedPipeline.getVersion());
     assertEquals("pipelineDisplayName", savedPipeline.getDisplayName());
     assertEquals("description", savedPipeline.getDescription());
@@ -104,7 +104,7 @@ class PipelinesServiceTest extends BaseEmbeddedDbTest {
 
   @Test
   void getPipelineById() {
-    PipelinesEnum imputationPipeline = PipelinesEnum.IMPUTATION_BEAGLE;
+    PipelinesEnum imputationPipeline = PipelinesEnum.ARRAY_IMPUTATION;
     Pipeline p = pipelinesService.getPipeline(imputationPipeline);
     Long pipelineId = p.getId();
 
@@ -116,7 +116,7 @@ class PipelinesServiceTest extends BaseEmbeddedDbTest {
 
   @Test
   void getPipelineInputDefinitions() {
-    PipelinesEnum imputationPipeline = PipelinesEnum.IMPUTATION_BEAGLE;
+    PipelinesEnum imputationPipeline = PipelinesEnum.ARRAY_IMPUTATION;
     List<PipelineInputDefinition> allPipelineInputDefinitions =
         pipelinesService.getPipeline(imputationPipeline).getPipelineInputDefinitions();
     List<PipelineInputDefinition> userProvidedPipelineInputDefinitions =
@@ -185,7 +185,7 @@ class PipelinesServiceTest extends BaseEmbeddedDbTest {
 
   @Test
   void updatePipelineWorkspace() {
-    PipelinesEnum pipelinesEnum = PipelinesEnum.IMPUTATION_BEAGLE;
+    PipelinesEnum pipelinesEnum = PipelinesEnum.ARRAY_IMPUTATION;
     Pipeline p = pipelinesService.getPipeline(pipelinesEnum);
     String newWorkspaceBillingProject = "newTestTerraProject";
     String newWorkspaceName = "newTestTerraWorkspaceName";
@@ -248,7 +248,7 @@ class PipelinesServiceTest extends BaseEmbeddedDbTest {
   @ParameterizedTest
   @MethodSource("badWdlMethodVersions")
   void updatePipelineWorkspaceBadWdlMethodVersion(String badWdlMethodVersion) {
-    PipelinesEnum pipelinesEnum = PipelinesEnum.IMPUTATION_BEAGLE;
+    PipelinesEnum pipelinesEnum = PipelinesEnum.ARRAY_IMPUTATION;
     String newWorkspaceBillingProject = "newTestTerraProject";
     String newWorkspaceName = "newTestTerraWorkspaceName";
     assertThrows(
@@ -270,7 +270,7 @@ class PipelinesServiceTest extends BaseEmbeddedDbTest {
   @ParameterizedTest
   @MethodSource("goodWdlMethodVersions")
   void updatePipelineWorkspaceGoodWdlMethodVersion(String badWdlMethodVersion) {
-    PipelinesEnum pipelinesEnum = PipelinesEnum.IMPUTATION_BEAGLE;
+    PipelinesEnum pipelinesEnum = PipelinesEnum.ARRAY_IMPUTATION;
     String newWorkspaceBillingProject = "newTestTerraProject";
     String newWorkspaceName = "newTestTerraWorkspaceName";
     assertDoesNotThrow(
@@ -281,7 +281,7 @@ class PipelinesServiceTest extends BaseEmbeddedDbTest {
 
   @Test
   void updatePipelineWorkspaceNullValueThrows() {
-    PipelinesEnum pipelinesEnum = PipelinesEnum.IMPUTATION_BEAGLE;
+    PipelinesEnum pipelinesEnum = PipelinesEnum.ARRAY_IMPUTATION;
     Pipeline p = pipelinesService.getPipeline(pipelinesEnum);
 
     String newWorkspaceName = "newTestTerraWorkspaceName";
@@ -336,7 +336,7 @@ class PipelinesServiceTest extends BaseEmbeddedDbTest {
       Map<String, Object> inputs,
       Boolean shouldPassValidation,
       List<String> expectedErrorMessageStrings) {
-    PipelinesEnum pipelinesEnum = PipelinesEnum.IMPUTATION_BEAGLE;
+    PipelinesEnum pipelinesEnum = PipelinesEnum.ARRAY_IMPUTATION;
     List<PipelineInputDefinition> allInputDefinitions =
         pipelinesService.getPipeline(pipelinesEnum).getPipelineInputDefinitions();
 
@@ -500,7 +500,7 @@ class PipelinesServiceTest extends BaseEmbeddedDbTest {
   void constructImputationInputsSuccess() {
     Map<String, Object> userProvidedInputs = TestUtils.TEST_PIPELINE_INPUTS;
 
-    PipelinesEnum pipelineEnum = PipelinesEnum.IMPUTATION_BEAGLE;
+    PipelinesEnum pipelineEnum = PipelinesEnum.ARRAY_IMPUTATION;
     Pipeline pipeline = pipelinesRepository.findByName(pipelineEnum);
     List<PipelineInputDefinition> allPipelineInputDefinitions =
         pipeline.getPipelineInputDefinitions();

--- a/service/src/test/java/bio/terra/pipelines/service/QuotasServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/QuotasServiceTest.java
@@ -21,12 +21,12 @@ class QuotasServiceTest extends BaseEmbeddedDbTest {
   void getQuotaForUserAndPipeline() {
     // add row to user_quotas table
     UserQuota userQuota =
-        createAndSaveUserQuota(TestUtils.TEST_USER_ID_1, PipelinesEnum.IMPUTATION_BEAGLE, 30, 100);
+        createAndSaveUserQuota(TestUtils.TEST_USER_ID_1, PipelinesEnum.ARRAY_IMPUTATION, 30, 100);
 
     // call service and assert correct UserQuota is returned
     UserQuota returnedUserQuota =
         quotasService.getQuotaForUserAndPipeline(
-            TestUtils.TEST_USER_ID_1, PipelinesEnum.IMPUTATION_BEAGLE);
+            TestUtils.TEST_USER_ID_1, PipelinesEnum.ARRAY_IMPUTATION);
 
     assertEquals(userQuota.getUserId(), returnedUserQuota.getUserId());
     assertEquals(userQuota.getPipelineName(), returnedUserQuota.getPipelineName());
@@ -39,29 +39,29 @@ class QuotasServiceTest extends BaseEmbeddedDbTest {
     // assert nothing exists in the user_quotas table
     assertTrue(
         userQuotasRepository
-            .findByUserIdAndPipelineName(TestUtils.TEST_USER_ID_1, PipelinesEnum.IMPUTATION_BEAGLE)
+            .findByUserIdAndPipelineName(TestUtils.TEST_USER_ID_1, PipelinesEnum.ARRAY_IMPUTATION)
             .isEmpty());
 
     // get default quota for pipeline
     int defaultQuotaForImputationBeaglePipeline =
         pipelineQuotasRepository
-            .findByPipelineName(PipelinesEnum.IMPUTATION_BEAGLE)
+            .findByPipelineName(PipelinesEnum.ARRAY_IMPUTATION)
             .getDefaultQuota();
 
     // call service with same inputs and a new row should exist in user_quotas table
     UserQuota userQuota =
         quotasService.getQuotaForUserAndPipeline(
-            TestUtils.TEST_USER_ID_1, PipelinesEnum.IMPUTATION_BEAGLE);
+            TestUtils.TEST_USER_ID_1, PipelinesEnum.ARRAY_IMPUTATION);
 
     assertEquals(TestUtils.TEST_USER_ID_1, userQuota.getUserId());
-    assertEquals(PipelinesEnum.IMPUTATION_BEAGLE, userQuota.getPipelineName());
+    assertEquals(PipelinesEnum.ARRAY_IMPUTATION, userQuota.getPipelineName());
     assertEquals(0, userQuota.getQuotaConsumed());
     assertEquals(defaultQuotaForImputationBeaglePipeline, userQuota.getQuota());
 
     // assert user + pipeline exists in the user_quotas table
     assertTrue(
         userQuotasRepository
-            .findByUserIdAndPipelineName(TestUtils.TEST_USER_ID_1, PipelinesEnum.IMPUTATION_BEAGLE)
+            .findByUserIdAndPipelineName(TestUtils.TEST_USER_ID_1, PipelinesEnum.ARRAY_IMPUTATION)
             .isPresent());
   }
 

--- a/service/src/test/java/bio/terra/pipelines/stairway/imputation/RunImputationAzureFlightTest.java
+++ b/service/src/test/java/bio/terra/pipelines/stairway/imputation/RunImputationAzureFlightTest.java
@@ -64,7 +64,7 @@ class RunImputationAzureFlightTest extends BaseEmbeddedDbTest {
                 .flightClass(RunImputationAzureJobFlight.class)
                 .addParameter(JobMapKeys.DESCRIPTION, "test RunImputationAzureJobFlight")
                 .addParameter(JobMapKeys.USER_ID, TestUtils.TEST_USER_ID_1)
-                .addParameter(JobMapKeys.PIPELINE_NAME, PipelinesEnum.IMPUTATION_BEAGLE)
+                .addParameter(JobMapKeys.PIPELINE_NAME, PipelinesEnum.ARRAY_IMPUTATION)
                 .addParameter(JobMapKeys.PIPELINE_ID, TestUtils.TEST_PIPELINE_ID_1)
                 .addParameter(
                     ImputationJobMapKeys.PIPELINE_INPUT_DEFINITIONS,

--- a/service/src/test/java/bio/terra/pipelines/stairway/imputation/RunImputationGcpFlightTest.java
+++ b/service/src/test/java/bio/terra/pipelines/stairway/imputation/RunImputationGcpFlightTest.java
@@ -64,7 +64,7 @@ class RunImputationGcpFlightTest extends BaseEmbeddedDbTest {
                 .flightClass(RunImputationGcpJobFlight.class)
                 .addParameter(JobMapKeys.DESCRIPTION, "test RunImputationGcpJobFlight")
                 .addParameter(JobMapKeys.USER_ID, TestUtils.TEST_USER_ID_1)
-                .addParameter(JobMapKeys.PIPELINE_NAME, PipelinesEnum.IMPUTATION_BEAGLE)
+                .addParameter(JobMapKeys.PIPELINE_NAME, PipelinesEnum.ARRAY_IMPUTATION)
                 .addParameter(JobMapKeys.PIPELINE_ID, TestUtils.TEST_PIPELINE_ID_1)
                 .addParameter(
                     ImputationJobMapKeys.PIPELINE_INPUT_DEFINITIONS,

--- a/service/src/test/java/bio/terra/pipelines/stairway/imputation/steps/PrepareImputationInputsStepTest.java
+++ b/service/src/test/java/bio/terra/pipelines/stairway/imputation/steps/PrepareImputationInputsStepTest.java
@@ -71,17 +71,17 @@ class PrepareImputationInputsStepTest extends BaseEmbeddedDbTest {
     // setup
     when(flightContext.getFlightId()).thenReturn(testJobId.toString());
 
-    PipelinesEnum pipelineEnum = PipelinesEnum.IMPUTATION_BEAGLE;
+    PipelinesEnum pipelineEnum = PipelinesEnum.ARRAY_IMPUTATION;
     Pipeline pipeline = pipelinesService.getPipeline(pipelineEnum);
 
     StairwayTestUtils.constructCreateJobInputs(
         flightContext.getInputParameters(),
-        PipelinesEnum.IMPUTATION_BEAGLE,
+        PipelinesEnum.ARRAY_IMPUTATION,
         pipeline.getId(),
         pipeline.getPipelineInputDefinitions(),
         pipeline.getPipelineOutputDefinitions(),
         TestUtils.TEST_USER_ID_1,
-        TestUtils.TEST_PIPELINE_INPUTS_IMPUTATION_BEAGLE,
+        TestUtils.TEST_PIPELINE_INPUTS_ARRAY_IMPUTATION,
         TestUtils.CONTROL_WORKSPACE_ID,
         TestUtils.CONTROL_WORKSPACE_BILLING_PROJECT,
         TestUtils.CONTROL_WORKSPACE_NAME,

--- a/service/src/test/java/bio/terra/pipelines/stairway/imputation/steps/azure/AddWdsRowsStepTest.java
+++ b/service/src/test/java/bio/terra/pipelines/stairway/imputation/steps/azure/AddWdsRowsStepTest.java
@@ -65,7 +65,7 @@ class AddWdsRowsStepTest extends BaseEmbeddedDbTest {
             eq("thisToken"),
             recordRequestCaptor.capture(),
             eq(TestUtils.CONTROL_WORKSPACE_ID.toString()),
-            eq(PipelinesEnum.IMPUTATION_BEAGLE.getValue()),
+            eq(PipelinesEnum.ARRAY_IMPUTATION.getValue()),
             eq(testJobId.toString()),
             eq("flight_id"));
     RecordRequest capturedRecordRequest = recordRequestCaptor.getValue();
@@ -91,7 +91,7 @@ class AddWdsRowsStepTest extends BaseEmbeddedDbTest {
             eq("thisToken"),
             any(RecordRequest.class),
             eq(TestUtils.CONTROL_WORKSPACE_ID.toString()),
-            eq(PipelinesEnum.IMPUTATION_BEAGLE.getValue()),
+            eq(PipelinesEnum.ARRAY_IMPUTATION.getValue()),
             eq(testJobId.toString()),
             eq("flight_id")))
         .thenThrow(thrownException);

--- a/service/src/test/java/bio/terra/pipelines/stairway/imputation/steps/azure/FetchOutputsFromWdsStepTest.java
+++ b/service/src/test/java/bio/terra/pipelines/stairway/imputation/steps/azure/FetchOutputsFromWdsStepTest.java
@@ -57,7 +57,7 @@ class FetchOutputsFromWdsStepTest extends BaseEmbeddedDbTest {
     when(wdsService.getRecord(
             "wdsUri",
             "thisToken",
-            PipelinesEnum.IMPUTATION_BEAGLE.getValue(),
+            PipelinesEnum.ARRAY_IMPUTATION.getValue(),
             TestUtils.CONTROL_WORKSPACE_ID.toString(),
             TestUtils.TEST_NEW_UUID.toString()))
         .thenReturn(recordResponse);
@@ -84,7 +84,7 @@ class FetchOutputsFromWdsStepTest extends BaseEmbeddedDbTest {
     when(wdsService.getRecord(
             "wdsUri",
             "thisToken",
-            PipelinesEnum.IMPUTATION_BEAGLE.getValue(),
+            PipelinesEnum.ARRAY_IMPUTATION.getValue(),
             TestUtils.CONTROL_WORKSPACE_ID.toString(),
             TestUtils.TEST_NEW_UUID.toString()))
         .thenThrow(new WdsServiceApiException(new ApiException("WDS Service Api Exception")));

--- a/service/src/test/java/bio/terra/pipelines/stairway/imputation/steps/gcp/FetchOutputsFromDataTableStepTest.java
+++ b/service/src/test/java/bio/terra/pipelines/stairway/imputation/steps/gcp/FetchOutputsFromDataTableStepTest.java
@@ -57,7 +57,7 @@ class FetchOutputsFromDataTableStepTest extends BaseEmbeddedDbTest {
             "thisToken",
             TestUtils.CONTROL_WORKSPACE_BILLING_PROJECT,
             TestUtils.CONTROL_WORKSPACE_NAME,
-            PipelinesEnum.IMPUTATION_BEAGLE.getValue(),
+            PipelinesEnum.ARRAY_IMPUTATION.getValue(),
             TestUtils.TEST_NEW_UUID.toString()))
         .thenReturn(entity);
     Map<String, String> outputsProcessedFromEntity =
@@ -87,7 +87,7 @@ class FetchOutputsFromDataTableStepTest extends BaseEmbeddedDbTest {
             "thisToken",
             TestUtils.CONTROL_WORKSPACE_BILLING_PROJECT,
             TestUtils.CONTROL_WORKSPACE_NAME,
-            PipelinesEnum.IMPUTATION_BEAGLE.getValue(),
+            PipelinesEnum.ARRAY_IMPUTATION.getValue(),
             TestUtils.TEST_NEW_UUID.toString()))
         .thenThrow(new RawlsServiceApiException("Rawls Service Api Exception"));
 
@@ -111,7 +111,7 @@ class FetchOutputsFromDataTableStepTest extends BaseEmbeddedDbTest {
             "thisToken",
             TestUtils.CONTROL_WORKSPACE_BILLING_PROJECT,
             TestUtils.CONTROL_WORKSPACE_NAME,
-            PipelinesEnum.IMPUTATION_BEAGLE.getValue(),
+            PipelinesEnum.ARRAY_IMPUTATION.getValue(),
             TestUtils.TEST_NEW_UUID.toString()))
         .thenReturn(entity);
     when(pipelineInputsOutputsService.extractPipelineOutputsFromEntity(

--- a/service/src/test/java/bio/terra/pipelines/stairway/imputation/steps/gcp/SubmitCromwellSubmissionStepTest.java
+++ b/service/src/test/java/bio/terra/pipelines/stairway/imputation/steps/gcp/SubmitCromwellSubmissionStepTest.java
@@ -63,7 +63,7 @@ class SubmitCromwellSubmissionStepTest extends BaseEmbeddedDbTest {
         .thenReturn(returnedMethodConfiguration);
     when(rawlsService.validateMethodConfig(
             returnedMethodConfiguration,
-            PipelinesEnum.IMPUTATION_BEAGLE.getValue(),
+            PipelinesEnum.ARRAY_IMPUTATION.getValue(),
             TestUtils.TEST_WDL_METHOD_NAME_1,
             TestUtils.TEST_PIPELINE_INPUTS_DEFINITION_LIST,
             TestUtils.TEST_PIPELINE_OUTPUTS_DEFINITION_LIST,
@@ -113,7 +113,7 @@ class SubmitCromwellSubmissionStepTest extends BaseEmbeddedDbTest {
         .thenReturn(returnedMethodConfiguration);
     when(rawlsService.validateMethodConfig(
             returnedMethodConfiguration,
-            PipelinesEnum.IMPUTATION_BEAGLE.getValue(),
+            PipelinesEnum.ARRAY_IMPUTATION.getValue(),
             TestUtils.TEST_WDL_METHOD_NAME_1,
             TestUtils.TEST_PIPELINE_INPUTS_DEFINITION_LIST,
             TestUtils.TEST_PIPELINE_OUTPUTS_DEFINITION_LIST,
@@ -121,7 +121,7 @@ class SubmitCromwellSubmissionStepTest extends BaseEmbeddedDbTest {
         .thenReturn(false);
     when(rawlsService.updateMethodConfigToBeValid(
             updateMethodConfigCaptor.capture(),
-            eq(PipelinesEnum.IMPUTATION_BEAGLE.getValue()),
+            eq(PipelinesEnum.ARRAY_IMPUTATION.getValue()),
             eq(TestUtils.TEST_WDL_METHOD_NAME_1),
             eq(TestUtils.TEST_PIPELINE_INPUTS_DEFINITION_LIST),
             eq(TestUtils.TEST_PIPELINE_OUTPUTS_DEFINITION_LIST),
@@ -170,7 +170,7 @@ class SubmitCromwellSubmissionStepTest extends BaseEmbeddedDbTest {
         .thenReturn(returnedMethodConfiguration);
     when(rawlsService.validateMethodConfig(
             returnedMethodConfiguration,
-            PipelinesEnum.IMPUTATION_BEAGLE.getValue(),
+            PipelinesEnum.ARRAY_IMPUTATION.getValue(),
             TestUtils.TEST_WDL_METHOD_NAME_1,
             TestUtils.TEST_PIPELINE_INPUTS_DEFINITION_LIST,
             TestUtils.TEST_PIPELINE_OUTPUTS_DEFINITION_LIST,
@@ -194,7 +194,7 @@ class SubmitCromwellSubmissionStepTest extends BaseEmbeddedDbTest {
     // throw exception on setting method config to be valid
     when(rawlsService.validateMethodConfig(
             returnedMethodConfiguration,
-            PipelinesEnum.IMPUTATION_BEAGLE.getValue(),
+            PipelinesEnum.ARRAY_IMPUTATION.getValue(),
             TestUtils.TEST_WDL_METHOD_NAME_1,
             TestUtils.TEST_PIPELINE_INPUTS_DEFINITION_LIST,
             TestUtils.TEST_PIPELINE_OUTPUTS_DEFINITION_LIST,

--- a/service/src/test/java/bio/terra/pipelines/testutils/MockMvcUtils.java
+++ b/service/src/test/java/bio/terra/pipelines/testutils/MockMvcUtils.java
@@ -59,7 +59,7 @@ public class MockMvcUtils {
   public static Pipeline getTestPipeline() {
     Pipeline testPipeline =
         new Pipeline(
-            PipelinesEnum.IMPUTATION_BEAGLE,
+            PipelinesEnum.ARRAY_IMPUTATION,
             0,
             "displayName",
             "description",

--- a/service/src/test/java/bio/terra/pipelines/testutils/StairwayTestUtils.java
+++ b/service/src/test/java/bio/terra/pipelines/testutils/StairwayTestUtils.java
@@ -38,7 +38,7 @@ public class StairwayTestUtils {
           TestUtils.TEST_PIPELINE_INPUTS_DEFINITION_LIST,
           TestUtils.TEST_PIPELINE_OUTPUTS_DEFINITION_LIST,
           TestUtils.TEST_USER_ID_1,
-          TestUtils.TEST_PIPELINE_INPUTS_IMPUTATION_BEAGLE,
+          TestUtils.TEST_PIPELINE_INPUTS_ARRAY_IMPUTATION,
           TestUtils.CONTROL_WORKSPACE_ID,
           TestUtils.CONTROL_WORKSPACE_BILLING_PROJECT,
           TestUtils.CONTROL_WORKSPACE_NAME,
@@ -213,12 +213,12 @@ public class StairwayTestUtils {
   public static FlightMap constructCreateJobInputs(FlightMap inputParameters) {
     return constructCreateJobInputs(
         inputParameters,
-        PipelinesEnum.IMPUTATION_BEAGLE,
+        PipelinesEnum.ARRAY_IMPUTATION,
         TestUtils.TEST_PIPELINE_ID_1,
         TestUtils.TEST_PIPELINE_INPUTS_DEFINITION_LIST,
         TestUtils.TEST_PIPELINE_OUTPUTS_DEFINITION_LIST,
         TestUtils.TEST_USER_ID_1,
-        TestUtils.TEST_PIPELINE_INPUTS_IMPUTATION_BEAGLE,
+        TestUtils.TEST_PIPELINE_INPUTS_ARRAY_IMPUTATION,
         TestUtils.CONTROL_WORKSPACE_ID,
         TestUtils.CONTROL_WORKSPACE_BILLING_PROJECT,
         TestUtils.CONTROL_WORKSPACE_NAME,

--- a/service/src/test/java/bio/terra/pipelines/testutils/TestUtils.java
+++ b/service/src/test/java/bio/terra/pipelines/testutils/TestUtils.java
@@ -15,7 +15,7 @@ import java.util.*;
 public class TestUtils {
   // Pipelines test constants
   public static final PipelinesEnum TEST_PIPELINE_1_IMPUTATION_ENUM =
-      PipelinesEnum.IMPUTATION_BEAGLE;
+      PipelinesEnum.ARRAY_IMPUTATION;
   public static final String TEST_PIPELINE_NAME_1_IMPUTATION =
       TEST_PIPELINE_1_IMPUTATION_ENUM
           .getValue(); // this matches the job pre-populated in the db for tests in that it is in
@@ -121,7 +121,7 @@ public class TestUtils {
 
   public static final Pipeline TEST_PIPELINE_1 =
       new Pipeline(
-          PipelinesEnum.IMPUTATION_BEAGLE,
+          PipelinesEnum.ARRAY_IMPUTATION,
           TEST_PIPELINE_VERSION_1,
           TEST_PIPELINE_DISPLAY_NAME_1,
           TEST_PIPELINE_DESCRIPTION_1,
@@ -138,7 +138,7 @@ public class TestUtils {
           TEST_PIPELINE_OUTPUTS_DEFINITION_LIST);
   public static final Pipeline TEST_PIPELINE_2 =
       new Pipeline(
-          PipelinesEnum.IMPUTATION_BEAGLE,
+          PipelinesEnum.ARRAY_IMPUTATION,
           TEST_PIPELINE_VERSION_2,
           TEST_PIPELINE_DISPLAY_NAME_2,
           TEST_PIPELINE_DESCRIPTION_2,
@@ -188,7 +188,7 @@ public class TestUtils {
   public static final Map<String, Object> TEST_PIPELINE_INPUTS =
       new HashMap<>(Map.of("first_key", "first_value"));
 
-  public static final Map<String, Object> TEST_PIPELINE_INPUTS_IMPUTATION_BEAGLE =
+  public static final Map<String, Object> TEST_PIPELINE_INPUTS_ARRAY_IMPUTATION =
       new HashMap<>(
           Map.of("multiSampleVcf", "fake/file.vcf.gz", "outputBasename", "fake_basename"));
 


### PR DESCRIPTION
### Description 

Updated the pipeline name `imputation_beagle` to `array_imputation`. Also updated that pipeline's description.

Tested locally, a new PipelineRun worked successfully.

This change is not backwards-compatible; old jobs run using `imputation_beagle` will no longer be accessible. This is acceptable since we're still only in dev and are about to wipe/migrate our database anyway.

Associated PR to update the e2e test: https://github.com/broadinstitute/dsp-reusable-workflows/pull/52

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-368
