### PR TITLE
TSPS-359 add empty quota consumed wdl and make it available through dockstore

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -16,6 +16,13 @@ workflows:
         email: teaspoons-developers@broadinstitute.org
 
   - subclass: WDL
+    name: QuotaConsumedEmpty
+    primaryDescriptorPath: /pipelines/imputation/testing/QuotaConsumedEmpty.wdl
+    authors:
+      - name: Terra Scientific Services
+        email: teaspoons-developers@broadinstitute.org
+
+  - subclass: WDL
     name: StdPopSim
     primaryDescriptorPath: /pipelines/imputation/simulatedData/StdPopSim.wdl
     authors:

--- a/pipelines/imputation/testing/QuotaConsumedEmpty.wdl
+++ b/pipelines/imputation/testing/QuotaConsumedEmpty.wdl
@@ -1,0 +1,48 @@
+version 1.0
+
+workflow QuotaConsumed {
+    String pipeline_version = "0.0.1"
+
+    input {
+        Int chunkLength = 25000000
+        Int chunkOverlaps = 5000000
+
+        File multi_sample_vcf
+
+        File ref_dict
+        Array[String] contigs
+        String reference_panel_path_prefix
+        String genetic_maps_path
+        String output_basename
+        Boolean split_output_to_single_sample = false
+
+        # file extensions used to find reference panel files
+        String interval_list_suffix = ".interval_list"
+        String bref3_suffix = ".bref3"
+    }
+
+    call ReturnHardcodedInt
+
+    output {
+        Int quota_consumed = ReturnHardcodedInt.quota_consumed
+    }
+}
+
+
+task ReturnHardcodedInt {
+    String ubuntu_docker = "ubuntu:20.04"
+
+    command {
+        touch empty_file
+    }
+
+    runtime {
+        docker: ubuntu_docker
+        disk: "10 GB"
+        memory: "1000 MiB"
+        cpu: 1
+    }
+    output {
+        Int quota_consumed = 50
+    }
+}


### PR DESCRIPTION
### Description 

To keep things consistent, we want to add the quota consumed workflow that should run in the e2e test in this repo.  This is required for https://github.com/broadinstitute/dsp-reusable-workflows/pull/53 to work

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-359