### PR TITLE
TSPS-382 remove pipelineName from serveral APIs that dont need it

### DIFF
--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -129,9 +129,7 @@ paths:
           $ref: '#/components/responses/ServerError'
 
   # pipeline run related APIs
-  /api/pipelineruns/v1/{pipelineName}/prepare:
-    parameters:
-      - $ref: '#/components/parameters/PipelineName'
+  /api/pipelineruns/v1/prepare:
     post:
       summary: Prepare a new pipeline run
       operationId: preparePipelineRun
@@ -156,9 +154,7 @@ paths:
         500:
           $ref: '#/components/responses/ServerError'
 
-  /api/pipelineruns/v1/{pipelineName}/start:
-    parameters:
-      - $ref: '#/components/parameters/PipelineName'
+  /api/pipelineruns/v1/start:
     post:
       summary: Start a prepared pipeline run
       operationId: startPipelineRun
@@ -732,10 +728,12 @@ components:
       description: |
         Object containing the job id, status, user-provided description, time submitted, and (if run is complete) time completed of a Pipeline Run.
       type: object
-      required: [ jobId, status, timeSubmitted ]
+      required: [ jobId, pipelineName, status, timeSubmitted ]
       properties:
         jobId:
           $ref: '#/components/schemas/Id'
+        pipelineName:
+          $ref: "#/components/schemas/PipelineName"
         status:
           $ref: "#/components/schemas/PipelineRunStatus"
         description:
@@ -872,10 +870,12 @@ components:
       description: |
         Object containing the user-provided information defining a pipeline run request.
       type: object
-      required: [ jobId, pipelineVersion, pipelineInputs ]
+      required: [ jobId, pipelineName, pipelineVersion, pipelineInputs ]
       properties:
         jobId:
           $ref: '#/components/schemas/Id'
+        pipelineName:
+          $ref: "#/components/schemas/PipelineName"
         pipelineVersion:
           $ref: "#/components/schemas/PipelineVersion"
         pipelineInputs:

--- a/service/src/test/java/bio/terra/pipelines/controller/PipelineRunsApiControllerTest.java
+++ b/service/src/test/java/bio/terra/pipelines/controller/PipelineRunsApiControllerTest.java
@@ -335,8 +335,8 @@ class PipelineRunsApiControllerTest {
         .andExpect(
             MockMvcResultMatchers.jsonPath("$.message")
                 .value(
-                    "JSON parse error: Cannot deserialize value of type `java.util.UUID`"
-                        + " from String \"this-is-not-a-uuid\": UUID has to be represented by "
+                    "JSON parse error: Cannot deserialize value of type `java.util.UUID` "
+                        + "from String \"this-is-not-a-uuid\": UUID has to be represented by "
                         + "standard 36-char representation"));
   }
 

--- a/service/src/test/java/bio/terra/pipelines/controller/PipelineRunsApiControllerTest.java
+++ b/service/src/test/java/bio/terra/pipelines/controller/PipelineRunsApiControllerTest.java
@@ -265,7 +265,6 @@ class PipelineRunsApiControllerTest {
 
   @Test
   void startPipelineRunMissingJobControl() throws Exception {
-    String pipelineName = PipelinesEnum.ARRAY_IMPUTATION.getValue();
     ApiStartPipelineRunRequestBody postBody =
         new ApiStartPipelineRunRequestBody()
             .description("description for testCreateJobMissingJobId");
@@ -290,7 +289,6 @@ class PipelineRunsApiControllerTest {
 
   @Test
   void startPipelineRunMissingJobId() throws Exception {
-    String pipelineName = PipelinesEnum.ARRAY_IMPUTATION.getValue();
     ApiJobControl apiJobControl = new ApiJobControl();
     ApiStartPipelineRunRequestBody postBody =
         new ApiStartPipelineRunRequestBody()
@@ -318,7 +316,6 @@ class PipelineRunsApiControllerTest {
 
   @Test
   void startPipelineRunBadJobId() throws Exception {
-    String pipelineName = PipelinesEnum.ARRAY_IMPUTATION.getValue();
     String postBodyAsJson =
         testStartPipelineRunPostBody(
             "this-is-not-a-uuid", "description for testCreateJobMissingJobId");
@@ -338,7 +335,9 @@ class PipelineRunsApiControllerTest {
         .andExpect(
             MockMvcResultMatchers.jsonPath("$.message")
                 .value(
-                    "JSON parse error: Cannot deserialize value of type `java.util.UUID` from String \"this-is-not-a-uuid\": UUID has to be represented by standard 36-char representation"));
+                    "JSON parse error: Cannot deserialize value of type `java.util.UUID`"
+                        + " from String \"this-is-not-a-uuid\": UUID has to be represented by "
+                        + "standard 36-char representation"));
   }
 
   @Test

--- a/service/src/test/java/bio/terra/pipelines/controller/PipelineRunsApiControllerTest.java
+++ b/service/src/test/java/bio/terra/pipelines/controller/PipelineRunsApiControllerTest.java
@@ -523,7 +523,6 @@ class PipelineRunsApiControllerTest {
 
   @Test
   void getPipelineRunResultPreparing() throws Exception {
-    String pipelineName = PipelinesEnum.ARRAY_IMPUTATION.getValue();
     String jobIdString = newJobId.toString();
     PipelineRun pipelineRun = getPipelineRunPreparing();
 
@@ -532,7 +531,7 @@ class PipelineRunsApiControllerTest {
         .thenReturn(pipelineRun);
 
     mockMvc
-        .perform(get(String.format("/api/pipelineruns/v1/%s/result/%s", pipelineName, jobIdString)))
+        .perform(get(String.format("/api/pipelineruns/v1/result/%s", jobIdString)))
         .andExpect(status().isBadRequest())
         .andExpect(
             result -> assertInstanceOf(BadRequestException.class, result.getResolvedException()));

--- a/service/src/test/java/bio/terra/pipelines/testutils/MockMvcUtils.java
+++ b/service/src/test/java/bio/terra/pipelines/testutils/MockMvcUtils.java
@@ -75,7 +75,7 @@ public class MockMvcUtils {
             TEST_WORKSPACE_GOOGLE_PROJECT,
             TestUtils.TEST_PIPELINE_INPUTS_DEFINITION_LIST,
             TestUtils.TEST_PIPELINE_OUTPUTS_DEFINITION_LIST);
-    testPipeline.setId(2L);
+    testPipeline.setId(TestUtils.TEST_PIPELINE_ID_1);
     return testPipeline;
   }
 


### PR DESCRIPTION
### Description 

Note this does not change the result endpoint because that is being changed in https://github.com/DataBiosphere/terra-scientific-pipelines-service/pull/166 .  This PR also adds the pipeline name to the response of getAllPipelineRuns

![Screenshot 2024-12-02 at 1 03 46 PM](https://github.com/user-attachments/assets/6dc55785-0e23-44bf-aa04-22e810c21a91)



![Screenshot 2024-11-26 at 11 56 33 AM](https://github.com/user-attachments/assets/01f78814-62a8-4840-97cc-507d744b13fd)


### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-382