### PR TITLE
TSPS-361 add quota consumed logic

### DIFF
--- a/service/src/main/java/bio/terra/pipelines/common/utils/FlightBeanBag.java
+++ b/service/src/main/java/bio/terra/pipelines/common/utils/FlightBeanBag.java
@@ -12,6 +12,7 @@ import bio.terra.pipelines.dependencies.workspacemanager.WorkspaceManagerService
 import bio.terra.pipelines.service.PipelineInputsOutputsService;
 import bio.terra.pipelines.service.PipelineRunsService;
 import bio.terra.pipelines.service.PipelinesService;
+import bio.terra.pipelines.service.QuotasService;
 import lombok.Getter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
@@ -36,6 +37,7 @@ public class FlightBeanBag {
   private final CbasService cbasService;
   private final WorkspaceManagerService workspaceManagerService;
   private final RawlsService rawlsService;
+  private final QuotasService quotasService;
   private final ImputationConfiguration imputationConfiguration;
   private final CbasConfiguration cbasConfiguration;
   private final WdlPipelineConfiguration wdlPipelineConfiguration;
@@ -51,6 +53,7 @@ public class FlightBeanBag {
       WdsService wdsService,
       CbasService cbasService,
       RawlsService rawlsService,
+      QuotasService quotasService,
       WorkspaceManagerService workspaceManagerService,
       ImputationConfiguration imputationConfiguration,
       CbasConfiguration cbasConfiguration,
@@ -64,6 +67,7 @@ public class FlightBeanBag {
     this.cbasService = cbasService;
     this.workspaceManagerService = workspaceManagerService;
     this.rawlsService = rawlsService;
+    this.quotasService = quotasService;
     this.imputationConfiguration = imputationConfiguration;
     this.cbasConfiguration = cbasConfiguration;
     this.wdlPipelineConfiguration = wdlPipelineConfiguration;

--- a/service/src/main/java/bio/terra/pipelines/service/QuotasService.java
+++ b/service/src/main/java/bio/terra/pipelines/service/QuotasService.java
@@ -1,6 +1,7 @@
 package bio.terra.pipelines.service;
 
 import bio.terra.common.db.WriteTransaction;
+import bio.terra.common.exception.InternalServerErrorException;
 import bio.terra.pipelines.common.utils.PipelinesEnum;
 import bio.terra.pipelines.db.entities.PipelineQuota;
 import bio.terra.pipelines.db.entities.UserQuota;
@@ -52,5 +53,24 @@ public class QuotasService {
       return newUserQuota;
     }
     return userQuota.get();
+  }
+
+  /**
+   * This method updates the quota consumed for a given user and pipeline. It will return the
+   * updated user quota object.
+   *
+   * @param userQuota - the user quota object to update
+   * @param newQuotaConsumed - the quota consumed
+   * @return - the updated user quota object
+   */
+  public UserQuota updateQuotaConsumed(UserQuota userQuota, int newQuotaConsumed) {
+    if (newQuotaConsumed < 0) {
+      throw new InternalServerErrorException("Quota consumed must be greater than or equal to 0");
+    }
+    if (newQuotaConsumed > userQuota.getQuota()) {
+      throw new InternalServerErrorException("Quota consumed cannot be greater than user quota");
+    }
+    userQuota.setQuotaConsumed(newQuotaConsumed);
+    return userQuotasRepository.save(userQuota);
   }
 }

--- a/service/src/main/java/bio/terra/pipelines/service/QuotasService.java
+++ b/service/src/main/java/bio/terra/pipelines/service/QuotasService.java
@@ -64,11 +64,13 @@ public class QuotasService {
    * @return - the updated user quota object
    */
   public UserQuota updateQuotaConsumed(UserQuota userQuota, int newQuotaConsumed) {
-    if (newQuotaConsumed < 0) {
-      throw new InternalServerErrorException("Quota consumed must be greater than or equal to 0");
-    }
-    if (newQuotaConsumed > userQuota.getQuota()) {
-      throw new InternalServerErrorException("Quota consumed cannot be greater than user quota");
+    if (newQuotaConsumed <= 0 || newQuotaConsumed > userQuota.getQuota()) {
+      logger.error(
+          "Issue with updating quota consumed: User quota: {}, current quota consumed: {}, new quota consumed {}",
+          userQuota.getQuota(),
+          userQuota.getQuotaConsumed(),
+          newQuotaConsumed);
+      throw new InternalServerErrorException("Internal Error");
     }
     userQuota.setQuotaConsumed(newQuotaConsumed);
     return userQuotasRepository.save(userQuota);

--- a/service/src/main/java/bio/terra/pipelines/stairway/FetchQuotaConsumedFromDataTableStep.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/FetchQuotaConsumedFromDataTableStep.java
@@ -10,8 +10,6 @@ import bio.terra.pipelines.dependencies.stairway.JobMapKeys;
 import bio.terra.pipelines.stairway.imputation.ImputationJobMapKeys;
 import bio.terra.rawls.model.Entity;
 import bio.terra.stairway.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * This step calls Rawls to fetch outputs from a data table row for a given quota consumed job. It

--- a/service/src/main/java/bio/terra/pipelines/stairway/FetchQuotaConsumedFromDataTableStep.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/FetchQuotaConsumedFromDataTableStep.java
@@ -16,7 +16,7 @@ import org.slf4j.LoggerFactory;
 /**
  * This step calls Rawls to fetch outputs from a data table row for a given quota consumed job. It
  * specifically fetches the quota consumed value from the data table row using the quota_consumed
- * key.  If successful, it stores the quota consumed value in the working map.
+ * key. If successful, it stores the quota consumed value in the working map.
  *
  * <p>This step expects nothing from the working map
  */

--- a/service/src/main/java/bio/terra/pipelines/stairway/FetchQuotaConsumedFromDataTableStep.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/FetchQuotaConsumedFromDataTableStep.java
@@ -16,7 +16,7 @@ import org.slf4j.LoggerFactory;
 /**
  * This step calls Rawls to fetch outputs from a data table row for a given quota consumed job. It
  * specifically fetches the quota consumed value from the data table row using the quota_consumed
- * key
+ * key.  If successful, it stores the quota consumed value in the working map.
  *
  * <p>This step expects nothing from the working map
  */
@@ -52,6 +52,9 @@ public class FetchQuotaConsumedFromDataTableStep implements Step {
         inputParameters.get(ImputationJobMapKeys.CONTROL_WORKSPACE_NAME, String.class);
     PipelinesEnum pipelineName = inputParameters.get(JobMapKeys.PIPELINE_NAME, PipelinesEnum.class);
 
+    // validate and extract parameters from working map
+    FlightMap workingMap = flightContext.getWorkingMap();
+
     Entity entity;
     try {
       entity =
@@ -80,7 +83,8 @@ public class FetchQuotaConsumedFromDataTableStep implements Step {
           new InternalServerErrorException("Quota consumed is unexpectedly null"));
     }
 
-    logger.info("Quota consumed: {}", quotaConsumed);
+    // store the quota consumed value in the working map to use in a subsequent step
+    workingMap.put(ImputationJobMapKeys.QUOTA_CONSUMED, quotaConsumed);
 
     return StepResult.getStepResultSuccess();
   }

--- a/service/src/main/java/bio/terra/pipelines/stairway/FetchQuotaConsumedFromDataTableStep.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/FetchQuotaConsumedFromDataTableStep.java
@@ -24,7 +24,6 @@ public class FetchQuotaConsumedFromDataTableStep implements Step {
 
   private final RawlsService rawlsService;
   private final SamService samService;
-  private final Logger logger = LoggerFactory.getLogger(FetchQuotaConsumedFromDataTableStep.class);
 
   public FetchQuotaConsumedFromDataTableStep(RawlsService rawlsService, SamService samService) {
     this.rawlsService = rawlsService;

--- a/service/src/main/java/bio/terra/pipelines/stairway/FetchQuotaConsumedFromDataTableStep.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/FetchQuotaConsumedFromDataTableStep.java
@@ -49,7 +49,6 @@ public class FetchQuotaConsumedFromDataTableStep implements Step {
         inputParameters.get(ImputationJobMapKeys.CONTROL_WORKSPACE_NAME, String.class);
     PipelinesEnum pipelineName = inputParameters.get(JobMapKeys.PIPELINE_NAME, PipelinesEnum.class);
 
-    // validate and extract parameters from working map
     FlightMap workingMap = flightContext.getWorkingMap();
 
     Entity entity;

--- a/service/src/main/java/bio/terra/pipelines/stairway/QuotaConsumedValidationStep.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/QuotaConsumedValidationStep.java
@@ -42,7 +42,8 @@ public class QuotaConsumedValidationStep implements Step {
     FlightUtils.validateRequiredEntries(workingMap, ImputationJobMapKeys.QUOTA_CONSUMED);
 
     // check if user quota used plus quota consumed is less than or equal to user quota
-    int quotaUsedForThisRun = workingMap.get(ImputationJobMapKeys.QUOTA_CONSUMED, Integer.class);
+    Integer quotaUsedForThisRun =
+        workingMap.get(ImputationJobMapKeys.QUOTA_CONSUMED, Integer.class);
     UserQuota userQuota = quotasService.getQuotaForUserAndPipeline(userId, pipelineName);
 
     // user quota has been exceeded, fail the flight

--- a/service/src/main/java/bio/terra/pipelines/stairway/QuotaConsumedValidationStep.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/QuotaConsumedValidationStep.java
@@ -28,7 +28,6 @@ public class QuotaConsumedValidationStep implements Step {
       "java:S2259") // suppress warning for possible NPE when calling pipelineName.getValue(),
   //  since we do validate that pipelineName is not null in `validateRequiredEntries`
   public StepResult doStep(FlightContext flightContext) {
-    String jobId = flightContext.getFlightId();
 
     // validate and extract parameters from input map
     var inputParameters = flightContext.getInputParameters();

--- a/service/src/main/java/bio/terra/pipelines/stairway/QuotaConsumedValidationStep.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/QuotaConsumedValidationStep.java
@@ -10,7 +10,7 @@ import bio.terra.pipelines.stairway.imputation.ImputationJobMapKeys;
 import bio.terra.stairway.*;
 
 /**
- * This step validates that the quota consumed for this run does cause the user to exceed their
+ * This step validates that the quota consumed for this run does not cause the user to exceed their
  * quota limit
  *
  * <p>This step expects quota consumed to be provided in the working map
@@ -52,9 +52,9 @@ public class QuotaConsumedValidationStep implements Step {
           StepStatus.STEP_RESULT_FAILURE_FATAL,
           new BadRequestException(
               String.format(
-                  "User quota exceeded for pipeline %s. User quota: %d, Quota consumed so far: %d, Quota consumed for"
-                      + " this run: %d.  If you would like to request a quota increase, you can email "
-                      + "teaspoons-developers@broadinstitute.org ",
+                  "User quota exceeded for pipeline %s. User quota limit: %d, Quota consumed before this run: %d, "
+                      + "Quota consumed for this run: %d.  If you would like to request a quota increase, you can "
+                      + "email teaspoons-developers@broadinstitute.org",
                   pipelineName.getValue(),
                   userQuota.getQuota(),
                   userQuota.getQuotaConsumed(),

--- a/service/src/main/java/bio/terra/pipelines/stairway/QuotaConsumedValidationStep.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/QuotaConsumedValidationStep.java
@@ -1,80 +1,81 @@
 package bio.terra.pipelines.stairway;
 
 import bio.terra.common.exception.BadRequestException;
-import bio.terra.common.exception.InternalServerErrorException;
 import bio.terra.pipelines.common.utils.FlightUtils;
 import bio.terra.pipelines.common.utils.PipelinesEnum;
 import bio.terra.pipelines.db.entities.UserQuota;
-import bio.terra.pipelines.dependencies.rawls.RawlsService;
-import bio.terra.pipelines.dependencies.rawls.RawlsServiceApiException;
-import bio.terra.pipelines.dependencies.sam.SamService;
 import bio.terra.pipelines.dependencies.stairway.JobMapKeys;
 import bio.terra.pipelines.service.QuotasService;
 import bio.terra.pipelines.stairway.imputation.ImputationJobMapKeys;
-import bio.terra.rawls.model.Entity;
 import bio.terra.stairway.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * This step calls Rawls to fetch outputs from a data table row for a given quota consumed job. It
  * specifically fetches the quota consumed value from the data table row using the quota_consumed
- * key.  If successful, it stores the quota consumed value in the working map.
+ * key. If successful, it stores the quota consumed value in the working map.
  *
  * <p>This step expects quota consumed to be provided in the working map
  */
 public class QuotaConsumedValidationStep implements Step {
+  private final QuotasService quotasService;
 
-    private final RawlsService rawlsService;
-    private final SamService samService;
-    private final QuotasService quotasService;
-    private final Logger logger = LoggerFactory.getLogger(FetchQuotaConsumedFromDataTableStep.class);
+  public QuotaConsumedValidationStep(QuotasService quotasService) {
+    this.quotasService = quotasService;
+  }
 
-    public QuotaConsumedValidationStep(RawlsService rawlsService, SamService samService, QuotasService quotasService) {
-        this.rawlsService = rawlsService;
-        this.samService = samService;
-        this.quotasService = quotasService;
+  @Override
+  @SuppressWarnings(
+      "java:S2259") // suppress warning for possible NPE when calling pipelineName.getValue(),
+  //  since we do validate that pipelineName is not null in `validateRequiredEntries`
+  public StepResult doStep(FlightContext flightContext) {
+    String jobId = flightContext.getFlightId();
+
+    // validate and extract parameters from input map
+    var inputParameters = flightContext.getInputParameters();
+    FlightUtils.validateRequiredEntries(
+        inputParameters, JobMapKeys.PIPELINE_NAME, JobMapKeys.USER_ID);
+
+    PipelinesEnum pipelineName = inputParameters.get(JobMapKeys.PIPELINE_NAME, PipelinesEnum.class);
+    String userId = inputParameters.get(JobMapKeys.USER_ID, String.class);
+
+    // validate and extract parameters from working map
+    FlightMap workingMap = flightContext.getWorkingMap();
+    FlightUtils.validateRequiredEntries(workingMap, ImputationJobMapKeys.QUOTA_CONSUMED);
+
+    // check if user quota used plus quota consumed is less than or equal to user quota
+    int quotaUsedForThisRun = workingMap.get(ImputationJobMapKeys.QUOTA_CONSUMED, Integer.class);
+    UserQuota userQuota = quotasService.getQuotaForUserAndPipeline(userId, pipelineName);
+
+    // user quota has been exceeded, fail the flight
+    int totalQuotaConsumed = userQuota.getQuotaConsumed() + quotaUsedForThisRun;
+    if (totalQuotaConsumed > userQuota.getQuota()) {
+      return new StepResult(
+          StepStatus.STEP_RESULT_FAILURE_FATAL,
+          new BadRequestException("User quota exceeded for pipeline " + pipelineName.getValue()));
     }
+    // quota has not been exceeded, update user quota consumed
+    quotasService.updateQuotaConsumed(userQuota, totalQuotaConsumed);
 
-    @Override
-    @SuppressWarnings(
-            "java:S2259") // suppress warning for possible NPE when calling pipelineName.getValue(),
-    //  since we do validate that pipelineName is not null in `validateRequiredEntries`
-    public StepResult doStep(FlightContext flightContext) {
-        String jobId = flightContext.getFlightId();
+    return StepResult.getStepResultSuccess();
+  }
 
-        // validate and extract parameters from input map
-        var inputParameters = flightContext.getInputParameters();
-        FlightUtils.validateRequiredEntries(
-                inputParameters,
-                JobMapKeys.PIPELINE_NAME,
-                JobMapKeys.USER_ID);
+  // Undo the increase in quota consumed
+  @Override
+  public StepResult undoStep(FlightContext flightContext) {
+    // grab variable needed
+    var inputParameters = flightContext.getInputParameters();
+    PipelinesEnum pipelineName = inputParameters.get(JobMapKeys.PIPELINE_NAME, PipelinesEnum.class);
 
-        PipelinesEnum pipelineName = inputParameters.get(JobMapKeys.PIPELINE_NAME, PipelinesEnum.class);
-        String userId = inputParameters.get(JobMapKeys.USER_ID, String.class);
+    String userId = inputParameters.get(JobMapKeys.USER_ID, String.class);
+    FlightMap workingMap = flightContext.getWorkingMap();
 
-        // validate and extract parameters from working map
-        FlightMap workingMap = flightContext.getWorkingMap();
-        FlightUtils.validateRequiredEntries(
-                workingMap,
-                ImputationJobMapKeys.QUOTA_CONSUMED);
+    // update the user quota to be what it was before this run's quota was added
+    int quotaUsedForThisRun = workingMap.get(ImputationJobMapKeys.QUOTA_CONSUMED, Integer.class);
 
-        // check if user quota used plus quota consumed is less than or equal to user quota
-        int quotaConsumed = workingMap.get(ImputationJobMapKeys.QUOTA_CONSUMED, Integer.class);
-        UserQuota userQuota = quotasService.getQuotaForUserAndPipeline(userId, pipelineName);
+    UserQuota userQuota = quotasService.getQuotaForUserAndPipeline(userId, pipelineName);
 
-        // user quota has been exceeded, fail the flight
-        if(userQuota.getQuotaConsumed() + quotaConsumed > userQuota.getQuota()) {
-            return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, new BadRequestException("User quota exceeded for pipeline " + pipelineName.getValue()));
-        }
-        // quota has not been exceeded, update user quota consumed
-
-        return StepResult.getStepResultSuccess();
-    }
-
-    @Override
-    public StepResult undoStep(FlightContext flightContext) {
-        // nothing to undo
-        return StepResult.getStepResultSuccess();
-    }
+    quotasService.updateQuotaConsumed(
+        userQuota, userQuota.getQuotaConsumed() - quotaUsedForThisRun);
+    return StepResult.getStepResultSuccess();
+  }
 }

--- a/service/src/main/java/bio/terra/pipelines/stairway/QuotaConsumedValidationStep.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/QuotaConsumedValidationStep.java
@@ -1,0 +1,89 @@
+package bio.terra.pipelines.stairway;
+
+import bio.terra.common.exception.InternalServerErrorException;
+import bio.terra.pipelines.common.utils.FlightUtils;
+import bio.terra.pipelines.common.utils.PipelinesEnum;
+import bio.terra.pipelines.dependencies.rawls.RawlsService;
+import bio.terra.pipelines.dependencies.rawls.RawlsServiceApiException;
+import bio.terra.pipelines.dependencies.sam.SamService;
+import bio.terra.pipelines.dependencies.stairway.JobMapKeys;
+import bio.terra.pipelines.service.QuotasService;
+import bio.terra.pipelines.stairway.imputation.ImputationJobMapKeys;
+import bio.terra.rawls.model.Entity;
+import bio.terra.stairway.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This step calls Rawls to fetch outputs from a data table row for a given quota consumed job. It
+ * specifically fetches the quota consumed value from the data table row using the quota_consumed
+ * key.  If successful, it stores the quota consumed value in the working map.
+ *
+ * <p>This step expects quota consumed to be provided in the working map
+ */
+public class QuotaConsumedValidationStep implements Step {
+
+    private final RawlsService rawlsService;
+    private final SamService samService;
+    private final QuotasService quotasService;
+    private final Logger logger = LoggerFactory.getLogger(FetchQuotaConsumedFromDataTableStep.class);
+
+    public QuotaConsumedValidationStep(RawlsService rawlsService, SamService samService, QuotasService quotasService) {
+        this.rawlsService = rawlsService;
+        this.samService = samService;
+        this.quotasService = quotasService;
+    }
+
+    @Override
+    @SuppressWarnings(
+            "java:S2259") // suppress warning for possible NPE when calling pipelineName.getValue(),
+    //  since we do validate that pipelineName is not null in `validateRequiredEntries`
+    public StepResult doStep(FlightContext flightContext) {
+        String jobId = flightContext.getFlightId();
+
+        // validate and extract parameters from input map
+        var inputParameters = flightContext.getInputParameters();
+        FlightUtils.validateRequiredEntries(
+                inputParameters,
+                JobMapKeys.PIPELINE_NAME,
+                JobMapKeys.USER_ID);
+
+        PipelinesEnum pipelineName = inputParameters.get(JobMapKeys.PIPELINE_NAME, PipelinesEnum.class);
+        String userId = inputParameters.get(JobMapKeys.USER_ID, String.class);
+
+        // validate and extract parameters from working map
+        FlightMap workingMap = flightContext.getWorkingMap();
+        FlightUtils.validateRequiredEntries(
+                workingMap,
+                ImputationJobMapKeys.QUOTA_CONSUMED);
+
+        int quotaConsumed = workingMap.get(ImputationJobMapKeys.QUOTA_CONSUMED, Integer.class);
+
+        Entity entity = new Entity();
+
+        // extract quota_consumed from entity
+        try {
+            quotaConsumed = (int) entity.getAttributes().get("quota_consumed");
+            if (quotaConsumed <= 0) {
+                return new StepResult(
+                        StepStatus.STEP_RESULT_FAILURE_FATAL,
+                        new InternalServerErrorException("Quota consumed is unexpectedly not greater than 0"));
+            }
+        } catch (NullPointerException e) {
+            return new StepResult(
+                    StepStatus.STEP_RESULT_FAILURE_FATAL,
+                    new InternalServerErrorException("Quota consumed is unexpectedly null"));
+        }
+
+        // store the quota consumed value in the working map to use in a subsequent step
+        workingMap.put(ImputationJobMapKeys.QUOTA_CONSUMED, quotaConsumed);
+
+        return StepResult.getStepResultSuccess();
+    }
+
+    @Override
+    public StepResult undoStep(FlightContext flightContext) {
+        // nothing to undo
+        return StepResult.getStepResultSuccess();
+    }
+}

--- a/service/src/main/java/bio/terra/pipelines/stairway/imputation/ImputationJobMapKeys.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/imputation/ImputationJobMapKeys.java
@@ -19,6 +19,7 @@ public class ImputationJobMapKeys {
   public static final String CONTROL_WORKSPACE_NAME = "control_workspace_name";
   public static final String SUBMISSION_ID = "submission_id";
   public static final String QUOTA_SUBMISSION_ID = "quota_submission_id";
+  public static final String QUOTA_CONSUMED = "quota_consumed";
 
   // Azure specific keys
   public static final String CONTROL_WORKSPACE_ID = "control_workspace_id";

--- a/service/src/main/java/bio/terra/pipelines/stairway/imputation/RunImputationGcpJobFlight.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/imputation/RunImputationGcpJobFlight.java
@@ -7,6 +7,7 @@ import bio.terra.pipelines.common.utils.PipelinesEnum;
 import bio.terra.pipelines.dependencies.stairway.JobMapKeys;
 import bio.terra.pipelines.stairway.FetchQuotaConsumedFromDataTableStep;
 import bio.terra.pipelines.stairway.PollQuotaConsumedSubmissionStatusStep;
+import bio.terra.pipelines.stairway.QuotaConsumedValidationStep;
 import bio.terra.pipelines.stairway.SubmitQuotaConsumedSubmissionStep;
 import bio.terra.pipelines.stairway.imputation.steps.CompletePipelineRunStep;
 import bio.terra.pipelines.stairway.imputation.steps.PrepareImputationInputsStep;
@@ -94,6 +95,8 @@ public class RunImputationGcpJobFlight extends Flight {
         new FetchQuotaConsumedFromDataTableStep(
             flightBeanBag.getRawlsService(), flightBeanBag.getSamService()),
         externalServiceRetryRule);
+
+    addStep(new QuotaConsumedValidationStep(flightBeanBag.getQuotasService()), dbRetryRule);
 
     addStep(
         new SubmitCromwellSubmissionStep(

--- a/service/src/test/java/bio/terra/pipelines/common/utils/FlightBeanBagTest.java
+++ b/service/src/test/java/bio/terra/pipelines/common/utils/FlightBeanBagTest.java
@@ -14,6 +14,7 @@ import bio.terra.pipelines.dependencies.workspacemanager.WorkspaceManagerService
 import bio.terra.pipelines.service.PipelineInputsOutputsService;
 import bio.terra.pipelines.service.PipelineRunsService;
 import bio.terra.pipelines.service.PipelinesService;
+import bio.terra.pipelines.service.QuotasService;
 import bio.terra.pipelines.testutils.BaseEmbeddedDbTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -29,6 +30,7 @@ class FlightBeanBagTest extends BaseEmbeddedDbTest {
   @Autowired private CbasService cbasService;
   @Autowired private WorkspaceManagerService workspaceManagerService;
   @Autowired private RawlsService rawlsService;
+  @Autowired private QuotasService quotasService;
   @Autowired private ImputationConfiguration imputationConfiguration;
   @Autowired private CbasConfiguration cbasConfiguration;
   @Autowired private WdlPipelineConfiguration wdlPipelineConfiguration;
@@ -45,6 +47,7 @@ class FlightBeanBagTest extends BaseEmbeddedDbTest {
             wdsService,
             cbasService,
             rawlsService,
+            quotasService,
             workspaceManagerService,
             imputationConfiguration,
             cbasConfiguration,
@@ -58,6 +61,7 @@ class FlightBeanBagTest extends BaseEmbeddedDbTest {
     assertEquals(cbasService, flightBeanBag.getCbasService());
     assertEquals(workspaceManagerService, flightBeanBag.getWorkspaceManagerService());
     assertEquals(rawlsService, flightBeanBag.getRawlsService());
+    assertEquals(quotasService, flightBeanBag.getQuotasService());
     assertEquals(imputationConfiguration, flightBeanBag.getImputationConfiguration());
     assertEquals(cbasConfiguration, flightBeanBag.getCbasConfiguration());
     assertEquals(wdlPipelineConfiguration, flightBeanBag.getWdlPipelineConfiguration());

--- a/service/src/test/java/bio/terra/pipelines/stairway/FetchQuotaConsumedFromDataTableStepTest.java
+++ b/service/src/test/java/bio/terra/pipelines/stairway/FetchQuotaConsumedFromDataTableStepTest.java
@@ -1,4 +1,4 @@
-package bio.terra.pipelines.stairway.imputation.steps;
+package bio.terra.pipelines.stairway;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
@@ -9,7 +9,7 @@ import bio.terra.pipelines.dependencies.rawls.RawlsService;
 import bio.terra.pipelines.dependencies.rawls.RawlsServiceApiException;
 import bio.terra.pipelines.dependencies.rawls.RawlsServiceException;
 import bio.terra.pipelines.dependencies.sam.SamService;
-import bio.terra.pipelines.stairway.FetchQuotaConsumedFromDataTableStep;
+import bio.terra.pipelines.stairway.imputation.ImputationJobMapKeys;
 import bio.terra.pipelines.testutils.BaseEmbeddedDbTest;
 import bio.terra.pipelines.testutils.StairwayTestUtils;
 import bio.terra.pipelines.testutils.TestUtils;
@@ -47,7 +47,8 @@ class FetchQuotaConsumedFromDataTableStepTest extends BaseEmbeddedDbTest {
     when(flightContext.getFlightId()).thenReturn(TestUtils.TEST_NEW_UUID.toString());
 
     // outputs to match the test output definitions
-    Map<String, Object> entityAttributes = new HashMap<>(Map.of("quota_consumed", 1));
+    int quotaConsumed = 15;
+    Map<String, Object> entityAttributes = new HashMap<>(Map.of("quota_consumed", quotaConsumed));
     Entity entity = new Entity().attributes(entityAttributes);
 
     when(rawlsService.getDataTableEntity(
@@ -63,6 +64,10 @@ class FetchQuotaConsumedFromDataTableStepTest extends BaseEmbeddedDbTest {
     StepResult result = fetchQuotaConsumedFromDataTableStep.doStep(flightContext);
 
     assertEquals(StepStatus.STEP_RESULT_SUCCESS, result.getStepStatus());
+
+    assertEquals(
+        quotaConsumed,
+        flightContext.getWorkingMap().get(ImputationJobMapKeys.QUOTA_CONSUMED, Integer.class));
   }
 
   @Test

--- a/service/src/test/java/bio/terra/pipelines/stairway/PollQuotaConsumedSubmissionStatusStepTest.java
+++ b/service/src/test/java/bio/terra/pipelines/stairway/PollQuotaConsumedSubmissionStatusStepTest.java
@@ -1,4 +1,4 @@
-package bio.terra.pipelines.stairway.imputation.steps;
+package bio.terra.pipelines.stairway;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
@@ -7,7 +7,6 @@ import bio.terra.pipelines.app.configuration.internal.WdlPipelineConfiguration;
 import bio.terra.pipelines.dependencies.rawls.RawlsService;
 import bio.terra.pipelines.dependencies.rawls.RawlsServiceApiException;
 import bio.terra.pipelines.dependencies.sam.SamService;
-import bio.terra.pipelines.stairway.PollQuotaConsumedSubmissionStatusStep;
 import bio.terra.pipelines.stairway.imputation.ImputationJobMapKeys;
 import bio.terra.pipelines.testutils.BaseEmbeddedDbTest;
 import bio.terra.pipelines.testutils.StairwayTestUtils;

--- a/service/src/test/java/bio/terra/pipelines/stairway/QuotaConsumedValidationStepTest.java
+++ b/service/src/test/java/bio/terra/pipelines/stairway/QuotaConsumedValidationStepTest.java
@@ -40,7 +40,7 @@ class QuotaConsumedValidationStepTest extends BaseEmbeddedDbTest {
   }
 
   @Test
-  void doStepSuccess() throws InterruptedException {
+  void doStepSuccess() {
     // setup
     StairwayTestUtils.constructCreateJobInputs(flightContext.getInputParameters());
 
@@ -66,7 +66,7 @@ class QuotaConsumedValidationStepTest extends BaseEmbeddedDbTest {
   }
 
   @Test
-  void doStepOverQuotaLimit() throws InterruptedException {
+  void doStepOverQuotaLimit() {
     // setup
     StairwayTestUtils.constructCreateJobInputs(flightContext.getInputParameters());
     // set quota consumed in working map to above the pipeline quota limit

--- a/service/src/test/java/bio/terra/pipelines/stairway/QuotaConsumedValidationStepTest.java
+++ b/service/src/test/java/bio/terra/pipelines/stairway/QuotaConsumedValidationStepTest.java
@@ -1,0 +1,105 @@
+package bio.terra.pipelines.stairway;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+import bio.terra.pipelines.common.utils.PipelinesEnum;
+import bio.terra.pipelines.db.entities.UserQuota;
+import bio.terra.pipelines.db.repositories.PipelineQuotasRepository;
+import bio.terra.pipelines.db.repositories.UserQuotasRepository;
+import bio.terra.pipelines.service.QuotasService;
+import bio.terra.pipelines.stairway.imputation.ImputationJobMapKeys;
+import bio.terra.pipelines.testutils.BaseEmbeddedDbTest;
+import bio.terra.pipelines.testutils.StairwayTestUtils;
+import bio.terra.pipelines.testutils.TestUtils;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.StepStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class QuotaConsumedValidationStepTest extends BaseEmbeddedDbTest {
+
+  @Autowired private QuotasService quotasService;
+  @Autowired private UserQuotasRepository userQuotasRepository;
+  @Autowired private PipelineQuotasRepository pipelineQuotasRepository;
+
+  @Mock private FlightContext flightContext;
+
+  @BeforeEach
+  void setup() {
+    FlightMap inputParameters = new FlightMap();
+    FlightMap workingMap = new FlightMap();
+    workingMap.put(ImputationJobMapKeys.QUOTA_CONSUMED, 30);
+
+    when(flightContext.getInputParameters()).thenReturn(inputParameters);
+    when(flightContext.getWorkingMap()).thenReturn(workingMap);
+  }
+
+  @Test
+  void doStepSuccess() throws InterruptedException {
+    // setup
+    StairwayTestUtils.constructCreateJobInputs(flightContext.getInputParameters());
+
+    // before running make sure quota consumed for user is 0
+    UserQuota userQuota =
+        quotasService.getQuotaForUserAndPipeline(
+            TestUtils.TEST_USER_ID_1, PipelinesEnum.ARRAY_IMPUTATION);
+    assertEquals(0, userQuota.getQuotaConsumed());
+
+    // do the step
+    QuotaConsumedValidationStep quotaConsumedValidationStep =
+        new QuotaConsumedValidationStep(quotasService);
+    StepResult result = quotaConsumedValidationStep.doStep(flightContext);
+
+    // make sure the step was a success
+    assertEquals(StepStatus.STEP_RESULT_SUCCESS, result.getStepStatus());
+
+    // after running make sure quota for user is 30
+    userQuota =
+        quotasService.getQuotaForUserAndPipeline(
+            TestUtils.TEST_USER_ID_1, PipelinesEnum.ARRAY_IMPUTATION);
+    assertEquals(30, userQuota.getQuotaConsumed());
+  }
+
+  @Test
+  void doStepOverQuotaLimit() throws InterruptedException {
+    // setup
+    StairwayTestUtils.constructCreateJobInputs(flightContext.getInputParameters());
+    // set quota consumed in working map to above the pipeline quota limit
+    FlightMap workingMap = flightContext.getWorkingMap();
+    workingMap.put(ImputationJobMapKeys.QUOTA_CONSUMED, 11000);
+
+    // do the step
+    QuotaConsumedValidationStep quotaConsumedValidationStep =
+        new QuotaConsumedValidationStep(quotasService);
+    StepResult result = quotaConsumedValidationStep.doStep(flightContext);
+
+    // make sure the step was a failure
+    assertEquals(StepStatus.STEP_RESULT_FAILURE_FATAL, result.getStepStatus());
+  }
+
+  @Test
+  void undoStepSuccess() {
+    // setup user
+    StairwayTestUtils.constructCreateJobInputs(flightContext.getInputParameters());
+    // create a user quotas row with 50 quota consumed
+    userQuotasRepository.save(
+        new UserQuota(PipelinesEnum.ARRAY_IMPUTATION, TestUtils.TEST_USER_ID_1, 10000, 50));
+
+    // make sure quota consumed is updated properly for undoStep
+    QuotaConsumedValidationStep quotaConsumedValidationStep =
+        new QuotaConsumedValidationStep(quotasService);
+    StepResult result = quotaConsumedValidationStep.undoStep(flightContext);
+
+    assertEquals(StepStatus.STEP_RESULT_SUCCESS, result.getStepStatus());
+    // the working map has 30 quota consumed, so the user quota consumed should be 50 - 30 = 20
+    UserQuota userQuota =
+        quotasService.getQuotaForUserAndPipeline(
+            TestUtils.TEST_USER_ID_1, PipelinesEnum.ARRAY_IMPUTATION);
+    assertEquals(20, userQuota.getQuotaConsumed());
+  }
+}

--- a/service/src/test/java/bio/terra/pipelines/stairway/SubmitQuotaConsumedSubmissionStepTest.java
+++ b/service/src/test/java/bio/terra/pipelines/stairway/SubmitQuotaConsumedSubmissionStepTest.java
@@ -1,4 +1,4 @@
-package bio.terra.pipelines.stairway.imputation.steps;
+package bio.terra.pipelines.stairway;
 
 import static bio.terra.pipelines.testutils.TestUtils.VALID_METHOD_CONFIGURATION;
 import static org.junit.jupiter.api.Assertions.*;
@@ -11,7 +11,6 @@ import bio.terra.pipelines.common.utils.PipelinesEnum;
 import bio.terra.pipelines.dependencies.rawls.RawlsService;
 import bio.terra.pipelines.dependencies.rawls.RawlsServiceApiException;
 import bio.terra.pipelines.dependencies.sam.SamService;
-import bio.terra.pipelines.stairway.SubmitQuotaConsumedSubmissionStep;
 import bio.terra.pipelines.stairway.imputation.ImputationJobMapKeys;
 import bio.terra.pipelines.testutils.BaseEmbeddedDbTest;
 import bio.terra.pipelines.testutils.StairwayTestUtils;

--- a/service/src/test/java/bio/terra/pipelines/stairway/imputation/RunImputationGcpFlightTest.java
+++ b/service/src/test/java/bio/terra/pipelines/stairway/imputation/RunImputationGcpFlightTest.java
@@ -35,6 +35,7 @@ class RunImputationGcpFlightTest extends BaseEmbeddedDbTest {
           "SubmitQuotaConsumedSubmissionStep",
           "PollQuotaConsumedSubmissionStatusStep",
           "FetchQuotaConsumedFromDataTableStep",
+          "QuotaConsumedValidationStep",
           "SubmitCromwellSubmissionStep",
           "PollCromwellSubmissionStatusStep",
           "CompletePipelineRunStep",


### PR DESCRIPTION
### Description 

This pr does a few things

* if the quota consumed for the current flight plus their aggregate quota consumed is above the users quota limit, we fail the flight and not submit the imputation wdl
* if the quota consumed for the current flight plus their aggregate quota consumed is below the users quota limit, we store the quota consumed for the current flight to the user quotas table
* in case the step is undo'd, we give back the user their quota consumed for the flight

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-361