### PR TITLE
TSPS-366 fix CSP header to work with b2c auth

### DIFF
--- a/service/src/main/java/bio/terra/pipelines/app/controller/PublicApiController.java
+++ b/service/src/main/java/bio/terra/pipelines/app/controller/PublicApiController.java
@@ -54,14 +54,9 @@ public class PublicApiController implements PublicApi {
 
   private static final String CSP_HEADER_NAME = "Content-Security-Policy";
   private static final String CSP_HEADER_CONTENTS =
-      "default-src 'self'; script-src 'self' 'unsafe-inline'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; connect-src 'self'; form-action 'none';";
+      "script-src 'self' 'unsafe-inline'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; form-action 'none';";
 
-  @GetMapping(value = "/")
-  public String index() {
-    return "redirect:/swagger-ui.html";
-  }
-
-  @GetMapping({"/index.html", "/swagger-ui.html"})
+  @GetMapping({"/", "/index.html", "/swagger-ui.html"})
   public String getSwagger(Model model, HttpServletResponse response) {
     response.setHeader(CSP_HEADER_NAME, CSP_HEADER_CONTENTS);
 

--- a/service/src/test/java/bio/terra/pipelines/controller/PublicApiControllerTest.java
+++ b/service/src/test/java/bio/terra/pipelines/controller/PublicApiControllerTest.java
@@ -75,13 +75,8 @@ class PublicApiControllerTest extends BaseTest {
   }
 
   @Test
-  void testIndex() throws Exception {
-    this.mockMvc.perform(get("/")).andExpect(status().is3xxRedirection());
-  }
-
-  @Test
   void testGetSwagger() throws Exception {
-    var swaggerPaths = Set.of("/index.html", "/swagger-ui.html");
+    var swaggerPaths = Set.of("/", "/index.html", "/swagger-ui.html");
     for (var path : swaggerPaths) {
       this.mockMvc
           .perform(get(path))


### PR DESCRIPTION
### Description 

Update CSP header on swagger to not break b2c auth.

Also remove the redirect on the root swagger page.

### Jira Ticket
follow-on fix for https://broadworkbench.atlassian.net/browse/TSPS-366
