### PR TITLE
[DDO-3841] Publish new versions on the `teaspoons` chart

### DIFF
--- a/.github/workflows/tag-publish.yml
+++ b/.github/workflows/tag-publish.yml
@@ -230,7 +230,7 @@ jobs:
     if: ${{ needs.bump-check.outputs.is-bump == 'no' }}
     with:
       new-version: ${{ needs.tag-job.outputs.tag }}
-      chart-name: 'tsps'
+      chart-name: 'teaspoons'
     permissions:
       contents: 'read'
       id-token: 'write'


### PR DESCRIPTION
### Description 

When reporting new container image versions to Sherlock, associate them with the `teaspoons` chart, not `tsps`. This means that:
* BEEs with the `teaspoons` chart will start picking up the latest container image version
* Changes to will now be auto-deployed to the `teaspoons` dev deployment, and not `tsps`

### Jira Ticket
https://broadworkbench.atlassian.net/browse/DDO-3841