### PR TITLE
TSPS-424 fix up e2e test to have a environment specific slack message

### DIFF
--- a/.github/actions/create-bee/action.yml
+++ b/.github/actions/create-bee/action.yml
@@ -24,7 +24,6 @@ inputs:
     type: choice
     options:
       - dev
-      - alpha
       - staging
       - prod
 

--- a/.github/workflows/run-e2e-tests.yaml
+++ b/.github/workflows/run-e2e-tests.yaml
@@ -1,10 +1,5 @@
 name: Run Teaspoons e2e tests with BEE using GCP workspace
 on:
-  push:
-    branches:
-      - main
-    paths-ignore:
-      - '*.md'
   workflow_dispatch:
     inputs:
       custom-app-version:
@@ -34,22 +29,8 @@ env:
   TOKEN: '${{ secrets.BROADBOT_TOKEN }}'
   RUN_NAME_SUFFIX: ${{ github.event.repository.name }}-${{ github.run_id }}-${{github.run_attempt }}
 jobs:
-  bump-check:
-    runs-on: ubuntu-latest
-    outputs:
-      is-bump: ${{ steps.skiptest.outputs.is-bump }}
-    steps:
-      - uses: actions/checkout@v2
-      - name: Skip version bump merges
-        id: skiptest
-        uses: ./.github/actions/bump-skip
-        with:
-          event-name: ${{ github.event_name }}
-
   init-github-context-and-params-gen:
-    needs: [ bump-check ]
     runs-on: ubuntu-latest
-    if: needs.bump-check.outputs.is-bump == 'no'
     outputs:
       delete-bee: '${{ steps.extract-inputs-and-generate-params.outputs.delete-bee }}'
       custom-app-version-formatted: '${{ steps.extract-inputs-and-generate-params.outputs.custom-app-version-formatted }}'
@@ -86,8 +67,7 @@ jobs:
 
   create-bee-workflow:
     runs-on: ubuntu-latest
-    needs: [ bump-check, init-github-context-and-params-gen ]
-    if: needs.bump-check.outputs.is-bump == 'no'
+    needs: [ init-github-context-and-params-gen ]
     permissions:
       contents: read
       id-token: write
@@ -107,8 +87,7 @@ jobs:
           version-template: ${{ needs.init-github-context-and-params-gen.outputs.version-template }}
 
   run-e2e-test-job:
-    needs: [ bump-check, create-bee-workflow, init-github-context-and-params-gen ]
-    if: needs.bump-check.outputs.is-bump == 'no'
+    needs: [ create-bee-workflow, init-github-context-and-params-gen ]
     permissions:
       contents: read
       id-token: write
@@ -121,7 +100,7 @@ jobs:
 
   destroy-bee-workflow:
     runs-on: ubuntu-latest
-    needs: [ bump-check, run-e2e-test-job ]
+    needs: [ run-e2e-test-job ]
     if: '${{ needs.init-github-context-and-params-gen.outputs.delete-bee && always() }}'
     steps:
       - name: dispatch to terra-github-workflows
@@ -135,9 +114,9 @@ jobs:
           inputs: '{ "bee-name": "${{ env.BEE_NAME }}" }'
 
   report-workflow:
-    needs: [ bump-check, init-github-context-and-params-gen ]
+    needs: [ init-github-context-and-params-gen ]
     uses: broadinstitute/sherlock/.github/workflows/client-report-workflow.yaml@main
-    if: github.ref == 'refs/heads/main' && needs.bump-check.outputs.is-bump == 'no'
+    if: github.ref == 'refs/heads/main'
     with:
       notify-slack-channels-upon-workflow-completion: "#terra-teaspoons-alerts"
       relates-to-chart-releases: "teaspoons-${{ needs.init-github-context-and-params-gen.outputs.version-template }}"
@@ -145,9 +124,9 @@ jobs:
       id-token: write
 
   report-workflow-against-staging-to-qa:
-    needs: [ bump-check, init-github-context-and-params-gen ]
+    needs: [ init-github-context-and-params-gen ]
     uses: broadinstitute/sherlock/.github/workflows/client-report-workflow.yaml@main
-    if: github.ref == 'refs/heads/main' && needs.init-github-context-and-params-gen.outputs.version-template == 'staging' && needs.bump-check.outputs.is-bump == 'no'
+    if: github.ref == 'refs/heads/main' && needs.init-github-context-and-params-gen.outputs.version-template == 'staging'
     with:
       notify-slack-channels-upon-workflow-completion: "#dsde-qa"
       relates-to-chart-releases: "teaspoons-${{ needs.init-github-context-and-params-gen.outputs.version-template }}"

--- a/.github/workflows/run-e2e-tests.yaml
+++ b/.github/workflows/run-e2e-tests.yaml
@@ -27,7 +27,6 @@ on:
         type: choice
         options:
           - dev
-          - alpha
           - staging
           - prod
 env:
@@ -57,6 +56,7 @@ jobs:
       project-name: '${{ steps.extract-inputs-and-generate-params.outputs.project_name }}'
       bee-name: '${{ env.BEE_NAME }}'
       wdl-method-version: '${{ steps.extract-inputs-and-generate-params.outputs.wdl-method-version }}'
+      version-template: '${{ steps.extract-inputs-and-generate-params.outputs.version-template }}'
     steps:
       - uses: actions/checkout@v4
         with:
@@ -77,6 +77,11 @@ jobs:
             echo "wdl-method-version=$(git describe --tags $(git rev-list --tags --max-count=1))" >> $GITHUB_OUTPUT
           else
             echo "wdl-method-version=${{ inputs.wdl-method-version }}" >> $GITHUB_OUTPUT
+          fi
+          if [ -z ${{ inputs.version-template }} ]; then
+            echo "version-template=dev" >> $GITHUB_OUTPUT
+          else
+            echo "version-template=${{ inputs.version-template }}" >> $GITHUB_OUTPUT
           fi
 
   create-bee-workflow:
@@ -99,7 +104,7 @@ jobs:
           bee_name: ${{ env.BEE_NAME }}
           token: '${{ env.TOKEN }}'
           custom_version_json: ${{ needs.init-github-context-and-params-gen.outputs.custom-app-version-formatted }}
-          version-template: '${{ github.event.inputs.version-template }}'
+          version-template: ${{ needs.init-github-context-and-params-gen.outputs.version-template }}
 
   run-e2e-test-job:
     needs: [ bump-check, create-bee-workflow, init-github-context-and-params-gen ]
@@ -130,21 +135,21 @@ jobs:
           inputs: '{ "bee-name": "${{ env.BEE_NAME }}" }'
 
   report-workflow:
-    needs: [ bump-check ]
+    needs: [ bump-check, init-github-context-and-params-gen ]
     uses: broadinstitute/sherlock/.github/workflows/client-report-workflow.yaml@main
     if: github.ref == 'refs/heads/main' && needs.bump-check.outputs.is-bump == 'no'
     with:
       notify-slack-channels-upon-workflow-completion: "#terra-teaspoons-alerts"
-      relates-to-environments: '${{ github.event.inputs.version-template }}'
+      relates-to-chart-releases: "teaspoons-${{ needs.init-github-context-and-params-gen.outputs.version-template }}"
     permissions:
       id-token: write
 
   report-workflow-against-staging-to-qa:
-    needs: [ bump-check ]
+    needs: [ bump-check, init-github-context-and-params-gen ]
     uses: broadinstitute/sherlock/.github/workflows/client-report-workflow.yaml@main
-    if: github.ref == 'refs/heads/main' && github.event.inputs.version-template == 'staging' && needs.bump-check.outputs.is-bump == 'no'
+    if: github.ref == 'refs/heads/main' && needs.init-github-context-and-params-gen.outputs.version-template == 'staging' && needs.bump-check.outputs.is-bump == 'no'
     with:
       notify-slack-channels-upon-workflow-completion: "#dsde-qa"
-      relates-to-environments: '${{ github.event.inputs.version-template }}'
+      relates-to-chart-releases: "teaspoons-${{ needs.init-github-context-and-params-gen.outputs.version-template }}"
     permissions:
       id-token: write


### PR DESCRIPTION
### Description 

Relate our e2e slack messages to the associated "expected" app chart for the environment we're testing against

We also removed the e2e test being run on push to main in favor of running the e2e test on post [deploy hook for the dev environment](https://beehive.dsp-devops-prod.broadinstitute.org/environments/dev/chart-releases/teaspoons/deploy-hooks)

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-424