### PR TITLE
TSPS-385 add min quota consumed to array imputation flight

### DIFF
--- a/service/src/main/java/bio/terra/pipelines/db/entities/PipelineQuota.java
+++ b/service/src/main/java/bio/terra/pipelines/db/entities/PipelineQuota.java
@@ -25,8 +25,12 @@ public class PipelineQuota {
   @Column(name = "default_quota")
   private int defaultQuota;
 
-  public PipelineQuota(PipelinesEnum pipelineName, int defaultQuota) {
+  @Column(name = "min_quota_consumed")
+  private int minQuotaConsumed;
+
+  public PipelineQuota(PipelinesEnum pipelineName, int defaultQuota, int minQuotaConsumed) {
     this.pipelineName = pipelineName;
     this.defaultQuota = defaultQuota;
+    this.minQuotaConsumed = minQuotaConsumed;
   }
 }

--- a/service/src/main/java/bio/terra/pipelines/service/QuotasService.java
+++ b/service/src/main/java/bio/terra/pipelines/service/QuotasService.java
@@ -28,6 +28,11 @@ public class QuotasService {
     this.pipelineQuotasRepository = pipelineQuotasRepository;
   }
 
+  /** This method gets the PipelineQuota object for a given pipeline. */
+  public PipelineQuota getPipelineQuota(PipelinesEnum pipelineName) {
+    return pipelineQuotasRepository.findByPipelineName(pipelineName);
+  }
+
   /**
    * This method gets the quota for a given user and pipeline. If the user quota does not exist, it
    * will create a new row in the user quotas table with the default quota for the pipeline.

--- a/service/src/main/java/bio/terra/pipelines/stairway/QuotaConsumedValidationStep.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/QuotaConsumedValidationStep.java
@@ -40,9 +40,14 @@ public class QuotaConsumedValidationStep implements Step {
     FlightMap workingMap = flightContext.getWorkingMap();
     FlightUtils.validateRequiredEntries(workingMap, ImputationJobMapKeys.QUOTA_CONSUMED);
 
-    // check if user quota used plus quota consumed is less than or equal to user quota
+    // we want to have the ability to have a floor for quota consumed, so we take the max of the
+    // pipeline's min quota consumed and the quota consumed for this run
     Integer quotaUsedForThisRun =
-        workingMap.get(ImputationJobMapKeys.QUOTA_CONSUMED, Integer.class);
+        Math.max(
+            quotasService.getPipelineQuota(pipelineName).getMinQuotaConsumed(),
+            workingMap.get(ImputationJobMapKeys.QUOTA_CONSUMED, Integer.class));
+
+    // check if user quota used plus quota consumed is less than or equal to user quota
     UserQuota userQuota = quotasService.getOrCreateQuotaForUserAndPipeline(userId, pipelineName);
 
     // user quota has been exceeded, fail the flight

--- a/service/src/main/resources/db/changelog.xml
+++ b/service/src/main/resources/db/changelog.xml
@@ -7,6 +7,7 @@
   <include file="changesets/20241106-add-indexes.yaml" relativeToChangelogFile="true"/>
   <include file="changesets/20241106-base-data-insertion.yaml" relativeToChangelogFile="true"/>
   <include file="changesets/20241125_drop_result_url_column.yaml" relativeToChangelogFile="true"/>
+  <include file="changesets/20241212_add_min_quota_for_pipelines.yaml" relativeToChangelogFile="true"/>
 
   <include file="changesets/testdata.yaml" relativeToChangelogFile="true"/>
 

--- a/service/src/main/resources/db/changesets/20241212_add_min_quota_for_pipelines.yaml
+++ b/service/src/main/resources/db/changesets/20241212_add_min_quota_for_pipelines.yaml
@@ -2,7 +2,7 @@
 
 databaseChangeLog:
   -  changeSet:
-       id:  drop result_url column from pipeline_runs table
+       id:  add min_quota column to pipeline_quotas table and update imputation to be 500
        author:  js
        changes:
          -  addColumn:

--- a/service/src/main/resources/db/changesets/20241212_add_min_quota_for_pipelines.yaml
+++ b/service/src/main/resources/db/changesets/20241212_add_min_quota_for_pipelines.yaml
@@ -1,0 +1,25 @@
+# add min_quota column to pipeline_quotas table and update imputation to be 500
+
+databaseChangeLog:
+  -  changeSet:
+       id:  drop result_url column from pipeline_runs table
+       author:  js
+       changes:
+         -  addColumn:
+              tableName:  pipeline_quotas
+              columns:
+                -  column:
+                     name:  min_quota_consumed
+                     type:  int
+                     constraints:
+                       nullable:  true
+         - update:
+             columns:
+               - column:
+                   name: min_quota_consumed
+                   value: 500
+             tableName: pipeline_quotas
+             where: pipeline_name='array_imputation'
+         - addNotNullConstraint:
+             columnName: min_quota_consumed
+             tableName: pipeline_quotas

--- a/service/src/test/java/bio/terra/pipelines/db/entities/PipelineQuotaTest.java
+++ b/service/src/test/java/bio/terra/pipelines/db/entities/PipelineQuotaTest.java
@@ -1,0 +1,18 @@
+package bio.terra.pipelines.db.entities;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import bio.terra.pipelines.common.utils.PipelinesEnum;
+import bio.terra.pipelines.testutils.BaseTest;
+import org.junit.jupiter.api.Test;
+
+class PipelineQuotaTest extends BaseTest {
+
+  @Test
+  void testPipelineQuotaConstructor() {
+    PipelineQuota pipelineQuota = new PipelineQuota(PipelinesEnum.ARRAY_IMPUTATION, 10000, 500);
+    assertEquals(PipelinesEnum.ARRAY_IMPUTATION, pipelineQuota.getPipelineName());
+    assertEquals(10000, pipelineQuota.getDefaultQuota());
+    assertEquals(500, pipelineQuota.getMinQuotaConsumed());
+  }
+}

--- a/service/src/test/java/bio/terra/pipelines/service/QuotasServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/QuotasServiceTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import bio.terra.common.exception.InternalServerErrorException;
 import bio.terra.pipelines.common.utils.PipelinesEnum;
+import bio.terra.pipelines.db.entities.PipelineQuota;
 import bio.terra.pipelines.db.entities.UserQuota;
 import bio.terra.pipelines.db.repositories.PipelineQuotasRepository;
 import bio.terra.pipelines.db.repositories.UserQuotasRepository;
@@ -16,6 +17,15 @@ class QuotasServiceTest extends BaseEmbeddedDbTest {
   @Autowired QuotasService quotasService;
   @Autowired UserQuotasRepository userQuotasRepository;
   @Autowired PipelineQuotasRepository pipelineQuotasRepository;
+
+  @Test
+  void getPipelineQuota() {
+    PipelineQuota pipelineQuota = quotasService.getPipelineQuota(PipelinesEnum.ARRAY_IMPUTATION);
+
+    assertEquals(PipelinesEnum.ARRAY_IMPUTATION, pipelineQuota.getPipelineName());
+    assertEquals(10000, pipelineQuota.getDefaultQuota());
+    assertEquals(500, pipelineQuota.getMinQuotaConsumed());
+  }
 
   @Test
   void getQuotaForUserAndPipeline() {

--- a/service/src/test/java/bio/terra/pipelines/stairway/QuotaConsumedValidationStepTest.java
+++ b/service/src/test/java/bio/terra/pipelines/stairway/QuotaConsumedValidationStepTest.java
@@ -87,7 +87,7 @@ class QuotaConsumedValidationStepTest extends BaseEmbeddedDbTest {
     // make sure the step was a success
     assertEquals(StepStatus.STEP_RESULT_SUCCESS, result.getStepStatus());
 
-    // after running make sure quota for user is 300 based on the quota consumed
+    // after running make sure quota for user is 3000 based on the quota consumed
     // from the job running
     userQuota =
         quotasService.getOrCreateQuotaForUserAndPipeline(

--- a/service/src/test/java/bio/terra/pipelines/stairway/QuotaConsumedValidationStepTest.java
+++ b/service/src/test/java/bio/terra/pipelines/stairway/QuotaConsumedValidationStepTest.java
@@ -87,7 +87,8 @@ class QuotaConsumedValidationStepTest extends BaseEmbeddedDbTest {
     // make sure the step was a success
     assertEquals(StepStatus.STEP_RESULT_SUCCESS, result.getStepStatus());
 
-    // after running make sure quota for user is 500 from the pipeline min quota
+    // after running make sure quota for user is 300 based on the quota consumed
+    // from the job running
     userQuota =
         quotasService.getOrCreateQuotaForUserAndPipeline(
             TestUtils.TEST_USER_ID_1, PipelinesEnum.ARRAY_IMPUTATION);


### PR DESCRIPTION
### Description 

For cost purposes, we want to have a floor to how much quota a single submission will consume.  For array imputation the floor is 500

before submission

<img width="1406" alt="Screenshot 2024-12-12 at 6 19 21 PM" src="https://github.com/user-attachments/assets/effaa4b1-9127-4720-bc50-1bb6718ac529" />

after submission

<img width="1432" alt="Screenshot 2024-12-12 at 6 22 47 PM" src="https://github.com/user-attachments/assets/d560c090-b490-49a1-bc46-7f7521f39dd9" />

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-385