### PR TITLE
TSPS-331 Update name of e2e test yaml

### DIFF
--- a/.github/workflows/run-e2e-tests.yaml
+++ b/.github/workflows/run-e2e-tests.yaml
@@ -89,7 +89,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: broadinstitute/dsp-reusable-workflows/.github/workflows/run_teaspoons_e2e_tests.yaml@main
+    uses: broadinstitute/dsp-reusable-workflows/.github/workflows/run_teaspoons_e2e_service_tests.yaml@main
     with:
       billing-project-name: '${{ needs.init-github-context-and-params-gen.outputs.project-name }}'
       bee-name: '${{ needs.init-github-context-and-params-gen.outputs.bee-name }}'


### PR DESCRIPTION
### Description 

Since we added an e2e test for the CLI, we renamed the e2e test files to more clearly distinguish between those used for the service and those used for the CLI. This PR updates the name of the e2e test yaml file we call to run the service e2e test.

Needs to be merged with this PR: https://github.com/broadinstitute/dsp-reusable-workflows/pull/59

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-331
