### PR TITLE
TSPS-424 add dsde qa slack notification to e2e test workflow

### DIFF
--- a/.github/workflows/run-e2e-tests.yaml
+++ b/.github/workflows/run-e2e-tests.yaml
@@ -131,3 +131,11 @@ jobs:
       notify-slack-channels-upon-workflow-completion: "#terra-teaspoons-alerts"
     permissions:
       id-token: write
+
+  report-workflow-to-qa:
+    uses: broadinstitute/sherlock/.github/workflows/client-report-workflow.yaml@main
+    if: github.ref == 'refs/heads/main' && github.event.inputs.version-template == 'staging'
+    with:
+      notify-slack-channels-upon-workflow-completion: "#dsde-qa"
+    permissions:
+      id-token: write


### PR DESCRIPTION
### Description 

We want #dsde-qa to be notified when our post deploy hook staging e2e workflow completes.  This is one way to do that

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-424