### PR TITLE
TSPS-366 Add Content-Security-Policy header to Swagger page

### DIFF
--- a/.github/workflows/tag-publish.yml
+++ b/.github/workflows/tag-publish.yml
@@ -172,7 +172,7 @@ jobs:
         env:
           ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
           ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
-          ARTIFACTORY_REPO_KEY: "libs-release"
+          ARTIFACTORY_REPO_KEY: "libs-release-local"
 
       - name: Auth to GCP
         id: 'auth'

--- a/service/src/main/java/bio/terra/pipelines/app/controller/PublicApiController.java
+++ b/service/src/main/java/bio/terra/pipelines/app/controller/PublicApiController.java
@@ -52,19 +52,27 @@ public class PublicApiController implements PublicApi {
             .gitTag(versionProperties.getGitTag()));
   }
 
+  private static final String CSP_HEADER_NAME = "Content-Security-Policy";
+  private static final String CSP_HEADER_CONTENTS =
+      "default-src 'self'; script-src 'self' 'unsafe-inline'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; connect-src 'self'; form-action 'none';";
+
   @GetMapping(value = "/")
   public String index() {
     return "redirect:/swagger-ui.html";
   }
 
   @GetMapping({"/index.html", "/swagger-ui.html"})
-  public String getSwagger(Model model) {
+  public String getSwagger(Model model, HttpServletResponse response) {
+    response.setHeader(CSP_HEADER_NAME, CSP_HEADER_CONTENTS);
+
     model.addAttribute("clientId", oidcConfiguration.clientId());
     return "index";
   }
 
   @GetMapping(value = "/openapi.yml")
   public String getOpenApiYaml(Model model, HttpServletResponse response) {
+    response.setHeader(CSP_HEADER_NAME, CSP_HEADER_CONTENTS);
+
     model.addAttribute("authorityEndpoint", oidcConfiguration.authorityEndpoint());
     model.addAttribute("tokenEndpoint", oidcConfiguration.tokenEndpoint());
     return "openapi";

--- a/service/src/main/resources/templates/index.html
+++ b/service/src/main/resources/templates/index.html
@@ -1,107 +1,106 @@
 <!-- Copied from the swagger-ui static file -->
 <!DOCTYPE html>
 <html lang="en" xmlns:th="http://www.thymeleaf.org">
-  <head>
-    <meta charset="UTF-8">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; connect-src 'self'; form-action 'none';">
-    <title>Terra Scientific Pipelines Service Swagger UI</title>
-    <link rel="stylesheet" type="text/css" href="/webjars/swagger-ui-dist/swagger-ui.css" >
-    <link rel="icon" type="image/png" href="/webjars/swagger-ui-dist/favicon-32x32.png" sizes="32x32" />
-    <link rel="icon" type="image/png" href="/webjars/swagger-ui-dist/favicon-16x16.png" sizes="16x16" />
-    <style>
-      html
-      {
-        box-sizing: border-box;
-        overflow: -moz-scrollbars-vertical;
-        overflow-y: scroll;
-      }
+<head>
+  <meta charset="UTF-8">
+  <title>Terra Scientific Pipelines Service Swagger UI</title>
+  <link rel="stylesheet" type="text/css" href="/webjars/swagger-ui-dist/swagger-ui.css" >
+  <link rel="icon" type="image/png" href="/webjars/swagger-ui-dist/favicon-32x32.png" sizes="32x32" />
+  <link rel="icon" type="image/png" href="/webjars/swagger-ui-dist/favicon-16x16.png" sizes="16x16" />
+  <style>
+    html
+    {
+      box-sizing: border-box;
+      overflow: -moz-scrollbars-vertical;
+      overflow-y: scroll;
+    }
 
-      *,
-      *:before,
-      *:after
-      {
-        box-sizing: inherit;
-      }
+    *,
+    *:before,
+    *:after
+    {
+      box-sizing: inherit;
+    }
 
-      body
-      {
-        margin:0;
-        background: #fafafa;
-      }
+    body
+    {
+      margin:0;
+      background: #fafafa;
+    }
 
-       /* make the schema display full-width */
-      .swagger-ui .model-example .model-box {
-        display: block;
-      }
+    /* make the schema display full-width */
+    .swagger-ui .model-example .model-box {
+      display: block;
+    }
 
-      /* these take a lot of vertical space by default */
-      .swagger-ui div.info {
-        margin: 25px 0;
-      }
+    /* these take a lot of vertical space by default */
+    .swagger-ui div.info {
+      margin: 25px 0;
+    }
 
-      .swagger-ui .opblock .renderedMarkdown p {
-        margin: 0;
-        font-size: 14px;
-        line-height: 1.2;
-      }
+    .swagger-ui .opblock .renderedMarkdown p {
+      margin: 0;
+      font-size: 14px;
+      line-height: 1.2;
+    }
 
-      /* everything's application/json, and links aren't useful */
-      .swagger-ui section.response-controls, .swagger-ui td.response-col_links {
-        display: none;
-      }
-    </style>
-  </head>
+    /* everything's application/json, and links aren't useful */
+    .swagger-ui section.response-controls, .swagger-ui td.response-col_links {
+      display: none;
+    }
+  </style>
+</head>
 
-  <body>
-    <div id="swagger-ui"></div>
+<body>
+<div id="swagger-ui"></div>
 
-    <script src="/webjars/swagger-ui-dist/swagger-ui-bundle.js"> </script>
-    <script src="/webjars/swagger-ui-dist/swagger-ui-standalone-preset.js"> </script>
-    <script th:inline="javascript">
-    const cleanupPlugin = function(system) {
-      return {
-        components: {
-          // we don't need to load different specs here...
-          Topbar: () => null,
-          // since everything's application/json, the content-type dropdown just takes up space
-          contentType: ({ value, contentTypes }) => {
-            return system.React.createElement('div', null, value || contentTypes.first())
-          }
+<script src="/webjars/swagger-ui-dist/swagger-ui-bundle.js"> </script>
+<script src="/webjars/swagger-ui-dist/swagger-ui-standalone-preset.js"> </script>
+<script th:inline="javascript">
+  const cleanupPlugin = function(system) {
+    return {
+      components: {
+        // we don't need to load different specs here...
+        Topbar: () => null,
+        // since everything's application/json, the content-type dropdown just takes up space
+        contentType: ({ value, contentTypes }) => {
+          return system.React.createElement('div', null, value || contentTypes.first())
         }
       }
     }
+  }
 
-    window.onload = function() {
-      // Begin Swagger UI call region
-      const ui = SwaggerUIBundle({
-        url: 'openapi.yml',
-        dom_id: '#swagger-ui',
-        deepLinking: true,
-        presets: [
-          SwaggerUIBundle.presets.apis,
-          SwaggerUIStandalonePreset
-        ],
-        plugins: [
-          SwaggerUIBundle.plugins.DownloadUrl,
-          cleanupPlugin
-        ],
-        layout: 'StandaloneLayout',
-        defaultModelsExpandDepth: -1, // hide the huge list of schemas under the routes
-        defaultModelRendering: 'model', // schema has the descriptions, unlike the example value
-        defaultModelExpandDepth: 2, // affects the schema shown for a request or response
-        oauth2RedirectUrl: `${window.location.protocol}//${window.location.host}/webjars/swagger-ui-dist/oauth2-redirect.html`
-      })
-      // End Swagger UI call region
+  window.onload = function() {
+    // Begin Swagger UI call region
+    const ui = SwaggerUIBundle({
+      url: 'openapi.yml',
+      dom_id: '#swagger-ui',
+      deepLinking: true,
+      presets: [
+        SwaggerUIBundle.presets.apis,
+        SwaggerUIStandalonePreset
+      ],
+      plugins: [
+        SwaggerUIBundle.plugins.DownloadUrl,
+        cleanupPlugin
+      ],
+      layout: 'StandaloneLayout',
+      defaultModelsExpandDepth: -1, // hide the huge list of schemas under the routes
+      defaultModelRendering: 'model', // schema has the descriptions, unlike the example value
+      defaultModelExpandDepth: 2, // affects the schema shown for a request or response
+      oauth2RedirectUrl: `${window.location.protocol}//${window.location.host}/webjars/swagger-ui-dist/oauth2-redirect.html`
+    })
+    // End Swagger UI call region
 
-      ui.initOAuth({
-        clientId: [[${clientId}]],
-        scopes: "openid",
-        additionalQueryStringParams: {prompt: "login"},
-        usePkceWithAuthorizationCodeGrant: true
-      })
+    ui.initOAuth({
+      clientId: [[${clientId}]],
+      scopes: "openid",
+      additionalQueryStringParams: {prompt: "login"},
+      usePkceWithAuthorizationCodeGrant: true
+    })
 
-      window.ui = ui
-    }
-    </script>
-  </body>
+    window.ui = ui
+  }
+</script>
+</body>
 </html>

--- a/service/src/main/resources/templates/index.html
+++ b/service/src/main/resources/templates/index.html
@@ -1,106 +1,106 @@
 <!-- Copied from the swagger-ui static file -->
 <!DOCTYPE html>
 <html lang="en" xmlns:th="http://www.thymeleaf.org">
-<head>
-  <meta charset="UTF-8">
-  <title>Terra Scientific Pipelines Service Swagger UI</title>
-  <link rel="stylesheet" type="text/css" href="/webjars/swagger-ui-dist/swagger-ui.css" >
-  <link rel="icon" type="image/png" href="/webjars/swagger-ui-dist/favicon-32x32.png" sizes="32x32" />
-  <link rel="icon" type="image/png" href="/webjars/swagger-ui-dist/favicon-16x16.png" sizes="16x16" />
-  <style>
-    html
-    {
-      box-sizing: border-box;
-      overflow: -moz-scrollbars-vertical;
-      overflow-y: scroll;
-    }
+  <head>
+    <meta charset="UTF-8">
+    <title>Terra Scientific Pipelines Service Swagger UI</title>
+    <link rel="stylesheet" type="text/css" href="/webjars/swagger-ui-dist/swagger-ui.css" >
+    <link rel="icon" type="image/png" href="/webjars/swagger-ui-dist/favicon-32x32.png" sizes="32x32" />
+    <link rel="icon" type="image/png" href="/webjars/swagger-ui-dist/favicon-16x16.png" sizes="16x16" />
+    <style>
+      html
+      {
+        box-sizing: border-box;
+        overflow: -moz-scrollbars-vertical;
+        overflow-y: scroll;
+      }
 
-    *,
-    *:before,
-    *:after
-    {
-      box-sizing: inherit;
-    }
+      *,
+      *:before,
+      *:after
+      {
+        box-sizing: inherit;
+      }
 
-    body
-    {
-      margin:0;
-      background: #fafafa;
-    }
+      body
+      {
+        margin:0;
+        background: #fafafa;
+      }
 
-    /* make the schema display full-width */
-    .swagger-ui .model-example .model-box {
-      display: block;
-    }
+       /* make the schema display full-width */
+      .swagger-ui .model-example .model-box {
+        display: block;
+      }
 
-    /* these take a lot of vertical space by default */
-    .swagger-ui div.info {
-      margin: 25px 0;
-    }
+      /* these take a lot of vertical space by default */
+      .swagger-ui div.info {
+        margin: 25px 0;
+      }
 
-    .swagger-ui .opblock .renderedMarkdown p {
-      margin: 0;
-      font-size: 14px;
-      line-height: 1.2;
-    }
+      .swagger-ui .opblock .renderedMarkdown p {
+        margin: 0;
+        font-size: 14px;
+        line-height: 1.2;
+      }
 
-    /* everything's application/json, and links aren't useful */
-    .swagger-ui section.response-controls, .swagger-ui td.response-col_links {
-      display: none;
-    }
-  </style>
-</head>
+      /* everything's application/json, and links aren't useful */
+      .swagger-ui section.response-controls, .swagger-ui td.response-col_links {
+        display: none;
+      }
+    </style>
+  </head>
 
-<body>
-<div id="swagger-ui"></div>
+  <body>
+    <div id="swagger-ui"></div>
 
-<script src="/webjars/swagger-ui-dist/swagger-ui-bundle.js"> </script>
-<script src="/webjars/swagger-ui-dist/swagger-ui-standalone-preset.js"> </script>
-<script th:inline="javascript">
-  const cleanupPlugin = function(system) {
-    return {
-      components: {
-        // we don't need to load different specs here...
-        Topbar: () => null,
-        // since everything's application/json, the content-type dropdown just takes up space
-        contentType: ({ value, contentTypes }) => {
-          return system.React.createElement('div', null, value || contentTypes.first())
+    <script src="/webjars/swagger-ui-dist/swagger-ui-bundle.js"> </script>
+    <script src="/webjars/swagger-ui-dist/swagger-ui-standalone-preset.js"> </script>
+    <script th:inline="javascript">
+    const cleanupPlugin = function(system) {
+      return {
+        components: {
+          // we don't need to load different specs here...
+          Topbar: () => null,
+          // since everything's application/json, the content-type dropdown just takes up space
+          contentType: ({ value, contentTypes }) => {
+            return system.React.createElement('div', null, value || contentTypes.first())
+          }
         }
       }
     }
-  }
 
-  window.onload = function() {
-    // Begin Swagger UI call region
-    const ui = SwaggerUIBundle({
-      url: 'openapi.yml',
-      dom_id: '#swagger-ui',
-      deepLinking: true,
-      presets: [
-        SwaggerUIBundle.presets.apis,
-        SwaggerUIStandalonePreset
-      ],
-      plugins: [
-        SwaggerUIBundle.plugins.DownloadUrl,
-        cleanupPlugin
-      ],
-      layout: 'StandaloneLayout',
-      defaultModelsExpandDepth: -1, // hide the huge list of schemas under the routes
-      defaultModelRendering: 'model', // schema has the descriptions, unlike the example value
-      defaultModelExpandDepth: 2, // affects the schema shown for a request or response
-      oauth2RedirectUrl: `${window.location.protocol}//${window.location.host}/webjars/swagger-ui-dist/oauth2-redirect.html`
-    })
-    // End Swagger UI call region
+    window.onload = function() {
+      // Begin Swagger UI call region
+      const ui = SwaggerUIBundle({
+        url: 'openapi.yml',
+        dom_id: '#swagger-ui',
+        deepLinking: true,
+        presets: [
+          SwaggerUIBundle.presets.apis,
+          SwaggerUIStandalonePreset
+        ],
+        plugins: [
+          SwaggerUIBundle.plugins.DownloadUrl,
+          cleanupPlugin
+        ],
+        layout: 'StandaloneLayout',
+        defaultModelsExpandDepth: -1, // hide the huge list of schemas under the routes
+        defaultModelRendering: 'model', // schema has the descriptions, unlike the example value
+        defaultModelExpandDepth: 2, // affects the schema shown for a request or response
+        oauth2RedirectUrl: `${window.location.protocol}//${window.location.host}/webjars/swagger-ui-dist/oauth2-redirect.html`
+      })
+      // End Swagger UI call region
 
-    ui.initOAuth({
-      clientId: [[${clientId}]],
-      scopes: "openid",
-      additionalQueryStringParams: {prompt: "login"},
-      usePkceWithAuthorizationCodeGrant: true
-    })
+      ui.initOAuth({
+        clientId: [[${clientId}]],
+        scopes: "openid",
+        additionalQueryStringParams: {prompt: "login"},
+        usePkceWithAuthorizationCodeGrant: true
+      })
 
-    window.ui = ui
-  }
-</script>
-</body>
+      window.ui = ui
+    }
+    </script>
+  </body>
 </html>

--- a/service/src/main/resources/templates/index.html
+++ b/service/src/main/resources/templates/index.html
@@ -3,6 +3,7 @@
 <html lang="en" xmlns:th="http://www.thymeleaf.org">
   <head>
     <meta charset="UTF-8">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; connect-src 'self'; form-action 'none';">
     <title>Terra Scientific Pipelines Service Swagger UI</title>
     <link rel="stylesheet" type="text/css" href="/webjars/swagger-ui-dist/swagger-ui.css" >
     <link rel="icon" type="image/png" href="/webjars/swagger-ui-dist/favicon-32x32.png" sizes="32x32" />


### PR DESCRIPTION
### Description 

Add a Content-Security-Policy header to swagger.

Turns out that a lot in the `index.html` file gets overridden (e.g. the title there is `Terra Scientific Pipelines Service Swagger UI` but the swagger page title is just `Terra Scientific Pipelines Service`); adding the content header directly to that html doesn't work. Adding it in the Controller works.

Run locally:
<img width="841" alt="image" src="https://github.com/user-attachments/assets/7932eb89-37a4-4f68-8aeb-b2a57680f29b">
The CSP also appears on the openapi.yml response headers.

Also: again trying to fix our deployment by updating the artifactory repo to `libs-release-local`.


### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-366