### PR TITLE
drop pipeline_name unique constraint from user_quotas table

### DIFF
--- a/service/src/main/resources/db/changelog.xml
+++ b/service/src/main/resources/db/changelog.xml
@@ -32,6 +32,7 @@
   <include file="changesets/20241030_add_pipeline_quotas.yaml" relativeToChangelogFile="true"/>
   <include file="changesets/20241103_add_user_quotas.yaml" relativeToChangelogFile="true"/>
   <include file="changesets/20241106_array_imputation_rename.yaml" relativeToChangelogFile="true"/>
+  <include file="changesets/20241121_remove_user_quota_pname_uk.yaml" relativeToChangelogFile="true"/>
 
   <include file="changesets/20240412-testdata.yaml" relativeToChangelogFile="true"/>
 

--- a/service/src/main/resources/db/changesets/20241121_remove_user_quota_pname_uk.yaml
+++ b/service/src/main/resources/db/changesets/20241121_remove_user_quota_pname_uk.yaml
@@ -1,0 +1,11 @@
+# remove pipeline_name unique key constraint from the user_quotas table
+
+databaseChangeLog:
+  -  changeSet:
+       id:  drop user quotas pipeline_name unique constraint
+       author:  js
+       changes:
+         -  dropUniqueConstraint:
+              tableName:  user_quotas
+              constraintName:  user_quotas_pipeline_name_key
+              uniqueColumns:  pipeline_name

--- a/service/src/test/java/bio/terra/pipelines/service/QuotasServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/QuotasServiceTest.java
@@ -81,7 +81,7 @@ class QuotasServiceTest extends BaseEmbeddedDbTest {
             .findByUserIdAndPipelineName(TestUtils.TEST_USER_ID_1, PipelinesEnum.ARRAY_IMPUTATION)
             .isPresent());
 
-    // call service with second user and a new row should exist in user_quotas table
+    // call service with second user to test for unique constraints
     userQuota =
         quotasService.getOrCreateQuotaForUserAndPipeline(
             TestUtils.TEST_USER_ID_2, PipelinesEnum.ARRAY_IMPUTATION);

--- a/service/src/test/java/bio/terra/pipelines/service/QuotasServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/QuotasServiceTest.java
@@ -82,9 +82,14 @@ class QuotasServiceTest extends BaseEmbeddedDbTest {
             .isPresent());
 
     // call service with second user to test for unique constraints
-    userQuota =
-        quotasService.getOrCreateQuotaForUserAndPipeline(
-            TestUtils.TEST_USER_ID_2, PipelinesEnum.ARRAY_IMPUTATION);
+    quotasService.getOrCreateQuotaForUserAndPipeline(
+        TestUtils.TEST_USER_ID_2, PipelinesEnum.ARRAY_IMPUTATION);
+
+    // assert user + pipeline exists in the user_quotas table for the second user
+    assertTrue(
+        userQuotasRepository
+            .findByUserIdAndPipelineName(TestUtils.TEST_USER_ID_2, PipelinesEnum.ARRAY_IMPUTATION)
+            .isPresent());
   }
 
   UserQuota createAndSaveUserQuota(

--- a/service/src/test/java/bio/terra/pipelines/service/QuotasServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/QuotasServiceTest.java
@@ -52,7 +52,7 @@ class QuotasServiceTest extends BaseEmbeddedDbTest {
   }
 
   @Test
-  void addRowForNonExistentUserQuota() {
+  void addRowForNonExistentUserQuotaAndSecondUser() {
     // assert nothing exists in the user_quotas table
     assertTrue(
         userQuotasRepository
@@ -80,6 +80,11 @@ class QuotasServiceTest extends BaseEmbeddedDbTest {
         userQuotasRepository
             .findByUserIdAndPipelineName(TestUtils.TEST_USER_ID_1, PipelinesEnum.ARRAY_IMPUTATION)
             .isPresent());
+
+    // call service with second user and a new row should exist in user_quotas table
+    userQuota =
+        quotasService.getOrCreateQuotaForUserAndPipeline(
+            TestUtils.TEST_USER_ID_2, PipelinesEnum.ARRAY_IMPUTATION);
   }
 
   UserQuota createAndSaveUserQuota(


### PR DESCRIPTION
### Description 

Fixing an issue that morgan found with the user_quotas table.  There is no reason for there to be a unique constraint on the pipeline name column of the user quotas table

added a test to make sure this is workign as intended

### Jira Ticket
