### PR TITLE
TSPS-388 Move description input from start endpoint to prepare endpoint

### DIFF
--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -896,6 +896,8 @@ components:
           $ref: "#/components/schemas/PipelineVersion"
         pipelineInputs:
           $ref: "#/components/schemas/PipelineUserProvidedInputs"
+        description:
+          $ref: "#/components/schemas/PipelineRunDescription"
 
     PreparePipelineRunResponse:
         description: Result of the preparePipelineRun request, containing signed URLs to upload input files
@@ -939,10 +941,6 @@ components:
       type: object
       required: [ jobControl ]
       properties:
-        description:
-          description: >-
-            User-provided description of the pipeline run.
-          type: string
         jobControl:
           $ref: "#/components/schemas/JobControl"
 

--- a/service/src/main/java/bio/terra/pipelines/app/controller/PipelineRunsApiController.java
+++ b/service/src/main/java/bio/terra/pipelines/app/controller/PipelineRunsApiController.java
@@ -80,6 +80,7 @@ public class PipelineRunsApiController implements PipelineRunsApi {
     String userId = userRequest.getSubjectId();
     UUID jobId = body.getJobId();
     String pipelineName = body.getPipelineName();
+    String description = body.getDescription();
 
     Integer pipelineVersion = body.getPipelineVersion();
     Map<String, Object> userProvidedInputs = body.getPipelineInputs();
@@ -101,7 +102,8 @@ public class PipelineRunsApiController implements PipelineRunsApi {
         userProvidedInputs);
 
     Map<String, Map<String, String>> fileInputUploadUrls =
-        pipelineRunsService.preparePipelineRun(pipeline, jobId, userId, userProvidedInputs);
+        pipelineRunsService.preparePipelineRun(
+            pipeline, jobId, userId, userProvidedInputs, description);
 
     ApiPreparePipelineRunResponse prepareResponse =
         new ApiPreparePipelineRunResponse().jobId(jobId).fileInputUploadUrls(fileInputUploadUrls);
@@ -127,8 +129,6 @@ public class PipelineRunsApiController implements PipelineRunsApi {
     String userId = userRequest.getSubjectId();
     UUID jobId = body.getJobControl().getId();
 
-    String description = body.getDescription();
-
     PipelineRun pipelineRunBeforeStart = pipelineRunsService.getPipelineRun(jobId, userId);
     Pipeline pipeline = pipelinesService.getPipelineById(pipelineRunBeforeStart.getPipelineId());
 
@@ -139,7 +139,7 @@ public class PipelineRunsApiController implements PipelineRunsApi {
         userId);
 
     PipelineRun pipelineRunAfterStart =
-        pipelineRunsService.startPipelineRun(pipeline, jobId, userId, description);
+        pipelineRunsService.startPipelineRun(pipeline, jobId, userId);
 
     ApiAsyncPipelineRunResponse createdRunResponse =
         pipelineRunToApi(pipelineRunAfterStart, pipeline);

--- a/service/src/main/java/bio/terra/pipelines/db/entities/PipelineRun.java
+++ b/service/src/main/java/bio/terra/pipelines/db/entities/PipelineRun.java
@@ -109,7 +109,8 @@ public class PipelineRun {
       String workspaceName,
       String workspaceStorageContainerName,
       String workspaceGoogleProject,
-      CommonPipelineRunStatusEnum status) {
+      CommonPipelineRunStatusEnum status,
+      String description) {
     this.jobId = jobId;
     this.userId = userId;
     this.pipelineId = pipelineId;
@@ -119,5 +120,6 @@ public class PipelineRun {
     this.workspaceStorageContainerName = workspaceStorageContainerName;
     this.workspaceGoogleProject = workspaceGoogleProject;
     this.status = status;
+    this.description = description;
   }
 }

--- a/service/src/test/java/bio/terra/pipelines/service/PipelineRunsServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/PipelineRunsServiceTest.java
@@ -62,7 +62,6 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
   private final String testUserId = TestUtils.TEST_USER_ID_1;
   private final Long testPipelineId = TestUtils.TEST_PIPELINE_ID_1;
   private final String testWdlMethodVersion = TestUtils.TEST_WDL_METHOD_VERSION_1;
-  private final String testDescription = TestUtils.TEST_PIPELINE_DESCRIPTION_1;
   private final Map<String, Object> testPipelineInputs = TestUtils.TEST_PIPELINE_INPUTS;
   private final UUID testJobId = TestUtils.TEST_NEW_UUID;
   private final String testControlWorkspaceProject = TestUtils.CONTROL_WORKSPACE_BILLING_PROJECT;
@@ -71,6 +70,7 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
       TestUtils.CONTROL_WORKSPACE_STORAGE_CONTAINER_NAME;
   private final String testControlWorkspaceGoogleProject =
       TestUtils.CONTROL_WORKSPACE_GOOGLE_PROJECT;
+  private final String testUserDescription = TestUtils.TEST_USER_PROVIDED_DESCRIPTION;
 
   private SimpleMeterRegistry meterRegistry;
 
@@ -107,7 +107,7 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
             testControlWorkspaceStorageContainerName,
             testControlWorkspaceGoogleProject,
             testPipelineInputs,
-            testDescription);
+            testUserDescription);
 
     List<PipelineRun> runsAfterSave = pipelineRunsRepository.findAllByUserId(testUserId);
     assertEquals(2, runsAfterSave.size());
@@ -120,7 +120,7 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
     assertEquals(testJobId, savedRun.getJobId());
     assertEquals(testPipelineId, savedRun.getPipelineId());
     assertEquals(testUserId, savedRun.getUserId());
-    assertEquals(testDescription, savedRun.getDescription());
+    assertEquals(testUserDescription, savedRun.getDescription());
     assertEquals(CommonPipelineRunStatusEnum.PREPARING, savedRun.getStatus());
     assertNotNull(savedRun.getCreated());
     assertNotNull(savedRun.getUpdated());
@@ -205,7 +205,7 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
                 testJobId,
                 testUserId,
                 testPipelineInputs,
-                testDescription));
+                testUserDescription));
 
     // missing workspace name
     Pipeline testPipelineWithIdMissingWorkspaceName = createTestPipelineWithId();
@@ -219,7 +219,7 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
                 testJobId,
                 testUserId,
                 testPipelineInputs,
-                testDescription));
+                testUserDescription));
 
     // missing workspace storage container url
     Pipeline testPipelineWithIdMissingWorkspaceStorageContainerUrl = createTestPipelineWithId();
@@ -233,7 +233,7 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
                 testJobId,
                 testUserId,
                 testPipelineInputs,
-                testDescription));
+                testUserDescription));
   }
 
   @Test
@@ -251,13 +251,17 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
         testControlWorkspaceStorageContainerName,
         testControlWorkspaceGoogleProject,
         testPipelineInputs,
-        testDescription);
+        testUserDescription);
 
     assertThrows(
         BadRequestException.class,
         () ->
             pipelineRunsService.preparePipelineRun(
-                testPipelineWithId, testJobId, testUserId, testPipelineInputs, testDescription));
+                testPipelineWithId,
+                testJobId,
+                testUserId,
+                testPipelineInputs,
+                testUserDescription));
   }
 
   @Test
@@ -275,13 +279,17 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
         testControlWorkspaceStorageContainerName,
         testControlWorkspaceGoogleProject,
         testPipelineInputs,
-        testDescription);
+        testUserDescription);
 
     assertThrows(
         BadRequestException.class,
         () ->
             pipelineRunsService.preparePipelineRun(
-                testPipelineWithId, testJobId, testUserId, testPipelineInputs, testDescription));
+                testPipelineWithId,
+                testJobId,
+                testUserId,
+                testPipelineInputs,
+                testUserDescription));
   }
 
   @Test
@@ -305,7 +313,7 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
 
     Map<String, Map<String, String>> formattedPipelineFileInputs =
         pipelineRunsService.preparePipelineRun(
-            testPipelineWithId, testJobId, testUserId, userPipelineInputs, testDescription);
+            testPipelineWithId, testJobId, testUserId, userPipelineInputs, testUserDescription);
 
     assertEquals(userPipelineInputs.size(), formattedPipelineFileInputs.size());
     assertEquals(
@@ -321,11 +329,11 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
 
     assertEquals(testJobId, writtenPipelineRun.getJobId());
     assertEquals(testUserId, writtenPipelineRun.getUserId());
-    assertEquals(testDescription, writtenPipelineRun.getDescription());
+    assertEquals(testUserDescription, writtenPipelineRun.getDescription());
     assertEquals(testPipelineWithId.getId(), writtenPipelineRun.getPipelineId());
     assertEquals(
         testPipelineWithId.getWdlMethodVersion(), writtenPipelineRun.getWdlMethodVersion());
-    assertEquals(testDescription, writtenPipelineRun.getDescription());
+    assertEquals(testUserDescription, writtenPipelineRun.getDescription());
     assertNotNull(writtenPipelineRun.getCreated());
     assertNotNull(writtenPipelineRun.getUpdated());
 
@@ -432,7 +440,7 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
             testControlWorkspaceStorageContainerName,
             testControlWorkspaceGoogleProject,
             CommonPipelineRunStatusEnum.RUNNING,
-            testDescription));
+            testUserDescription));
 
     assertThrows(
         BadRequestException.class,
@@ -454,7 +462,7 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
         testControlWorkspaceStorageContainerName,
         testControlWorkspaceGoogleProject,
         testPipelineInputs,
-        testDescription);
+        testUserDescription);
 
     assertThrows(
         BadRequestException.class,
@@ -476,7 +484,7 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
         testControlWorkspaceStorageContainerName,
         testControlWorkspaceGoogleProject,
         testPipelineInputs,
-        testDescription);
+        testUserDescription);
 
     // override this mock to ensure the correct flight class is being requested
     when(mockJobBuilder.flightClass(RunImputationGcpJobFlight.class)).thenReturn(mockJobBuilder);
@@ -486,7 +494,7 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
 
     assertEquals(testJobId, returnedPipelineRun.getJobId());
     assertEquals(testUserId, returnedPipelineRun.getUserId());
-    assertEquals(testDescription, returnedPipelineRun.getDescription());
+    assertEquals(testUserDescription, returnedPipelineRun.getDescription());
     assertEquals(testPipelineWithId.getId(), returnedPipelineRun.getPipelineId());
     assertNotNull(returnedPipelineRun.getCreated());
     assertNotNull(returnedPipelineRun.getUpdated());

--- a/service/src/test/java/bio/terra/pipelines/testutils/TestUtils.java
+++ b/service/src/test/java/bio/terra/pipelines/testutils/TestUtils.java
@@ -221,7 +221,8 @@ public class TestUtils {
         CONTROL_WORKSPACE_NAME,
         CONTROL_WORKSPACE_STORAGE_CONTAINER_NAME,
         CONTROL_WORKSPACE_GOOGLE_PROJECT,
-        CommonPipelineRunStatusEnum.PREPARING);
+        CommonPipelineRunStatusEnum.PREPARING,
+        "test description");
   }
 
   public static String buildTestResultUrl(String jobId) {

--- a/service/src/test/java/bio/terra/pipelines/testutils/TestUtils.java
+++ b/service/src/test/java/bio/terra/pipelines/testutils/TestUtils.java
@@ -193,6 +193,8 @@ public class TestUtils {
           Map.of("multiSampleVcf", "fake/file.vcf.gz", "outputBasename", "fake_basename"));
 
   public static final String TEST_DOMAIN = "some-teaspoons-domain.com";
+  public static final String TEST_USER_PROVIDED_DESCRIPTION =
+      "user-provided description of a pipeline run";
 
   public static final MethodConfiguration VALID_METHOD_CONFIGURATION =
       new MethodConfiguration()


### PR DESCRIPTION
### Description 

The job description for each pipeline run is technically required for the flight, which is created on pipeline run start, but it was onerous and causing other problems to have to supply it then rather than with all the other inputs on pipeline run prepare, so we moved it to the prepare endpoint.

Note: Once this is merged, will need to update this CLI PR with the new thin client version: https://github.com/DataBiosphere/terra-scientific-pipelines-service-cli/pull/20

Calling prepare with a description:
<img width="566" alt="image" src="https://github.com/user-attachments/assets/7b17307e-79aa-47ae-9e04-74ef91938ab1">

Description is optional:
<img width="490" alt="image" src="https://github.com/user-attachments/assets/af99445d-af28-4199-b17d-5805fb20acf6">

Start doesn't take a description:
<img width="609" alt="image" src="https://github.com/user-attachments/assets/c2cb46ec-7d10-4079-8543-b0c78cea9dc5">

Note that if no description is provided, it's still not included in the get all pipeline runs response and the CLI still doesn't like it, so [this PR in the cli repo](https://github.com/DataBiosphere/terra-scientific-pipelines-service-cli/pull/19) is still needed.
<img width="616" alt="image" src="https://github.com/user-attachments/assets/a43e4550-6040-4b43-acdf-355a1de4ea75">

Companion PR to update the e2e test: https://github.com/broadinstitute/dsp-reusable-workflows/pull/60

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-388