### PR TITLE
TSPS-404 Update to TCL 1.1.36 to get 401 response for Sam user not found

### DIFF
--- a/.github/workflows/tag-publish.yml
+++ b/.github/workflows/tag-publish.yml
@@ -154,7 +154,7 @@ jobs:
           token: ${{ secrets.BROADBOT_TOKEN }}
 
       - name: Cache Gradle packages
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches

--- a/buildSrc/src/main/groovy/bio.terra.pipelines.java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/bio.terra.pipelines.java-common-conventions.gradle
@@ -44,7 +44,7 @@ dependencies {
 
     testImplementation 'org.hamcrest:hamcrest:2.2'
 
-    implementation 'bio.terra:terra-common-lib:1.1.35-SNAPSHOT'
+    implementation 'bio.terra:terra-common-lib:1.1.36-SNAPSHOT'
     implementation platform('com.google.cloud:libraries-bom:26.33.0') // required for TCL
 
     implementation 'io.swagger.core.v3:swagger-annotations:2.2.12'


### PR DESCRIPTION
### Description 

With this change, we now get back a 401 rather than a 500 from TCL/Sam when Sam doesn't recognize the user calling a Teaspoons API endpoint.

This supports a PR in the terralab repo: https://github.com/DataBiosphere/terra-scientific-pipelines-service-cli/pull/42

```
{
  "message": "User not found",
  "statusCode": 401,
  "causes": []
}
```

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-404

### Checklist (provide links to changes)

- [ ] Updated external documentation (if applicable)
- [ ] Updated internal documentation (if applicable)
- [ ] Planned non patch version bump (if applicable)
- [x] Updated CLI PR: https://github.com/DataBiosphere/terra-scientific-pipelines-service-cli/pull/42
