### PR TITLE
update workflow dispatch version to v4 for create bee action

### DIFF
--- a/.github/actions/create-bee/action.yml
+++ b/.github/actions/create-bee/action.yml
@@ -31,7 +31,7 @@ runs:
   using: 'composite'
   steps:
     - name: dispatch to terra-github-workflows
-      uses: broadinstitute/workflow-dispatch@v3
+      uses: broadinstitute/workflow-dispatch@v4
       with:
         workflow: bee-create
         repo: broadinstitute/terra-github-workflows


### PR DESCRIPTION
### Description 

This shoudl help with our create bee job accidentally grabbign someone elses create bee job  - https://github.com/broadinstitute/workflow-dispatch/releases/tag/v4

### Jira Ticket
N/A

### Checklist (provide links to changes)

- [x] Updated external documentation (if applicable)
- [x] Updated internal documentation (if applicable)
- [x] Planned non patch version bump (if applicable)
- [x] Updated CLI PR (if applicable)
