### PR TITLE
TSPS-380 Set required response fields to aid in CLI type checking

### DIFF
--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -645,6 +645,7 @@ components:
     GetPipelinesResult:
       description: result of a getPipelines request
       type: object
+      required: [ results ]
       properties:
         results:
           description: List of retrieved pipelines
@@ -910,6 +911,7 @@ components:
     PreparePipelineRunResponse:
         description: Result of the preparePipelineRun request, containing signed URLs to upload input files
         type: object
+        required: [ jobId, fileInputUploadUrls ]
         properties:
             jobId:
               $ref: '#/components/schemas/Id'


### PR DESCRIPTION
### Description 

This supports the CLI PR for TSPS-380 by specifying that certain fields in our API responses are required (not optional), meaning the CLI doesn't have to deal with the event that they are not present.

Tested with the CLI locally to ensure that this resolves the mypy type checking issues there.

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-380

### Checklist (provide links to changes)

- [ ] Updated external documentation (if applicable)
- [ ] Updated internal documentation (if applicable)
- [ ] Planned non patch version bump (if applicable)
- [ ] AFTER MERGE: Updated CLI PR: https://github.com/DataBiosphere/terra-scientific-pipelines-service-cli/pull/40
