### PR TITLE
TSPS-366 fix CSP header to work with b2c auth

### DIFF
--- a/service/src/main/java/bio/terra/pipelines/app/controller/PublicApiController.java
+++ b/service/src/main/java/bio/terra/pipelines/app/controller/PublicApiController.java
@@ -54,14 +54,9 @@ public class PublicApiController implements PublicApi {
 
   private static final String CSP_HEADER_NAME = "Content-Security-Policy";
   private static final String CSP_HEADER_CONTENTS =
-      "default-src 'self'; script-src 'self' 'unsafe-inline'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; connect-src 'self'; form-action 'none';";
+      "script-src 'self' 'unsafe-inline'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; form-action 'none';";
 
-  @GetMapping(value = "/")
-  public String index() {
-    return "redirect:/swagger-ui.html";
-  }
-
-  @GetMapping({"/index.html", "/swagger-ui.html"})
+  @GetMapping({"/", "/index.html", "/swagger-ui.html"})
   public String getSwagger(Model model, HttpServletResponse response) {
     response.setHeader(CSP_HEADER_NAME, CSP_HEADER_CONTENTS);
 

--- a/service/src/main/java/bio/terra/pipelines/db/entities/PipelineRun.java
+++ b/service/src/main/java/bio/terra/pipelines/db/entities/PipelineRun.java
@@ -7,7 +7,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -57,11 +57,11 @@ public class PipelineRun {
 
   @Column(name = "created", insertable = false)
   @CreationTimestamp(source = SourceType.DB)
-  private LocalDateTime created;
+  private Instant created;
 
   @Column(name = "updated", insertable = false)
   @UpdateTimestamp(source = SourceType.DB)
-  private LocalDateTime updated;
+  private Instant updated;
 
   @Column(name = "status", nullable = false)
   private CommonPipelineRunStatusEnum status;
@@ -80,8 +80,8 @@ public class PipelineRun {
       String workspaceName,
       String workspaceStorageContainerName,
       String workspaceGoogleProject,
-      LocalDateTime created,
-      LocalDateTime updated,
+      Instant created,
+      Instant updated,
       CommonPipelineRunStatusEnum status,
       String description) {
     this.jobId = jobId;

--- a/service/src/test/java/bio/terra/pipelines/controller/PipelineRunsApiControllerTest.java
+++ b/service/src/test/java/bio/terra/pipelines/controller/PipelineRunsApiControllerTest.java
@@ -5,6 +5,7 @@ import static bio.terra.pipelines.testutils.TestUtils.buildTestResultUrl;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
@@ -44,7 +45,7 @@ import bio.terra.stairway.FlightStatus;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -82,8 +83,8 @@ class PipelineRunsApiControllerTest {
   private final String testPipelineWdlMethodVersion = TestUtils.TEST_WDL_METHOD_VERSION_1;
   private final Map<String, Object> testPipelineInputs = TestUtils.TEST_PIPELINE_INPUTS;
   private final UUID newJobId = TestUtils.TEST_NEW_UUID;
-  private final LocalDateTime createdTime = LocalDateTime.now();
-  private final LocalDateTime updatedTime = LocalDateTime.now();
+  private final Instant createdTime = Instant.now();
+  private final Instant updatedTime = Instant.now();
   private final Map<String, String> testOutputs = TestUtils.TEST_PIPELINE_OUTPUTS;
 
   @BeforeEach
@@ -594,6 +595,8 @@ class PipelineRunsApiControllerTest {
     assertEquals(getTestPipeline().getName().getValue(), responsePipelineRun1.getPipelineName());
     assertEquals(
         pipelineRunPreparing.getCreated().toString(), responsePipelineRun1.getTimeSubmitted());
+    // timestamp string should be marked as UTC, i.e. end with Z
+    assertTrue(responsePipelineRun1.getTimeSubmitted().endsWith("Z"));
     assertNull(responsePipelineRun1.getTimeCompleted());
 
     // succeeded run should have a completed time
@@ -604,8 +607,12 @@ class PipelineRunsApiControllerTest {
     assertEquals(getTestPipeline().getName().getValue(), responsePipelineRun2.getPipelineName());
     assertEquals(
         pipelineRunSucceeded.getCreated().toString(), responsePipelineRun2.getTimeSubmitted());
+    // timestamp string should be marked as UTC, i.e. end with Z
+    assertTrue(responsePipelineRun2.getTimeSubmitted().endsWith("Z"));
     assertEquals(
         pipelineRunSucceeded.getUpdated().toString(), responsePipelineRun2.getTimeCompleted());
+    // timestamp string should be marked as UTC, i.e. end with Z
+    assertTrue(responsePipelineRun2.getTimeCompleted().endsWith("Z"));
 
     // failed run should have a completed time
     ApiPipelineRun responsePipelineRun3 = response.getResults().get(2);

--- a/service/src/test/java/bio/terra/pipelines/controller/PublicApiControllerTest.java
+++ b/service/src/test/java/bio/terra/pipelines/controller/PublicApiControllerTest.java
@@ -75,13 +75,8 @@ class PublicApiControllerTest extends BaseTest {
   }
 
   @Test
-  void testIndex() throws Exception {
-    this.mockMvc.perform(get("/")).andExpect(status().is3xxRedirection());
-  }
-
-  @Test
   void testGetSwagger() throws Exception {
-    var swaggerPaths = Set.of("/index.html", "/swagger-ui.html");
+    var swaggerPaths = Set.of("/", "/index.html", "/swagger-ui.html");
     for (var path : swaggerPaths) {
       this.mockMvc
           .perform(get(path))

--- a/service/src/test/java/bio/terra/pipelines/service/PipelineRunsServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/PipelineRunsServiceTest.java
@@ -35,7 +35,7 @@ import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -558,7 +558,7 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
     assertEquals(2, pageResults.content().size());
     assertNotNull(pageResults.nextPageCursor());
     assertNull(pageResults.previousPageCursor());
-    LocalDateTime firstResultTime = pageResults.content().get(0).getCreated();
+    Instant firstResultTime = pageResults.content().get(0).getCreated();
 
     // now query for next page
     pageResults =
@@ -568,7 +568,7 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
     assertNull(pageResults.nextPageCursor());
     assertNotNull(pageResults.previousPageCursor());
 
-    LocalDateTime thirdResultTime = pageResults.content().get(0).getCreated();
+    Instant thirdResultTime = pageResults.content().get(0).getCreated();
     // test that results are coming with most recent first
     assertTrue(firstResultTime.isAfter(thirdResultTime));
   }


### PR DESCRIPTION
### Description 

Update CSP header on swagger to not break b2c auth.

Also remove the redirect on the root swagger page.

### Jira Ticket
fix follow-on for https://broadworkbench.atlassian.net/browse/TSPS-366
