### PR TITLE
TSPS-375 reduce signed url durations

### DIFF
--- a/.github/workflows/tag-publish.yml
+++ b/.github/workflows/tag-publish.yml
@@ -172,7 +172,7 @@ jobs:
         env:
           ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
           ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
-          ARTIFACTORY_REPO_KEY: "libs-snapshot-local"
+          ARTIFACTORY_REPO_KEY: "libs-release"
 
       - name: Auth to GCP
         id: 'auth'

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -120,8 +120,8 @@ management:
       percentiles-histogram[http.server.requests]: true
 
 gcs:
-  signedUrlPutDurationHours: 24
-  signedUrlGetDurationHours: 24
+  signedUrlPutDurationHours: 8
+  signedUrlGetDurationHours: 1
 
 imputation:
   cromwellSubmissionPollingIntervalInSeconds: 600 # poll every 10 minutes for a cromwell submission

--- a/service/src/test/java/bio/terra/pipelines/configuration/external/GcsConfigurationTest.java
+++ b/service/src/test/java/bio/terra/pipelines/configuration/external/GcsConfigurationTest.java
@@ -13,7 +13,7 @@ class GcsConfigurationTest extends BaseEmbeddedDbTest {
 
   @Test
   void verifyGcsConfig() {
-    assertEquals(24L, gcsConfiguration.signedUrlGetDurationHours());
-    assertEquals(24L, gcsConfiguration.signedUrlPutDurationHours());
+    assertEquals(1L, gcsConfiguration.signedUrlGetDurationHours());
+    assertEquals(8L, gcsConfiguration.signedUrlPutDurationHours());
   }
 }

--- a/service/src/test/java/bio/terra/pipelines/dependencies/gcs/GcsServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/dependencies/gcs/GcsServiceTest.java
@@ -41,6 +41,9 @@ class GcsServiceTest extends BaseEmbeddedDbTest {
   final RetryConfiguration retryConfig = new RetryConfiguration();
   RetryTemplate template = retryConfig.listenerResetRetryTemplate();
 
+  private final Long testSignedUrlPutDuration = 8L;
+  private final Long testSignedUrlGetDuration = 1L;
+
   final Answer<Object> errorAnswer =
       invocation -> {
         throw new SocketTimeoutException("Timeout");
@@ -68,7 +71,7 @@ class GcsServiceTest extends BaseEmbeddedDbTest {
     URL fakeURL = getFakeURL();
     when(mockStorageService.signUrl(
             blobInfoCaptor.capture(),
-            eq(24L),
+            eq(testSignedUrlPutDuration),
             eq(TimeUnit.HOURS),
             any(Storage.SignUrlOption.class),
             any(Storage.SignUrlOption.class),
@@ -89,7 +92,7 @@ class GcsServiceTest extends BaseEmbeddedDbTest {
     URL fakeURL = getFakeURL();
     when(mockStorageService.signUrl(
             blobInfoCaptor.capture(),
-            eq(24L),
+            eq(testSignedUrlGetDuration),
             eq(TimeUnit.HOURS),
             any(Storage.SignUrlOption.class),
             any(Storage.SignUrlOption.class)))
@@ -109,7 +112,7 @@ class GcsServiceTest extends BaseEmbeddedDbTest {
 
     when(mockStorageService.signUrl(
             any(BlobInfo.class),
-            eq(24L),
+            eq(testSignedUrlPutDuration),
             eq(TimeUnit.HOURS),
             any(Storage.SignUrlOption.class),
             any(Storage.SignUrlOption.class),
@@ -127,7 +130,7 @@ class GcsServiceTest extends BaseEmbeddedDbTest {
 
     when(mockStorageService.signUrl(
             any(BlobInfo.class),
-            eq(24L),
+            eq(testSignedUrlPutDuration),
             eq(TimeUnit.HOURS),
             any(Storage.SignUrlOption.class),
             any(Storage.SignUrlOption.class),
@@ -148,7 +151,7 @@ class GcsServiceTest extends BaseEmbeddedDbTest {
   void storageExceptionDoNotRetry() {
     when(mockStorageService.signUrl(
             any(BlobInfo.class),
-            eq(24L),
+            eq(testSignedUrlPutDuration),
             eq(TimeUnit.HOURS),
             any(Storage.SignUrlOption.class),
             any(Storage.SignUrlOption.class),


### PR DESCRIPTION
### Description 

Reduce the duration of signed urls:
- put / upload: reduced from 24 hours to 8 hours
- get / download: reduced from 24 hours to 1 hour

Note that the user must simply begin the process (upload or download) within the active duration of the signed url; the operation does not need to complete in that time.

Also: changing our artifactory repo to `libs-release` rather than `libs-snapshot-local`

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-375
