### PR TITLE
TSPS-396 Add support email instruction to notification templates

### DIFF
--- a/notification-templates/job_failed.html
+++ b/notification-templates/job_failed.html
@@ -230,7 +230,7 @@
                             </tr>
                             <tr>
                                 <td align="center" style="font-family: 'Montserrat', Arial, sans-serif; color:#333F52; font-size:20px; line-height: 24px; letter-spacing:1px;">
-                                    For help troubleshooting, respond to this email.
+                                    For help troubleshooting, email <a href="mailto:scientific-services-support@broadinstitute.org">scientific-services-support@broadinstitute.org</a>.
                                 </td>
                             </tr>
                             <tr>

--- a/notification-templates/job_succeeded.html
+++ b/notification-templates/job_succeeded.html
@@ -285,7 +285,7 @@
                                             <td>%userDescription%</td>
                                         </tr>
                                     </table>
-                                    If you have any questions, respond to this email.
+                                    If you have any questions, email <a href="mailto:scientific-services-support@broadinstitute.org">scientific-services-support@broadinstitute.org</a>.
                                 </td>
                             </tr>
                             <!--end thank you content-->
@@ -393,6 +393,7 @@
 
 <!--footer-->
 <table class="full" align="center" width="100%" border="0" cellspacing="0" cellpadding="0">
+
 </table></td></tr></table>
 </body>
 


### PR DESCRIPTION
### Description 

Checking in the changes made in SendGrid to add an instruction to email the scientific-services-support@broadinstitute.org email address for help (instead of replying to the email, which would go to the generic support@terra.bio address).

Updated in dev SendGrid (screenshot to note updated time):
<img width="1165" alt="image" src="https://github.com/user-attachments/assets/be76434a-5029-446f-8452-71ae7fe1cece" />

And in prod SendGrid:
<img width="1175" alt="image" src="https://github.com/user-attachments/assets/0a5280ba-058b-423d-b260-fca8113d168a" />



### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-396
