### PR TITLE
TSPS-381 Address PREPARING job response for result endpoint 

### DIFF
--- a/service/src/main/java/bio/terra/pipelines/app/controller/PipelineRunsApiController.java
+++ b/service/src/main/java/bio/terra/pipelines/app/controller/PipelineRunsApiController.java
@@ -1,10 +1,12 @@
 package bio.terra.pipelines.app.controller;
 
+import bio.terra.common.exception.BadRequestException;
 import bio.terra.common.exception.NotFoundException;
 import bio.terra.common.iam.SamUser;
 import bio.terra.common.iam.SamUserFactory;
 import bio.terra.pipelines.app.configuration.external.IngressConfiguration;
 import bio.terra.pipelines.app.configuration.external.SamConfiguration;
+import bio.terra.pipelines.common.utils.CommonPipelineRunStatusEnum;
 import bio.terra.pipelines.common.utils.PipelinesEnum;
 import bio.terra.pipelines.common.utils.pagination.PageResponse;
 import bio.terra.pipelines.db.entities.Pipeline;
@@ -160,6 +162,12 @@ public class PipelineRunsApiController implements PipelineRunsApi {
       throw new NotFoundException("Pipeline run %s not found".formatted(jobId));
     }
 
+    if (pipelineRun.getStatus().equals(CommonPipelineRunStatusEnum.PREPARING)) {
+      throw new BadRequestException(
+          "Pipeline run %s is still preparing, it has to be started before you can query the result"
+              .formatted(jobId));
+    }
+
     Pipeline pipeline = pipelinesService.getPipelineById(pipelineRun.getPipelineId());
 
     ApiAsyncPipelineRunResponse runResponse = pipelineRunToApi(pipelineRun, pipeline);
@@ -235,6 +243,8 @@ public class PipelineRunsApiController implements PipelineRunsApi {
                 pipelineRun
                     .getWdlMethodVersion())); // wdlMethodVersion comes from pipelineRun, since the
     // pipeline might have been updated since the pipelineRun began
+
+    // if the pipeline run is successful, return the job report and add outputs to the response
     if (pipelineRun.getStatus().isSuccess()) {
       return response
           .jobReport(

--- a/service/src/test/java/bio/terra/pipelines/controller/PipelineRunsApiControllerTest.java
+++ b/service/src/test/java/bio/terra/pipelines/controller/PipelineRunsApiControllerTest.java
@@ -13,6 +13,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import bio.terra.common.exception.BadRequestException;
 import bio.terra.common.exception.NotFoundException;
 import bio.terra.common.exception.ValidationException;
 import bio.terra.common.iam.BearerTokenFactory;
@@ -523,6 +524,23 @@ class PipelineRunsApiControllerTest {
     assertEquals(testPipelineWdlMethodVersion, pipelineRunReportResponse.getWdlMethodVersion());
     assertNull(pipelineRunReportResponse.getOutputs());
     assertNull(response.getErrorReport());
+  }
+
+  @Test
+  void getPipelineRunResultPreparing() throws Exception {
+    String pipelineName = PipelinesEnum.ARRAY_IMPUTATION.getValue();
+    String jobIdString = newJobId.toString();
+    PipelineRun pipelineRun = getPipelineRunPreparing();
+
+    // the mocks
+    when(pipelineRunsServiceMock.getPipelineRun(newJobId, testUser.getSubjectId()))
+        .thenReturn(pipelineRun);
+
+    mockMvc
+        .perform(get(String.format("/api/pipelineruns/v1/%s/result/%s", pipelineName, jobIdString)))
+        .andExpect(status().isBadRequest())
+        .andExpect(
+            result -> assertInstanceOf(BadRequestException.class, result.getResolvedException()));
   }
 
   @Test


### PR DESCRIPTION
### Description 

I dont this endpoint should actually return a successful response for PREPARING jobs because nothing has been run yet.  I think this is the best way to handle that scenario by guiding the user down the correct path.

![Screenshot 2024-11-26 at 1 05 29 AM](https://github.com/user-attachments/assets/a216d1e8-c474-4319-9867-da817f550268)


### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-381