### PR TITLE
TSPS-340 return generic user facing message for 500 errors

### DIFF
--- a/service/src/main/java/bio/terra/pipelines/app/controller/GlobalExceptionHandler.java
+++ b/service/src/main/java/bio/terra/pipelines/app/controller/GlobalExceptionHandler.java
@@ -104,7 +104,7 @@ public class GlobalExceptionHandler {
   // -- catchall - log so we can understand what we have missed in the handlers above
   @ExceptionHandler(Exception.class)
   public ResponseEntity<ApiErrorReport> catchallHandler(Exception ex) {
-    logger.warn("Exception caught by catchall handler", ex);
+    logger.warn("Exception caught by catchall handler: {}", ex.getMessage());
     return buildApiErrorReport(ex, HttpStatus.INTERNAL_SERVER_ERROR, null, null);
   }
 
@@ -128,6 +128,12 @@ public class GlobalExceptionHandler {
       combinedCauseString.append("cause: ").append(cause).append(", ");
     }
     logger.error("Global exception handler: {}", combinedCauseString, ex);
+
+    // sanitize user facing message for 500 errors coming through controller
+    if (statusCode.is5xxServerError()) {
+      messageForApiErrorReport =
+          "Internal server error. Please contact support at scientific-services-support@broadinstitute.org for further assistance";
+    }
 
     ApiErrorReport errorReport =
         new ApiErrorReport()

--- a/service/src/test/java/bio/terra/pipelines/controller/PipelinesApiControllerTest.java
+++ b/service/src/test/java/bio/terra/pipelines/controller/PipelinesApiControllerTest.java
@@ -209,4 +209,23 @@ class PipelinesApiControllerTest {
             result ->
                 assertInstanceOf(InvalidPipelineException.class, result.getResolvedException()));
   }
+
+  @Test
+  void getPipelines500ErrorGenericSupportResponse() throws Exception {
+    when(pipelinesServiceMock.getPipelines()).thenThrow(new RuntimeException("test exception"));
+
+    MvcResult result =
+        mockMvc
+            .perform(get("/api/pipelines/v1"))
+            .andExpect(status().is5xxServerError())
+            .andReturn();
+
+    ApiErrorReport response =
+        new ObjectMapper()
+            .readValue(result.getResponse().getContentAsString(), ApiErrorReport.class);
+
+    assertEquals(
+        "Internal server error. Please contact support at scientific-services-support@broadinstitute.org for further assistance",
+        response.getMessage());
+  }
 }


### PR DESCRIPTION
### Description 

This will return a user facing generic support message for any 500 api response.  The actual error is still logged per usual

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-340