### PR TITLE
TSPS-325 Support for adding more CLI commands

### DIFF
--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -733,7 +733,7 @@ components:
       description: |
         Object containing the job id, status, and user-provided description of a Pipeline Run.
       type: object
-      required: [ jobId, status ]
+      required: [ jobId, status, timeSubmitted ]
       properties:
         jobId:
           $ref: '#/components/schemas/Id'
@@ -741,6 +741,10 @@ components:
           $ref: "#/components/schemas/PipelineRunStatus"
         description:
           $ref: "#/components/schemas/PipelineRunDescription"
+        timeSubmitted:
+          $ref: "#/components/schemas/JobTimeSubmitted"
+        timeCompleted:
+          $ref: "#/components/schemas/JobTimeCompleted"
 
     PipelineRunDescription:
       description: |

--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -731,7 +731,7 @@ components:
 
     PipelineRun:
       description: |
-        Object containing the job id, status, and user-provided description of a Pipeline Run.
+        Object containing the job id, status, user-provided description, time submitted, and (if run is complete) time completed of a Pipeline Run.
       type: object
       required: [ jobId, status, timeSubmitted ]
       properties:

--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -733,7 +733,7 @@ components:
       description: |
         Object containing the job id, status, and user-provided description of a Pipeline Run.
       type: object
-      required: [ pipelineName, displayName, description ]
+      required: [ jobId, status ]
       properties:
         jobId:
           $ref: '#/components/schemas/Id'

--- a/service/src/main/java/bio/terra/pipelines/app/controller/PipelineRunsApiController.java
+++ b/service/src/main/java/bio/terra/pipelines/app/controller/PipelineRunsApiController.java
@@ -198,7 +198,12 @@ public class PipelineRunsApiController implements PipelineRunsApi {
                     new ApiPipelineRun()
                         .jobId(pipelineRun.getJobId())
                         .status(pipelineRun.getStatus().name())
-                        .description(pipelineRun.getDescription()))
+                        .description(pipelineRun.getDescription())
+                        .timeSubmitted(pipelineRun.getCreated().toString())
+                        .timeCompleted(
+                            pipelineRun.getStatus().isCompleted()
+                                ? pipelineRun.getUpdated().toString()
+                                : null))
             .toList();
 
     ApiGetPipelineRunsResponse apiGetPipelineRunsResponse =

--- a/service/src/main/java/bio/terra/pipelines/common/utils/CommonPipelineRunStatusEnum.java
+++ b/service/src/main/java/bio/terra/pipelines/common/utils/CommonPipelineRunStatusEnum.java
@@ -10,4 +10,8 @@ public enum CommonPipelineRunStatusEnum {
   public boolean isSuccess() {
     return this == SUCCEEDED;
   }
+
+  public boolean isCompleted() {
+    return this == SUCCEEDED || this == FAILED;
+  }
 }


### PR DESCRIPTION
### Description 

Fix an error in our openapi.yml as well as don't require the description field in the PipelineRun object returned by getAllPipelineRuns. This wasn't actually making the field required anyway in our response - the following is the response to getAllPipelineRuns *before* this change:
```
{
  "pageToken": "IyMjNDEjIyMgLSAyMDI0LTExLTIwVDEzOjE5OjMxLjQ4MTc4NQ==",
  "results": [
    {
      "jobId": "82d391bf-d5e7-49c9-819e-71b5b9584365",
      "status": "SUCCEEDED",
      "description": "local run for download testing second attempt"
    },
    {
      "jobId": "6e99d57e-977b-4464-91f3-df7c8c5c4bf0",
      "status": "PREPARING"
    },
    {
      "jobId": "3582c093-5093-4193-b9e4-62c6334a62da",
      "status": "PREPARING"
    },
```

But making it not required allows the autogenerated Python client to accept this response rather than failing it on validation when a description is not present.

Goes with CLI PR: https://github.com/DataBiosphere/terra-scientific-pipelines-service-cli/pull/14

### Jira Ticket
in support of https://broadworkbench.atlassian.net/browse/TSPS-325
