### PR TITLE
TSPS-400 add logic around pipeline runs and bucket TTLs

### DIFF
--- a/service/src/main/java/bio/terra/pipelines/app/controller/GlobalExceptionHandler.java
+++ b/service/src/main/java/bio/terra/pipelines/app/controller/GlobalExceptionHandler.java
@@ -132,7 +132,7 @@ public class GlobalExceptionHandler {
     // sanitize user facing message for 500 errors coming through controller
     if (statusCode.is5xxServerError()) {
       messageForApiErrorReport =
-          "Internal server error. Please contact support at scientific-services-support@broadinstitute.org for further assistance";
+          "Internal server error. Please contact support if this problem persists.";
     }
 
     ApiErrorReport errorReport =

--- a/service/src/main/java/bio/terra/pipelines/app/controller/PipelineRunsApiController.java
+++ b/service/src/main/java/bio/terra/pipelines/app/controller/PipelineRunsApiController.java
@@ -151,7 +151,7 @@ public class PipelineRunsApiController implements PipelineRunsApi {
         .plus(pipelinesCommonConfiguration.getUserDataTtlDays(), ChronoUnit.DAYS)
         .isBefore(Instant.now())) {
       throw new BadRequestException(
-          "Pipeline run was prepared more than %s days ago, it can not be started"
+          "Pipeline run was prepared more than %s days ago; it cannot be started"
               .formatted(pipelinesCommonConfiguration.getUserDataTtlDays()));
     }
 
@@ -178,7 +178,7 @@ public class PipelineRunsApiController implements PipelineRunsApi {
 
     if (pipelineRun.getStatus().equals(CommonPipelineRunStatusEnum.PREPARING)) {
       throw new BadRequestException(
-          "Pipeline run %s is still preparing, it has to be started before you can query the result"
+          "Pipeline run %s is still preparing; it has to be started before you can query the result"
               .formatted(jobId));
     }
 

--- a/service/src/test/java/bio/terra/pipelines/controller/PipelineRunsApiControllerTest.java
+++ b/service/src/test/java/bio/terra/pipelines/controller/PipelineRunsApiControllerTest.java
@@ -524,7 +524,6 @@ class PipelineRunsApiControllerTest {
 
   @Test
   void getPipelineRunResultDoneSuccessExpiredOutputs() throws Exception {
-    String pipelineName = PipelinesEnum.ARRAY_IMPUTATION.getValue();
     String jobIdString = newJobId.toString();
     PipelineRun pipelineRun =
         getPipelineRunWithStatusAndQuotaConsumed(

--- a/service/src/test/java/bio/terra/pipelines/controller/PipelineRunsApiControllerTest.java
+++ b/service/src/test/java/bio/terra/pipelines/controller/PipelineRunsApiControllerTest.java
@@ -92,7 +92,7 @@ class PipelineRunsApiControllerTest {
 
   private final Integer testQuotaConsumed = 10;
 
-  private final Long userTtlDays = 8L;
+  private final Long userDataTtlDays = 8L;
 
   @BeforeEach
   void beforeEach() {
@@ -104,7 +104,7 @@ class PipelineRunsApiControllerTest {
         .thenReturn(getTestPipeline());
     when(pipelinesServiceMock.getPipelineById(anyLong())).thenReturn(getTestPipeline());
     when(pipelinesServiceMock.getPipelines()).thenReturn(List.of(getTestPipeline()));
-    when(pipelinesCommonConfiguration.getUserDataTtlDays()).thenReturn(userTtlDays);
+    when(pipelinesCommonConfiguration.getUserDataTtlDays()).thenReturn(userDataTtlDays);
   }
 
   // preparePipelineRun tests
@@ -381,7 +381,7 @@ class PipelineRunsApiControllerTest {
     PipelineRun expiredPreparingPipelineRun =
         getPipelineRunWithStatusAndQuotaConsumed(CommonPipelineRunStatusEnum.PREPARING, null);
     expiredPreparingPipelineRun.setCreated(
-        expiredPreparingPipelineRun.getCreated().minus(userTtlDays + 1L, ChronoUnit.DAYS));
+        expiredPreparingPipelineRun.getCreated().minus(userDataTtlDays + 1L, ChronoUnit.DAYS));
     when(pipelineRunsServiceMock.getPipelineRun(newJobId, testUser.getSubjectId()))
         .thenReturn(expiredPreparingPipelineRun);
 
@@ -403,7 +403,7 @@ class PipelineRunsApiControllerTest {
 
     assertEquals(
         "Pipeline run was prepared more than %s days ago, it can not be started"
-            .formatted(userTtlDays),
+            .formatted(userDataTtlDays),
         response.getMessage());
   }
 
@@ -517,7 +517,7 @@ class PipelineRunsApiControllerTest {
     assertEquals(testPipelineWdlMethodVersion, pipelineRunReportResponse.getWdlMethodVersion());
     assertEquals(testOutputs, pipelineRunReportResponse.getOutputs());
     assertEquals(
-        updatedTime.plus(userTtlDays, ChronoUnit.DAYS).toString(),
+        updatedTime.plus(userDataTtlDays, ChronoUnit.DAYS).toString(),
         pipelineRunReportResponse.getOutputExpirationDate());
     assertNull(response.getErrorReport());
   }
@@ -530,7 +530,7 @@ class PipelineRunsApiControllerTest {
         getPipelineRunWithStatusAndQuotaConsumed(
             CommonPipelineRunStatusEnum.SUCCEEDED, testQuotaConsumed);
     // set the updated time to 10 days ago so that the outputs are expired
-    pipelineRun.setUpdated(updatedTime.minus(userTtlDays + 1L, ChronoUnit.DAYS));
+    pipelineRun.setUpdated(updatedTime.minus(userDataTtlDays + 1L, ChronoUnit.DAYS));
     ApiPipelineRunOutputs apiPipelineRunOutputs = new ApiPipelineRunOutputs();
     apiPipelineRunOutputs.putAll(testOutputs);
 

--- a/service/src/test/java/bio/terra/pipelines/controller/PipelinesApiControllerTest.java
+++ b/service/src/test/java/bio/terra/pipelines/controller/PipelinesApiControllerTest.java
@@ -225,7 +225,7 @@ class PipelinesApiControllerTest {
             .readValue(result.getResponse().getContentAsString(), ApiErrorReport.class);
 
     assertEquals(
-        "Internal server error. Please contact support at scientific-services-support@broadinstitute.org for further assistance",
+        "Internal server error. Please contact support if this problem persists.",
         response.getMessage());
   }
 }


### PR DESCRIPTION
### Description 

This PR addresses two cases around Bucket TTLs that will delete user data (inputs and outputs) in a way we can notify the user about

For the start endpoint, we return a 400 Bad Request for start requests whose created date is over EXPIRATION_DAYS old with a expiration related message

For the result endpoint, requests that are made EXPIRTATION_DAYS after the updated date, the service will not generate signed urls.  It will then be up to the CLI/UI to correctly parse the response and alert the user that their data is no longer available to download presumably by checking whether or not anything exists in the `pipeline_run_report.outputs` key

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-400