### PR TITLE
TSPS-362 try removing VERSION_SUFFIX line from tag github step

### DIFF
--- a/.github/workflows/tag-publish.yml
+++ b/.github/workflows/tag-publish.yml
@@ -103,7 +103,6 @@ jobs:
           RELEASE_BRANCHES: main
           VERSION_FILE_PATH: settings.gradle
           VERSION_LINE_MATCH: "^gradle.ext.releaseVersion\\s*=\\s*\".*\""
-          VERSION_SUFFIX: SNAPSHOT
 
       - name: Generate tag for Java resources, version for Python, and checkout-ref to use in subsequent jobs
         id: generate-params


### PR DESCRIPTION
### Description 

Want to release this to see what it does to the version endpoint response.  I think this will make it so all deployments, even local not have a `-VERSION` suffix which may not be what we want

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-362