### PR TITLE
TSPS-365 Update swagger-ui-dist to latest version for dompurify vulnerability fix

### DIFF
--- a/service/generators.gradle
+++ b/service/generators.gradle
@@ -1,6 +1,6 @@
 dependencies {
 	implementation 'io.swagger.core.v3:swagger-annotations'
-	runtimeOnly 'org.webjars.npm:swagger-ui-dist:4.18.1'
+	runtimeOnly 'org.webjars.npm:swagger-ui-dist:5.18.2'
 	swaggerCodegen 'io.swagger.codegen.v3:swagger-codegen-cli'
 
 	// Versioned by Spring:


### PR DESCRIPTION
### Description 

Update swagger-ui-dist version from 4.18.1 -> 5.18.2 (latest version available), which apparently uses dompurify version 3.1.6. We wanted >= 2.5.0 to fix the vulnerability. 

Now http://localhost:8080/webjars/swagger-ui-dist/swagger-ui-bundle.js (when service run locally) includes 
```
if(DOMPurify.version="3.1.6",DOMPurify.removed=[],!o||!o.document||o.document.nodeType!==rt.document)return DOMPurify.isSupported=!1,DOMPurify
```

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-365
