### PR TITLE
TSPS-384 rename wdl specific columns

### DIFF
--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -572,7 +572,7 @@ components:
       description: |
         Object containing the pipeline identifier, version, display name, description, and control workspace information for a Pipeline.
       type: object
-      required: [ pipelineName, pipelineVersion, displayName, description, workspaceBillingProject, workspaceName, workspaceStorageContainerName, workspaceGoogleProject, wdlMethodVersion ]
+      required: [ pipelineName, pipelineVersion, displayName, description, workspaceBillingProject, workspaceName, workspaceStorageContainerName, workspaceGoogleProject, toolVersion ]
       properties:
         pipelineName:
           $ref: "#/components/schemas/PipelineName"
@@ -582,8 +582,8 @@ components:
           $ref: "#/components/schemas/PipelineDisplayName"
         description:
           $ref: "#/components/schemas/PipelineDescription"
-        wdlMethodVersion:
-          $ref: "#/components/schemas/PipelineWdlMethodVersion"
+        toolVersion:
+          $ref: "#/components/schemas/PipelineToolVersion"
         workspaceBillingProject:
           $ref: "#/components/schemas/PipelineWorkspaceBillingProject"
         workspaceName:
@@ -774,14 +774,14 @@ components:
       description: |
         Object containing metadata about the pipeline that was run, as well as pipeline run outputs if the run has completed successfully.
       type: object
-      required: [ pipelineName, pipelineVersion, wdlMethodVersion ]
+      required: [ pipelineName, pipelineVersion, toolVersion ]
       properties:
         pipelineName:
           $ref: "#/components/schemas/PipelineName"
         pipelineVersion:
           $ref: "#/components/schemas/PipelineVersion"
-        wdlMethodVersion:
-          $ref: "#/components/schemas/PipelineWdlMethodVersion"
+        toolVersion:
+          $ref: "#/components/schemas/PipelineToolVersion"
         outputs:
           $ref: "#/components/schemas/PipelineRunOutputs"
         outputExpirationDate:
@@ -799,6 +799,11 @@ components:
       type: object
       additionalProperties:
         $ref: "#/components/schemas/AnyTypeMapsToJavaObject"
+
+    PipelineToolVersion:
+      description: |
+        An identifier string for the Pipeline Tool Version i.e. github repo tag/branch/release
+      type: string
 
     PipelineType:
       description: |
@@ -836,11 +841,6 @@ components:
       description: |
         An identifier Integer for the Pipeline Version.
       type: integer
-
-    PipelineWdlMethodVersion:
-      description: |
-        An identifier string for the Pipeline Wdl Version i.e. github repo tag/branch/release
-      type: string
 
     PipelineWorkspaceGoogleProject:
       description: |
@@ -958,14 +958,14 @@ components:
       description: |
         json object containing the admin provided information to update a pipeline with
       type: object
-      required: [ workspaceBillingProject, workspaceName, wdlMethodVersion ]
+      required: [ workspaceBillingProject, workspaceName, toolVersion ]
       properties:
         workspaceBillingProject:
           $ref: "#/components/schemas/PipelineWorkspaceBillingProject"
         workspaceName:
           $ref: "#/components/schemas/PipelineWorkspaceName"
-        wdlMethodVersion:
-          $ref: "#/components/schemas/PipelineWdlMethodVersion"
+        toolVersion:
+          $ref: "#/components/schemas/PipelineToolVersion"
 
     UpdateQuotaLimitRequestBody:
       description: |

--- a/service/src/main/java/bio/terra/pipelines/app/controller/AdminApiController.java
+++ b/service/src/main/java/bio/terra/pipelines/app/controller/AdminApiController.java
@@ -97,14 +97,14 @@ public class AdminApiController implements AdminApi {
         PipelineApiUtils.validatePipelineName(pipelineName, logger);
     String workspaceBillingProject = body.getWorkspaceBillingProject();
     String workspaceName = body.getWorkspaceName();
-    String wdlMethodVersion = body.getWdlMethodVersion();
+    String toolVersion = body.getToolVersion();
     Pipeline updatedPipeline =
         pipelinesService.adminUpdatePipelineWorkspace(
             validatedPipelineName,
             pipelineVersion,
             workspaceBillingProject,
             workspaceName,
-            wdlMethodVersion);
+            toolVersion);
     return new ResponseEntity<>(pipelineToApiAdminPipeline(updatedPipeline), HttpStatus.OK);
   }
 
@@ -142,7 +142,7 @@ public class AdminApiController implements AdminApi {
         .workspaceName(pipeline.getWorkspaceName())
         .workspaceStorageContainerName(pipeline.getWorkspaceStorageContainerName())
         .workspaceGoogleProject(pipeline.getWorkspaceGoogleProject())
-        .wdlMethodVersion(pipeline.getWdlMethodVersion());
+        .toolVersion(pipeline.getToolVersion());
   }
 
   public ApiAdminQuota userQuotaToApiAdminQuota(UserQuota userQuota) {

--- a/service/src/main/java/bio/terra/pipelines/app/controller/PipelineRunsApiController.java
+++ b/service/src/main/java/bio/terra/pipelines/app/controller/PipelineRunsApiController.java
@@ -259,9 +259,8 @@ public class PipelineRunsApiController implements PipelineRunsApi {
         new ApiPipelineRunReport()
             .pipelineName(pipeline.getName().getValue())
             .pipelineVersion(pipeline.getVersion())
-            .wdlMethodVersion(
-                pipelineRun
-                    .getWdlMethodVersion())); // wdlMethodVersion comes from pipelineRun, since the
+            .toolVersion(
+                pipelineRun.getToolVersion())); // toolVersion comes from pipelineRun, since the
     // pipeline might have been updated since the pipelineRun began
 
     // if the pipeline run is successful, return the job report and add outputs to the response

--- a/service/src/main/java/bio/terra/pipelines/db/entities/Pipeline.java
+++ b/service/src/main/java/bio/terra/pipelines/db/entities/Pipeline.java
@@ -44,11 +44,11 @@ public class Pipeline {
   @Column(name = "wdl_url")
   private String wdlUrl;
 
-  @Column(name = "wdl_method_name")
-  private String wdlMethodName;
+  @Column(name = "tool_name")
+  private String toolName;
 
-  @Column(name = "wdl_method_version")
-  private String wdlMethodVersion;
+  @Column(name = "tool_version")
+  private String toolVersion;
 
   @Column(name = "workspace_id")
   private UUID workspaceId;
@@ -81,8 +81,8 @@ public class Pipeline {
       String description,
       String pipelineType,
       String wdlUrl,
-      String wdlMethodName,
-      String wdlMethodVersion,
+      String toolName,
+      String toolVersion,
       UUID workspaceId,
       String workspaceBillingProject,
       String workspaceName,
@@ -96,8 +96,8 @@ public class Pipeline {
     this.description = description;
     this.pipelineType = pipelineType;
     this.wdlUrl = wdlUrl;
-    this.wdlMethodName = wdlMethodName;
-    this.wdlMethodVersion = wdlMethodVersion;
+    this.toolName = toolName;
+    this.toolVersion = toolVersion;
     this.workspaceId = workspaceId;
     this.workspaceBillingProject = workspaceBillingProject;
     this.workspaceName = workspaceName;
@@ -116,8 +116,8 @@ public class Pipeline {
         .add("description=" + description)
         .add("pipelineType=" + pipelineType)
         .add("wdlUrl=" + wdlUrl)
-        .add("wdlMethodName=" + wdlMethodName)
-        .add("wdlMethodVersion=" + wdlMethodVersion)
+        .add("toolName=" + toolName)
+        .add("toolVersion=" + toolVersion)
         .add("workspaceId=" + workspaceId)
         .add("workspaceBillingProject=" + workspaceBillingProject)
         .add("workspaceName=" + workspaceName)
@@ -143,8 +143,8 @@ public class Pipeline {
         .append(description)
         .append(pipelineType)
         .append(wdlUrl)
-        .append(wdlMethodName)
-        .append(wdlMethodVersion)
+        .append(toolName)
+        .append(toolVersion)
         .append(workspaceId)
         .append(workspaceBillingProject)
         .append(workspaceName)
@@ -166,8 +166,8 @@ public class Pipeline {
         .append(description, otherObject.description)
         .append(pipelineType, otherObject.pipelineType)
         .append(wdlUrl, otherObject.wdlUrl)
-        .append(wdlMethodName, otherObject.wdlMethodName)
-        .append(wdlMethodVersion, otherObject.wdlMethodVersion)
+        .append(toolName, otherObject.toolName)
+        .append(toolVersion, otherObject.toolVersion)
         .append(workspaceId, otherObject.workspaceId)
         .append(workspaceBillingProject, otherObject.workspaceBillingProject)
         .append(workspaceName, otherObject.workspaceName)

--- a/service/src/main/java/bio/terra/pipelines/db/entities/PipelineRun.java
+++ b/service/src/main/java/bio/terra/pipelines/db/entities/PipelineRun.java
@@ -37,8 +37,8 @@ public class PipelineRun {
   @Column(name = "pipeline_id", nullable = false)
   private Long pipelineId;
 
-  @Column(name = "wdl_method_version")
-  private String wdlMethodVersion;
+  @Column(name = "tool_version")
+  private String toolVersion;
 
   @Column(name = "workspace_id")
   private UUID workspaceId;
@@ -77,7 +77,7 @@ public class PipelineRun {
       UUID jobId,
       String userId,
       Long pipelineId,
-      String wdlMethodVersion,
+      String toolVersion,
       UUID workspaceId,
       String workspaceBillingProject,
       String workspaceName,
@@ -91,7 +91,7 @@ public class PipelineRun {
     this.jobId = jobId;
     this.userId = userId;
     this.pipelineId = pipelineId;
-    this.wdlMethodVersion = wdlMethodVersion;
+    this.toolVersion = toolVersion;
     this.workspaceId = workspaceId;
     this.workspaceBillingProject = workspaceBillingProject;
     this.workspaceName = workspaceName;
@@ -109,7 +109,7 @@ public class PipelineRun {
       UUID jobId,
       String userId,
       Long pipelineId,
-      String wdlMethodVersion,
+      String toolVersion,
       String workspaceBillingProject,
       String workspaceName,
       String workspaceStorageContainerName,
@@ -119,7 +119,7 @@ public class PipelineRun {
     this.jobId = jobId;
     this.userId = userId;
     this.pipelineId = pipelineId;
-    this.wdlMethodVersion = wdlMethodVersion;
+    this.toolVersion = toolVersion;
     this.workspaceBillingProject = workspaceBillingProject;
     this.workspaceName = workspaceName;
     this.workspaceStorageContainerName = workspaceStorageContainerName;

--- a/service/src/main/java/bio/terra/pipelines/service/PipelineRunsService.java
+++ b/service/src/main/java/bio/terra/pipelines/service/PipelineRunsService.java
@@ -101,7 +101,7 @@ public class PipelineRunsService {
         jobId,
         userId,
         pipeline.getId(),
-        pipeline.getWdlMethodVersion(),
+        pipeline.getToolVersion(),
         pipeline.getWorkspaceBillingProject(),
         pipeline.getWorkspaceName(),
         pipeline.getWorkspaceStorageContainerName(),
@@ -182,8 +182,8 @@ public class PipelineRunsService {
             .addParameter(
                 ImputationJobMapKeys.CONTROL_WORKSPACE_STORAGE_CONTAINER_PROTOCOL,
                 "gs://") // this is the GCP storage url protocol
-            .addParameter(ImputationJobMapKeys.WDL_METHOD_NAME, pipeline.getWdlMethodName())
-            .addParameter(ImputationJobMapKeys.WDL_METHOD_VERSION, pipeline.getWdlMethodVersion());
+            .addParameter(ImputationJobMapKeys.WDL_METHOD_NAME, pipeline.getToolName())
+            .addParameter(ImputationJobMapKeys.WDL_METHOD_VERSION, pipeline.getToolVersion());
 
     jobBuilder.submit();
 
@@ -207,7 +207,7 @@ public class PipelineRunsService {
       UUID jobUuid,
       String userId,
       Long pipelineId,
-      String wdlMethodVersion,
+      String toolVersion,
       String controlWorkspaceProject,
       String controlWorkspaceName,
       String controlWorkspaceStorageContainerUrl,
@@ -221,7 +221,7 @@ public class PipelineRunsService {
             jobUuid,
             userId,
             pipelineId,
-            wdlMethodVersion,
+            toolVersion,
             controlWorkspaceProject,
             controlWorkspaceName,
             controlWorkspaceStorageContainerUrl,

--- a/service/src/main/java/bio/terra/pipelines/service/PipelinesService.java
+++ b/service/src/main/java/bio/terra/pipelines/service/PipelinesService.java
@@ -102,7 +102,7 @@ public class PipelinesService {
    * @param pipelineName - name of pipeline to update
    * @param workspaceBillingProject - workspace billing project to update to
    * @param workspaceName - workspace name to update to
-   * @param wdlMethodVersion - version of wdl expected to run for corresponding pipeline. must align
+   * @param toolVersion - version of the tool expected to run for corresponding pipeline. must align
    *     with pipeline version
    */
   public Pipeline adminUpdatePipelineWorkspace(
@@ -110,7 +110,7 @@ public class PipelinesService {
       Integer pipelineVersion,
       @NotNull String workspaceBillingProject,
       @NotNull String workspaceName,
-      @NotNull String wdlMethodVersion) {
+      @NotNull String toolVersion) {
     WorkspaceDetails workspaceDetails =
         rawlsService.getWorkspaceDetails(
             samService.getTeaspoonsServiceAccountToken(), workspaceBillingProject, workspaceName);
@@ -123,28 +123,27 @@ public class PipelinesService {
     pipeline.setWorkspaceStorageContainerName(workspaceStorageContainerUrl);
     pipeline.setWorkspaceGoogleProject(workspaceGoogleProject);
 
-    // ensure wdlMethodVersion follows semantic versioning regex (can be preceded by a string ending
+    // ensure toolVersion follows semantic versioning regex (can be preceded by a string ending
     // in v)
     final Pattern pattern = Pattern.compile(SEM_VER_REGEX_STRING);
-    final Matcher matcher = pattern.matcher(wdlMethodVersion);
+    final Matcher matcher = pattern.matcher(toolVersion);
     if (!matcher.matches()) {
       throw new ValidationException(
           String.format(
-              "wdlMethodVersion %s does not follow semantic versioning regex %s",
-              wdlMethodVersion, SEM_VER_REGEX_STRING));
+              "toolVersion %s does not follow semantic versioning regex %s",
+              toolVersion, SEM_VER_REGEX_STRING));
     }
 
-    // ensure that major version of wdlMethodVersion matches the value of the pipeline version.
-    // split wdlMethodVersion by 'v' and take the last element of the resulting array
-    String wdlMethodExtractedSemVer =
-        wdlMethodVersion.split("v")[wdlMethodVersion.split("v").length - 1];
+    // ensure that major version of toolVersion matches the value of the pipeline version.
+    // split toolVersion by 'v' and take the last element of the resulting array
+    String wdlMethodExtractedSemVer = toolVersion.split("v")[toolVersion.split("v").length - 1];
     if (pipeline.getVersion().equals(Integer.parseInt(wdlMethodExtractedSemVer.split("\\.")[0]))) {
-      pipeline.setWdlMethodVersion(wdlMethodVersion);
+      pipeline.setToolVersion(toolVersion);
     } else {
       throw new ValidationException(
           String.format(
-              "wdlMethodVersion %s does not align with pipeline version %s. The major version of wdlMethodVersion must match pipeline version",
-              wdlMethodVersion, pipeline.getVersion()));
+              "toolVersion %s does not align with pipeline version %s. The major version of toolVersion must match pipeline version",
+              toolVersion, pipeline.getVersion()));
     }
     pipelinesRepository.save(pipeline);
     return pipeline;

--- a/service/src/main/resources/db/changelog.xml
+++ b/service/src/main/resources/db/changelog.xml
@@ -10,6 +10,7 @@
   <include file="changesets/20241212_add_min_quota_for_pipelines.yaml" relativeToChangelogFile="true"/>
   <include file="changesets/20241212_add_quota_consumed_update_pipeline_display_name.yaml" relativeToChangelogFile="true"/>
   <include file="changesets/20250127_add_expects_custom_value_field_to_input_defs.yaml" relativeToChangelogFile="true"/>
+  <include file="changesets/20250220_rename_wdl_method_version_and_wdl_method_name.yaml" relativeToChangelogFile="true"/>
 
   <include file="changesets/testdata.yaml" relativeToChangelogFile="true"/>
 

--- a/service/src/main/resources/db/changesets/20250220_rename_wdl_method_version_and_wdl_method_name.yaml
+++ b/service/src/main/resources/db/changesets/20250220_rename_wdl_method_version_and_wdl_method_name.yaml
@@ -1,0 +1,24 @@
+# rename wdl_method_version and wdl_method_name to tool_version and tool_name in pipeline and pipeline_runs table
+
+databaseChangeLog:
+  -  changeSet:
+       id:  rename wdl_method_version and wdl_method_name columns
+       author:  js
+       changes:
+           # rename pipelines table wdl_method_version column to tool_version
+         - renameColumn:
+            tableName:  pipelines
+            oldColumnName:  wdl_method_version
+            newColumnName:  tool_version
+
+         # rename pipelines table wdl_method_name column to tool_name
+         - renameColumn:
+            tableName:  pipelines
+            oldColumnName:  wdl_method_name
+            newColumnName:  tool_name
+
+         # rename pipeline_runs table wdl_method_version column to tool_version
+         - renameColumn:
+            tableName:  pipeline_runs
+            oldColumnName:  wdl_method_version
+            newColumnName:  tool_version

--- a/service/src/test/java/bio/terra/pipelines/common/utils/StairwaySendFailedJobNotificationHookTest.java
+++ b/service/src/test/java/bio/terra/pipelines/common/utils/StairwaySendFailedJobNotificationHookTest.java
@@ -22,13 +22,13 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 class StairwaySendFailedJobNotificationHookTest extends BaseEmbeddedDbTest {
   @Autowired @InjectMocks
   StairwaySendFailedJobNotificationHook stairwaySendFailedJobNotificationHook;
 
-  @MockBean NotificationService notificationService;
+  @MockitoBean NotificationService notificationService;
 
   @Mock private FlightContext flightContext;
 

--- a/service/src/test/java/bio/terra/pipelines/controller/AdminApiControllerTest.java
+++ b/service/src/test/java/bio/terra/pipelines/controller/AdminApiControllerTest.java
@@ -36,21 +36,21 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
 @ContextConfiguration(classes = {AdminApiController.class, GlobalExceptionHandler.class})
 @WebMvcTest()
 class AdminApiControllerTest {
-  @MockBean PipelinesService pipelinesServiceMock;
-  @MockBean QuotasService quotasServiceMock;
-  @MockBean SamUserFactory samUserFactoryMock;
-  @MockBean BearerTokenFactory bearerTokenFactory;
-  @MockBean SamConfiguration samConfiguration;
-  @MockBean SamService samServiceMock;
+  @MockitoBean PipelinesService pipelinesServiceMock;
+  @MockitoBean QuotasService quotasServiceMock;
+  @MockitoBean SamUserFactory samUserFactoryMock;
+  @MockitoBean BearerTokenFactory bearerTokenFactory;
+  @MockitoBean SamConfiguration samConfiguration;
+  @MockitoBean SamService samServiceMock;
 
   @Autowired private MockMvc mockMvc;
   private final SamUser testUser = MockMvcUtils.TEST_SAM_USER;
@@ -70,7 +70,7 @@ class AdminApiControllerTest {
             TestUtils.TEST_PIPELINE_VERSION_1,
             TEST_WORKSPACE_BILLING_PROJECT,
             TEST_WORKSPACE_NAME,
-            TEST_WDL_METHOD_VERSION))
+            TEST_TOOL_VERSION))
         .thenReturn(MockMvcUtils.getTestPipeline());
     MvcResult result =
         mockMvc
@@ -85,7 +85,7 @@ class AdminApiControllerTest {
                         createTestJobPostBody(
                             TEST_WORKSPACE_BILLING_PROJECT,
                             TEST_WORKSPACE_NAME,
-                            TEST_WDL_METHOD_VERSION)))
+                            TEST_TOOL_VERSION)))
             .andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON))
             .andReturn();
@@ -101,7 +101,7 @@ class AdminApiControllerTest {
     assertEquals(
         TEST_WORKSPACE_STORAGE_CONTAINER_NAME, response.getWorkspaceStorageContainerName());
     assertEquals(TEST_WORKSPACE_GOOGLE_PROJECT, response.getWorkspaceGoogleProject());
-    assertEquals(TEST_WDL_METHOD_VERSION, response.getWdlMethodVersion());
+    assertEquals(TEST_TOOL_VERSION, response.getToolVersion());
   }
 
   @Test
@@ -115,8 +115,7 @@ class AdminApiControllerTest {
                         TestUtils.TEST_PIPELINE_VERSION_1))
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(
-                    createTestJobPostBody(
-                        TEST_WORKSPACE_BILLING_PROJECT, null, TEST_WDL_METHOD_VERSION)))
+                    createTestJobPostBody(TEST_WORKSPACE_BILLING_PROJECT, null, TEST_TOOL_VERSION)))
         .andExpect(status().isBadRequest());
   }
 
@@ -130,12 +129,12 @@ class AdminApiControllerTest {
                         PipelinesEnum.ARRAY_IMPUTATION.getValue(),
                         TestUtils.TEST_PIPELINE_VERSION_1))
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(createTestJobPostBody(null, TEST_WORKSPACE_NAME, TEST_WDL_METHOD_VERSION)))
+                .content(createTestJobPostBody(null, TEST_WORKSPACE_NAME, TEST_TOOL_VERSION)))
         .andExpect(status().isBadRequest());
   }
 
   @Test
-  void updatePipelineWorkspaceIdRequireWdlMethodVersion() throws Exception {
+  void updatePipelineWorkspaceIdRequireToolVersion() throws Exception {
     mockMvc
         .perform(
             patch(
@@ -164,9 +163,7 @@ class AdminApiControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(
                     createTestJobPostBody(
-                        TEST_WORKSPACE_BILLING_PROJECT,
-                        TEST_WORKSPACE_NAME,
-                        TEST_WDL_METHOD_VERSION)))
+                        TEST_WORKSPACE_BILLING_PROJECT, TEST_WORKSPACE_NAME, TEST_TOOL_VERSION)))
         .andExpect(status().isForbidden());
   }
 
@@ -177,7 +174,7 @@ class AdminApiControllerTest {
             TestUtils.TEST_PIPELINE_VERSION_1,
             TEST_WORKSPACE_BILLING_PROJECT,
             TEST_WORKSPACE_NAME,
-            TEST_WDL_METHOD_VERSION))
+            TEST_TOOL_VERSION))
         .thenThrow(new NotFoundException("badversion"));
 
     mockMvc
@@ -190,9 +187,7 @@ class AdminApiControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(
                     createTestJobPostBody(
-                        TEST_WORKSPACE_BILLING_PROJECT,
-                        TEST_WORKSPACE_NAME,
-                        TEST_WDL_METHOD_VERSION)))
+                        TEST_WORKSPACE_BILLING_PROJECT, TEST_WORKSPACE_NAME, TEST_TOOL_VERSION)))
         .andExpect(status().isNotFound());
   }
 
@@ -384,13 +379,13 @@ class AdminApiControllerTest {
   }
 
   private String createTestJobPostBody(
-      String workspaceBillingProject, String workspaceName, String wdlMethodVersion)
+      String workspaceBillingProject, String workspaceName, String toolVersion)
       throws JsonProcessingException {
     ApiUpdatePipelineRequestBody apiUpdatePipelineRequestBody =
         new ApiUpdatePipelineRequestBody()
             .workspaceBillingProject(workspaceBillingProject)
             .workspaceName(workspaceName)
-            .wdlMethodVersion(wdlMethodVersion);
+            .toolVersion(toolVersion);
     return MockMvcUtils.convertToJsonString(apiUpdatePipelineRequestBody);
   }
 

--- a/service/src/test/java/bio/terra/pipelines/controller/JobsApiControllerTest.java
+++ b/service/src/test/java/bio/terra/pipelines/controller/JobsApiControllerTest.java
@@ -34,21 +34,21 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
 @ContextConfiguration(classes = {JobsApiController.class, GlobalExceptionHandler.class})
 @WebMvcTest()
 class JobsApiControllerTest {
-  @MockBean JobService jobServiceMock;
-  @MockBean PipelinesService pipelinesServiceMock;
-  @MockBean SamUserFactory samUserFactoryMock;
-  @MockBean BearerTokenFactory bearerTokenFactory;
-  @MockBean SamConfiguration samConfiguration;
-  @MockBean SamService samService;
+  @MockitoBean JobService jobServiceMock;
+  @MockitoBean PipelinesService pipelinesServiceMock;
+  @MockitoBean SamUserFactory samUserFactoryMock;
+  @MockitoBean BearerTokenFactory bearerTokenFactory;
+  @MockitoBean SamConfiguration samConfiguration;
+  @MockitoBean SamService samService;
 
   @Autowired private MockMvc mockMvc;
   private final SamUser testUser = MockMvcUtils.TEST_SAM_USER;

--- a/service/src/test/java/bio/terra/pipelines/controller/PipelineRunsApiControllerTest.java
+++ b/service/src/test/java/bio/terra/pipelines/controller/PipelineRunsApiControllerTest.java
@@ -56,11 +56,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
@@ -69,21 +69,21 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 @ContextConfiguration(classes = {PipelineRunsApiController.class, GlobalExceptionHandler.class})
 @WebMvcTest
 class PipelineRunsApiControllerTest {
-  @MockBean PipelinesService pipelinesServiceMock;
-  @MockBean PipelineRunsService pipelineRunsServiceMock;
-  @MockBean PipelineInputsOutputsService pipelineInputsOutputsServiceMock;
-  @MockBean JobService jobServiceMock;
-  @MockBean SamUserFactory samUserFactoryMock;
-  @MockBean BearerTokenFactory bearerTokenFactory;
-  @MockBean SamConfiguration samConfiguration;
-  @MockBean IngressConfiguration ingressConfiguration;
-  @MockBean PipelinesCommonConfiguration pipelinesCommonConfiguration;
+  @MockitoBean PipelinesService pipelinesServiceMock;
+  @MockitoBean PipelineRunsService pipelineRunsServiceMock;
+  @MockitoBean PipelineInputsOutputsService pipelineInputsOutputsServiceMock;
+  @MockitoBean JobService jobServiceMock;
+  @MockitoBean SamUserFactory samUserFactoryMock;
+  @MockitoBean BearerTokenFactory bearerTokenFactory;
+  @MockitoBean SamConfiguration samConfiguration;
+  @MockitoBean IngressConfiguration ingressConfiguration;
+  @MockitoBean PipelinesCommonConfiguration pipelinesCommonConfiguration;
 
   @Autowired private MockMvc mockMvc;
 
   private final SamUser testUser = MockMvcUtils.TEST_SAM_USER;
   private final int testPipelineVersion = TestUtils.TEST_PIPELINE_VERSION_1;
-  private final String testPipelineWdlMethodVersion = TestUtils.TEST_WDL_METHOD_VERSION_1;
+  private final String testPipelineToolVersion = TestUtils.TEST_TOOL_VERSION_1;
   private final Map<String, Object> testPipelineInputs = TestUtils.TEST_PIPELINE_INPUTS;
   private final UUID newJobId = TestUtils.TEST_NEW_UUID;
   private final Instant createdTime = Instant.now();
@@ -323,7 +323,7 @@ class PipelineRunsApiControllerTest {
     assertEquals(createdTime.toString(), response.getJobReport().getSubmitted());
     assertEquals(pipelineName, pipelineRunReportResponse.getPipelineName());
     assertEquals(testPipelineVersion, pipelineRunReportResponse.getPipelineVersion());
-    assertEquals(testPipelineWdlMethodVersion, pipelineRunReportResponse.getWdlMethodVersion());
+    assertEquals(testPipelineToolVersion, pipelineRunReportResponse.getToolVersion());
     assertNull(pipelineRunReportResponse.getOutputs());
     assertNull(response.getJobReport().getCompleted());
   }
@@ -531,7 +531,7 @@ class PipelineRunsApiControllerTest {
     assertEquals(updatedTime.toString(), response.getJobReport().getCompleted());
     assertEquals(pipelineName, pipelineRunReportResponse.getPipelineName());
     assertEquals(testPipelineVersion, pipelineRunReportResponse.getPipelineVersion());
-    assertEquals(testPipelineWdlMethodVersion, pipelineRunReportResponse.getWdlMethodVersion());
+    assertEquals(testPipelineToolVersion, pipelineRunReportResponse.getToolVersion());
     assertEquals(testOutputs, pipelineRunReportResponse.getOutputs());
     assertEquals(
         updatedTime.plus(userDataTtlDays, ChronoUnit.DAYS).toString(),
@@ -617,7 +617,7 @@ class PipelineRunsApiControllerTest {
     assertEquals(newJobId.toString(), response.getJobReport().getId());
     assertEquals(pipelineName, pipelineRunReportResponse.getPipelineName());
     assertEquals(testPipelineVersion, pipelineRunReportResponse.getPipelineVersion());
-    assertEquals(testPipelineWdlMethodVersion, pipelineRunReportResponse.getWdlMethodVersion());
+    assertEquals(testPipelineToolVersion, pipelineRunReportResponse.getToolVersion());
     assertNull(pipelineRunReportResponse.getOutputs());
     assertEquals(statusCode, response.getJobReport().getStatusCode());
     assertEquals(errorMessage, response.getErrorReport().getMessage());
@@ -664,7 +664,7 @@ class PipelineRunsApiControllerTest {
     assertEquals(statusCode, response.getJobReport().getStatusCode());
     assertEquals(pipelineName, pipelineRunReportResponse.getPipelineName());
     assertEquals(testPipelineVersion, pipelineRunReportResponse.getPipelineVersion());
-    assertEquals(testPipelineWdlMethodVersion, pipelineRunReportResponse.getWdlMethodVersion());
+    assertEquals(testPipelineToolVersion, pipelineRunReportResponse.getToolVersion());
     assertNull(pipelineRunReportResponse.getOutputs());
     assertNull(response.getErrorReport());
     assertNull(response.getPipelineRunReport().getOutputExpirationDate());
@@ -884,7 +884,7 @@ class PipelineRunsApiControllerTest {
         newJobId,
         testUser.getSubjectId(),
         TestUtils.TEST_PIPELINE_ID_1,
-        TestUtils.TEST_WDL_METHOD_VERSION_1,
+        TestUtils.TEST_TOOL_VERSION_1,
         TestUtils.CONTROL_WORKSPACE_ID,
         TestUtils.CONTROL_WORKSPACE_BILLING_PROJECT,
         TestUtils.CONTROL_WORKSPACE_NAME,

--- a/service/src/test/java/bio/terra/pipelines/controller/PipelinesApiControllerTest.java
+++ b/service/src/test/java/bio/terra/pipelines/controller/PipelinesApiControllerTest.java
@@ -31,20 +31,20 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
 @ContextConfiguration(classes = {PipelinesApiController.class, GlobalExceptionHandler.class})
 @WebMvcTest
 class PipelinesApiControllerTest {
-  @MockBean PipelinesService pipelinesServiceMock;
-  @MockBean SamUserFactory samUserFactoryMock;
-  @MockBean BearerTokenFactory bearerTokenFactory;
-  @MockBean SamConfiguration samConfiguration;
-  @MockBean SamService samService;
+  @MockitoBean PipelinesService pipelinesServiceMock;
+  @MockitoBean SamUserFactory samUserFactoryMock;
+  @MockitoBean BearerTokenFactory bearerTokenFactory;
+  @MockitoBean SamConfiguration samConfiguration;
+  @MockitoBean SamService samService;
 
   @Autowired private MockMvc mockMvc;
 

--- a/service/src/test/java/bio/terra/pipelines/controller/PublicApiControllerTest.java
+++ b/service/src/test/java/bio/terra/pipelines/controller/PublicApiControllerTest.java
@@ -18,8 +18,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -30,9 +30,9 @@ class PublicApiControllerTest extends BaseTest {
 
   @Autowired private MockMvc mockMvc;
 
-  @MockBean private ApiVersionProperties versionProperties;
-  @MockBean private StatusService statusService;
-  @MockBean private OidcConfiguration oidcConfiguration;
+  @MockitoBean private ApiVersionProperties versionProperties;
+  @MockitoBean private StatusService statusService;
+  @MockitoBean private OidcConfiguration oidcConfiguration;
 
   @BeforeEach
   void setup() {

--- a/service/src/test/java/bio/terra/pipelines/controller/QuotasControllerTest.java
+++ b/service/src/test/java/bio/terra/pipelines/controller/QuotasControllerTest.java
@@ -26,18 +26,18 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
 @ContextConfiguration(classes = {QuotasController.class, GlobalExceptionHandler.class})
 @WebMvcTest
 class QuotasControllerTest {
-  @MockBean QuotasService quotasServiceMock;
-  @MockBean SamUserFactory samUserFactoryMock;
-  @MockBean SamConfiguration samConfiguration;
+  @MockitoBean QuotasService quotasServiceMock;
+  @MockitoBean SamUserFactory samUserFactoryMock;
+  @MockitoBean SamConfiguration samConfiguration;
 
   @Autowired private MockMvc mockMvc;
 

--- a/service/src/test/java/bio/terra/pipelines/dependencies/cbas/CbasServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/dependencies/cbas/CbasServiceTest.java
@@ -23,14 +23,14 @@ import org.mockito.InjectMocks;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.stubbing.Answer;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.retry.backoff.FixedBackOffPolicy;
 import org.springframework.retry.support.RetryTemplate;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @ExtendWith(MockitoExtension.class)
 class CbasServiceTest extends BaseEmbeddedDbTest {
   @Autowired @InjectMocks CbasService cbasService;
-  @MockBean CbasClient cbasClient;
+  @MockitoBean CbasClient cbasClient;
 
   final RetryConfiguration retryConfig = new RetryConfiguration();
   RetryTemplate template = retryConfig.listenerResetRetryTemplate();

--- a/service/src/test/java/bio/terra/pipelines/dependencies/gcs/GcsServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/dependencies/gcs/GcsServiceTest.java
@@ -22,14 +22,14 @@ import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.stubbing.Answer;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.retry.backoff.FixedBackOffPolicy;
 import org.springframework.retry.support.RetryTemplate;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 class GcsServiceTest extends BaseEmbeddedDbTest {
 
   @Autowired @InjectMocks private GcsService gcsService;
-  @MockBean private GcsClient gcsClient;
+  @MockitoBean private GcsClient gcsClient;
 
   private final Storage mockStorageService = mock(Storage.class);
 

--- a/service/src/test/java/bio/terra/pipelines/dependencies/leonardo/LeonardoServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/dependencies/leonardo/LeonardoServiceTest.java
@@ -20,13 +20,13 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.stubbing.Answer;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.retry.backoff.FixedBackOffPolicy;
 import org.springframework.retry.support.RetryTemplate;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 class LeonardoServiceTest extends BaseEmbeddedDbTest {
   @Autowired @InjectMocks LeonardoService leonardoService;
-  @MockBean LeonardoClient leonardoClient;
+  @MockitoBean LeonardoClient leonardoClient;
 
   final String workspaceId = UUID.randomUUID().toString();
   final RetryConfiguration retryConfig = new RetryConfiguration();

--- a/service/src/test/java/bio/terra/pipelines/dependencies/rawls/RawlsServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/dependencies/rawls/RawlsServiceTest.java
@@ -24,13 +24,13 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.stubbing.Answer;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.retry.backoff.FixedBackOffPolicy;
 import org.springframework.retry.support.RetryTemplate;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 class RawlsServiceTest extends BaseEmbeddedDbTest {
   @Autowired @InjectMocks RawlsService rawlsService;
-  @MockBean RawlsClient rawlsClient;
+  @MockitoBean RawlsClient rawlsClient;
 
   final RetryConfiguration retryConfig = new RetryConfiguration();
   RetryTemplate template = retryConfig.listenerResetRetryTemplate();

--- a/service/src/test/java/bio/terra/pipelines/dependencies/sam/SamServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/dependencies/sam/SamServiceTest.java
@@ -25,12 +25,12 @@ import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @ExtendWith(MockitoExtension.class)
 class SamServiceTest extends BaseEmbeddedDbTest {
   @Autowired @InjectMocks SamService samService;
-  @MockBean SamClient samClient;
+  @MockitoBean SamClient samClient;
 
   @Test
   void checkHealth() throws ApiException {

--- a/service/src/test/java/bio/terra/pipelines/dependencies/wds/WdsServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/dependencies/wds/WdsServiceTest.java
@@ -25,14 +25,14 @@ import org.mockito.InjectMocks;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.stubbing.Answer;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.retry.backoff.FixedBackOffPolicy;
 import org.springframework.retry.support.RetryTemplate;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @ExtendWith(MockitoExtension.class)
 class WdsServiceTest extends BaseEmbeddedDbTest {
   @Autowired @InjectMocks WdsService wdsService;
-  @MockBean WdsClient wdsClient;
+  @MockitoBean WdsClient wdsClient;
 
   final RetryConfiguration retryConfig = new RetryConfiguration();
   RetryTemplate template = retryConfig.listenerResetRetryTemplate();

--- a/service/src/test/java/bio/terra/pipelines/dependencies/workspacemanager/WorkspaceManagerServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/dependencies/workspacemanager/WorkspaceManagerServiceTest.java
@@ -23,14 +23,14 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.stubbing.Answer;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.retry.backoff.FixedBackOffPolicy;
 import org.springframework.retry.support.RetryTemplate;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 class WorkspaceManagerServiceTest extends BaseEmbeddedDbTest {
 
   @Autowired @InjectMocks WorkspaceManagerService workspaceManagerService;
-  @MockBean WorkspaceManagerClient workspaceManagerClient;
+  @MockitoBean WorkspaceManagerClient workspaceManagerClient;
 
   final UUID workspaceId = UUID.randomUUID();
 

--- a/service/src/test/java/bio/terra/pipelines/notifications/NotificationServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/notifications/NotificationServiceTest.java
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 class NotificationServiceTest extends BaseEmbeddedDbTest {
   @InjectMocks @Autowired NotificationService notificationService;
@@ -44,7 +44,7 @@ class NotificationServiceTest extends BaseEmbeddedDbTest {
   @Autowired NotificationConfiguration notificationConfiguration;
   @Autowired PipelinesCommonConfiguration pipelinesCommonConfiguration;
   @Autowired ObjectMapper objectMapper;
-  @MockBean PubsubService pubsubService;
+  @MockitoBean PubsubService pubsubService;
   @Mock private FlightContext flightContext;
 
   UUID testJobId = TestUtils.TEST_NEW_UUID;
@@ -294,7 +294,7 @@ class NotificationServiceTest extends BaseEmbeddedDbTest {
             testJobId,
             testUserId,
             pipeline.getId(),
-            pipeline.getWdlMethodVersion(),
+            pipeline.getToolVersion(),
             pipeline.getWorkspaceId(),
             pipeline.getWorkspaceBillingProject(),
             pipeline.getWorkspaceName(),

--- a/service/src/test/java/bio/terra/pipelines/service/PipelineInputsOutputsServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/PipelineInputsOutputsServiceTest.java
@@ -44,7 +44,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 class PipelineInputsOutputsServiceTest extends BaseEmbeddedDbTest {
   @Autowired @InjectMocks PipelineInputsOutputsService pipelineInputsOutputsService;
@@ -55,7 +55,7 @@ class PipelineInputsOutputsServiceTest extends BaseEmbeddedDbTest {
 
   @Autowired PipelineRunsRepository pipelineRunsRepository;
 
-  @MockBean private GcsService mockGcsService;
+  @MockitoBean private GcsService mockGcsService;
 
   private final UUID testJobId = TestUtils.TEST_NEW_UUID;
 

--- a/service/src/test/java/bio/terra/pipelines/service/PipelineRunsServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/PipelineRunsServiceTest.java
@@ -45,7 +45,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
   @Autowired @InjectMocks PipelineRunsService pipelineRunsService;
@@ -54,14 +54,14 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
   @Autowired PipelineOutputsRepository pipelineOutputsRepository;
 
   // mock Stairway and other services
-  @MockBean private JobService mockJobService;
-  @MockBean private JobBuilder mockJobBuilder;
-  @MockBean private GcsService mockGcsService;
-  @MockBean private SamService mockSamService;
+  @MockitoBean private JobService mockJobService;
+  @MockitoBean private JobBuilder mockJobBuilder;
+  @MockitoBean private GcsService mockGcsService;
+  @MockitoBean private SamService mockSamService;
 
   private final String testUserId = TestUtils.TEST_USER_ID_1;
   private final Long testPipelineId = TestUtils.TEST_PIPELINE_ID_1;
-  private final String testWdlMethodVersion = TestUtils.TEST_WDL_METHOD_VERSION_1;
+  private final String testToolVersion = TestUtils.TEST_TOOL_VERSION_1;
   private final Map<String, Object> testPipelineInputs = TestUtils.TEST_PIPELINE_INPUTS;
   private final UUID testJobId = TestUtils.TEST_NEW_UUID;
   private final String testControlWorkspaceProject = TestUtils.CONTROL_WORKSPACE_BILLING_PROJECT;
@@ -102,7 +102,7 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
             testJobId,
             testUserId,
             testPipelineId,
-            testWdlMethodVersion,
+            testToolVersion,
             testControlWorkspaceProject,
             testControlWorkspaceName,
             testControlWorkspaceStorageContainerName,
@@ -246,7 +246,7 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
         testJobId,
         testUserId,
         testPipelineId,
-        testWdlMethodVersion,
+        testToolVersion,
         testControlWorkspaceProject,
         testControlWorkspaceName,
         testControlWorkspaceStorageContainerName,
@@ -274,7 +274,7 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
         testJobId,
         TestUtils.TEST_USER_ID_2, // different user than the caller
         testPipelineId,
-        testWdlMethodVersion,
+        testToolVersion,
         testControlWorkspaceProject,
         testControlWorkspaceName,
         testControlWorkspaceStorageContainerName,
@@ -332,8 +332,7 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
     assertEquals(testUserId, writtenPipelineRun.getUserId());
     assertEquals(testUserDescription, writtenPipelineRun.getDescription());
     assertEquals(testPipelineWithId.getId(), writtenPipelineRun.getPipelineId());
-    assertEquals(
-        testPipelineWithId.getWdlMethodVersion(), writtenPipelineRun.getWdlMethodVersion());
+    assertEquals(testPipelineWithId.getToolVersion(), writtenPipelineRun.getToolVersion());
     assertEquals(testUserDescription, writtenPipelineRun.getDescription());
     assertNotNull(writtenPipelineRun.getCreated());
     assertNotNull(writtenPipelineRun.getUpdated());
@@ -435,7 +434,7 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
             testJobId,
             testUserId,
             testPipelineId,
-            testWdlMethodVersion,
+            testToolVersion,
             testControlWorkspaceProject,
             testControlWorkspaceName,
             testControlWorkspaceStorageContainerName,
@@ -457,7 +456,7 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
         testJobId,
         TestUtils.TEST_USER_ID_2, // different user than the caller
         testPipelineId,
-        testWdlMethodVersion,
+        testToolVersion,
         testControlWorkspaceProject,
         testControlWorkspaceName,
         testControlWorkspaceStorageContainerName,
@@ -479,7 +478,7 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
         testJobId,
         testUserId,
         testPipelineId,
-        testWdlMethodVersion,
+        testToolVersion,
         testControlWorkspaceProject,
         testControlWorkspaceName,
         testControlWorkspaceStorageContainerName,

--- a/service/src/test/java/bio/terra/pipelines/service/PipelinesServiceMockTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/PipelinesServiceMockTest.java
@@ -10,11 +10,11 @@ import bio.terra.pipelines.testutils.TestUtils;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 class PipelinesServiceMockTest extends BaseEmbeddedDbTest {
   @Autowired private PipelinesService pipelinesService;
-  @MockBean private PipelinesRepository pipelinesRepository;
+  @MockitoBean private PipelinesRepository pipelinesRepository;
 
   @Test
   void getPipelinesOk() {

--- a/service/src/test/java/bio/terra/pipelines/service/StatusServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/StatusServiceTest.java
@@ -16,11 +16,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.jdbc.core.ConnectionCallback;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 @ExtendWith(SpringExtension.class)
@@ -28,9 +28,9 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 class StatusServiceTest extends BaseTest {
   @Autowired private StatusService statusService;
 
-  @MockBean private NamedParameterJdbcTemplate jdbcTemplate;
-  @MockBean private StatusCheckConfiguration configuration;
-  @MockBean private SamService samService;
+  @MockitoBean private NamedParameterJdbcTemplate jdbcTemplate;
+  @MockitoBean private StatusCheckConfiguration configuration;
+  @MockitoBean private SamService samService;
 
   @Mock private final JdbcTemplate jdbcTemplateMock = new JdbcTemplate();
 

--- a/service/src/test/java/bio/terra/pipelines/stairway/steps/common/CompletePipelineRunStepTest.java
+++ b/service/src/test/java/bio/terra/pipelines/stairway/steps/common/CompletePipelineRunStepTest.java
@@ -61,7 +61,7 @@ class CompletePipelineRunStepTest extends BaseEmbeddedDbTest {
             testJobId,
             TestUtils.TEST_USER_ID_1,
             TestUtils.TEST_PIPELINE_ID_1,
-            TestUtils.TEST_WDL_METHOD_VERSION_1,
+            TestUtils.TEST_TOOL_VERSION_1,
             TestUtils.CONTROL_WORKSPACE_ID,
             TestUtils.CONTROL_WORKSPACE_BILLING_PROJECT,
             TestUtils.CONTROL_WORKSPACE_NAME,

--- a/service/src/test/java/bio/terra/pipelines/stairway/steps/common/SubmitQuotaConsumedSubmissionStepTest.java
+++ b/service/src/test/java/bio/terra/pipelines/stairway/steps/common/SubmitQuotaConsumedSubmissionStepTest.java
@@ -73,7 +73,7 @@ class SubmitQuotaConsumedSubmissionStepTest extends BaseEmbeddedDbTest {
             SubmitQuotaConsumedSubmissionStep.QUOTA_CONSUMED_METHOD_NAME,
             TestUtils.TEST_PIPELINE_INPUTS_DEFINITION_LIST,
             TestUtils.TEST_PIPELINE_OUTPUTS_DEFINITION_LIST,
-            TestUtils.TEST_WDL_METHOD_VERSION_1))
+            TestUtils.TEST_TOOL_VERSION_1))
         .thenReturn(true);
     when(rawlsService.submitWorkflow(
             eq("thisToken"),
@@ -121,10 +121,10 @@ class SubmitQuotaConsumedSubmissionStepTest extends BaseEmbeddedDbTest {
     when(rawlsService.validateMethodConfig(
             returnedMethodConfiguration,
             PipelinesEnum.ARRAY_IMPUTATION.getValue(),
-            TestUtils.TEST_WDL_METHOD_NAME_1,
+            TestUtils.TEST_TOOL_NAME_1,
             TestUtils.TEST_PIPELINE_INPUTS_DEFINITION_LIST,
             SubmitQuotaConsumedSubmissionStep.QUOTA_CONSUMED_OUTPUT_DEFINITION_LIST,
-            TestUtils.TEST_WDL_METHOD_VERSION_1))
+            TestUtils.TEST_TOOL_VERSION_1))
         .thenReturn(false);
     when(rawlsService.updateMethodConfigToBeValid(
             updateMethodConfigCaptor.capture(),
@@ -132,7 +132,7 @@ class SubmitQuotaConsumedSubmissionStepTest extends BaseEmbeddedDbTest {
             eq(SubmitQuotaConsumedSubmissionStep.QUOTA_CONSUMED_METHOD_NAME),
             eq(TestUtils.TEST_PIPELINE_INPUTS_DEFINITION_LIST),
             eq(SubmitQuotaConsumedSubmissionStep.QUOTA_CONSUMED_OUTPUT_DEFINITION_LIST),
-            eq(TestUtils.TEST_WDL_METHOD_VERSION_1)))
+            eq(TestUtils.TEST_TOOL_VERSION_1)))
         .thenReturn(VALID_METHOD_CONFIGURATION);
     when(rawlsService.setMethodConfigForMethod(
             eq("thisToken"),
@@ -182,7 +182,7 @@ class SubmitQuotaConsumedSubmissionStepTest extends BaseEmbeddedDbTest {
             SubmitQuotaConsumedSubmissionStep.QUOTA_CONSUMED_METHOD_NAME,
             TestUtils.TEST_PIPELINE_INPUTS_DEFINITION_LIST,
             TestUtils.TEST_PIPELINE_OUTPUTS_DEFINITION_LIST,
-            TestUtils.TEST_WDL_METHOD_VERSION_1))
+            TestUtils.TEST_TOOL_VERSION_1))
         .thenReturn(true);
 
     // throw exception on submitting workflow
@@ -207,7 +207,7 @@ class SubmitQuotaConsumedSubmissionStepTest extends BaseEmbeddedDbTest {
             SubmitQuotaConsumedSubmissionStep.QUOTA_CONSUMED_METHOD_NAME,
             TestUtils.TEST_PIPELINE_INPUTS_DEFINITION_LIST,
             TestUtils.TEST_PIPELINE_OUTPUTS_DEFINITION_LIST,
-            TestUtils.TEST_WDL_METHOD_VERSION_1))
+            TestUtils.TEST_TOOL_VERSION_1))
         .thenReturn(false);
     when(rawlsService.setMethodConfigForMethod(
             "thisToken",

--- a/service/src/test/java/bio/terra/pipelines/stairway/steps/imputation/PrepareImputationInputsStepTest.java
+++ b/service/src/test/java/bio/terra/pipelines/stairway/steps/imputation/PrepareImputationInputsStepTest.java
@@ -87,8 +87,8 @@ class PrepareImputationInputsStepTest extends BaseEmbeddedDbTest {
         TestUtils.CONTROL_WORKSPACE_NAME,
         TestUtils.CONTROL_WORKSPACE_CONTAINER_NAME,
         TestUtils.GCP_STORAGE_PROTOCOL,
-        TestUtils.TEST_WDL_METHOD_NAME_1,
-        TestUtils.TEST_WDL_METHOD_VERSION_1,
+        TestUtils.TEST_TOOL_NAME_1,
+        TestUtils.TEST_TOOL_VERSION_1,
         TestUtils.TEST_DOMAIN);
 
     // make sure the full inputs are not populated before the step is executed

--- a/service/src/test/java/bio/terra/pipelines/stairway/steps/imputation/azure/SubmitCromwellRunSetStepTest.java
+++ b/service/src/test/java/bio/terra/pipelines/stairway/steps/imputation/azure/SubmitCromwellRunSetStepTest.java
@@ -87,7 +87,7 @@ class SubmitCromwellRunSetStepTest extends BaseEmbeddedDbTest {
                     .inputType(null)
                     .source(null)));
     when(pipelinesService.prepareCbasWorkflowInputRecordLookupDefinitions(
-            TestUtils.TEST_PIPELINE_INPUTS_DEFINITION_LIST, TestUtils.TEST_WDL_METHOD_NAME_1))
+            TestUtils.TEST_PIPELINE_INPUTS_DEFINITION_LIST, TestUtils.TEST_TOOL_NAME_1))
         .thenReturn(testWorkflowInputDefinitions);
 
     List<WorkflowOutputDefinition> testWorkflowOutputDefinitions =
@@ -102,7 +102,7 @@ class SubmitCromwellRunSetStepTest extends BaseEmbeddedDbTest {
                     .outputType(null)
                     .destination(null)));
     when(pipelinesService.prepareCbasWorkflowOutputRecordUpdateDefinitions(
-            TestUtils.TEST_PIPELINE_OUTPUTS_DEFINITION_LIST, TestUtils.TEST_WDL_METHOD_NAME_1))
+            TestUtils.TEST_PIPELINE_OUTPUTS_DEFINITION_LIST, TestUtils.TEST_TOOL_NAME_1))
         .thenReturn(testWorkflowOutputDefinitions);
 
     // do the step

--- a/service/src/test/java/bio/terra/pipelines/stairway/steps/imputation/gcp/SubmitCromwellSubmissionStepTest.java
+++ b/service/src/test/java/bio/terra/pipelines/stairway/steps/imputation/gcp/SubmitCromwellSubmissionStepTest.java
@@ -60,15 +60,15 @@ class SubmitCromwellSubmissionStepTest extends BaseEmbeddedDbTest {
             "thisToken",
             TestUtils.CONTROL_WORKSPACE_BILLING_PROJECT,
             TestUtils.CONTROL_WORKSPACE_NAME,
-            TestUtils.TEST_WDL_METHOD_NAME_1))
+            TestUtils.TEST_TOOL_NAME_1))
         .thenReturn(returnedMethodConfiguration);
     when(rawlsService.validateMethodConfig(
             returnedMethodConfiguration,
             PipelinesEnum.ARRAY_IMPUTATION.getValue(),
-            TestUtils.TEST_WDL_METHOD_NAME_1,
+            TestUtils.TEST_TOOL_NAME_1,
             TestUtils.TEST_PIPELINE_INPUTS_DEFINITION_LIST,
             TestUtils.TEST_PIPELINE_OUTPUTS_DEFINITION_LIST,
-            TestUtils.TEST_WDL_METHOD_VERSION_1))
+            TestUtils.TEST_TOOL_VERSION_1))
         .thenReturn(true);
     when(rawlsService.submitWorkflow(
             eq("thisToken"),
@@ -110,30 +110,30 @@ class SubmitCromwellSubmissionStepTest extends BaseEmbeddedDbTest {
             "thisToken",
             TestUtils.CONTROL_WORKSPACE_BILLING_PROJECT,
             TestUtils.CONTROL_WORKSPACE_NAME,
-            TestUtils.TEST_WDL_METHOD_NAME_1))
+            TestUtils.TEST_TOOL_NAME_1))
         .thenReturn(returnedMethodConfiguration);
     when(rawlsService.validateMethodConfig(
             returnedMethodConfiguration,
             PipelinesEnum.ARRAY_IMPUTATION.getValue(),
-            TestUtils.TEST_WDL_METHOD_NAME_1,
+            TestUtils.TEST_TOOL_NAME_1,
             TestUtils.TEST_PIPELINE_INPUTS_DEFINITION_LIST,
             TestUtils.TEST_PIPELINE_OUTPUTS_DEFINITION_LIST,
-            TestUtils.TEST_WDL_METHOD_VERSION_1))
+            TestUtils.TEST_TOOL_VERSION_1))
         .thenReturn(false);
     when(rawlsService.updateMethodConfigToBeValid(
             updateMethodConfigCaptor.capture(),
             eq(PipelinesEnum.ARRAY_IMPUTATION.getValue()),
-            eq(TestUtils.TEST_WDL_METHOD_NAME_1),
+            eq(TestUtils.TEST_TOOL_NAME_1),
             eq(TestUtils.TEST_PIPELINE_INPUTS_DEFINITION_LIST),
             eq(TestUtils.TEST_PIPELINE_OUTPUTS_DEFINITION_LIST),
-            eq(TestUtils.TEST_WDL_METHOD_VERSION_1)))
+            eq(TestUtils.TEST_TOOL_VERSION_1)))
         .thenReturn(VALID_METHOD_CONFIGURATION);
     when(rawlsService.setMethodConfigForMethod(
             eq("thisToken"),
             setMethodConfigCaptor.capture(),
             eq(TestUtils.CONTROL_WORKSPACE_BILLING_PROJECT),
             eq(TestUtils.CONTROL_WORKSPACE_NAME),
-            eq(TestUtils.TEST_WDL_METHOD_NAME_1)))
+            eq(TestUtils.TEST_TOOL_NAME_1)))
         .thenReturn(null);
     when(rawlsService.submitWorkflow(
             eq("thisToken"),
@@ -167,15 +167,15 @@ class SubmitCromwellSubmissionStepTest extends BaseEmbeddedDbTest {
             "thisToken",
             TestUtils.CONTROL_WORKSPACE_BILLING_PROJECT,
             TestUtils.CONTROL_WORKSPACE_NAME,
-            TestUtils.TEST_WDL_METHOD_NAME_1))
+            TestUtils.TEST_TOOL_NAME_1))
         .thenReturn(returnedMethodConfiguration);
     when(rawlsService.validateMethodConfig(
             returnedMethodConfiguration,
             PipelinesEnum.ARRAY_IMPUTATION.getValue(),
-            TestUtils.TEST_WDL_METHOD_NAME_1,
+            TestUtils.TEST_TOOL_NAME_1,
             TestUtils.TEST_PIPELINE_INPUTS_DEFINITION_LIST,
             TestUtils.TEST_PIPELINE_OUTPUTS_DEFINITION_LIST,
-            TestUtils.TEST_WDL_METHOD_VERSION_1))
+            TestUtils.TEST_TOOL_VERSION_1))
         .thenReturn(true);
 
     // throw exception on submitting workflow
@@ -196,17 +196,17 @@ class SubmitCromwellSubmissionStepTest extends BaseEmbeddedDbTest {
     when(rawlsService.validateMethodConfig(
             returnedMethodConfiguration,
             PipelinesEnum.ARRAY_IMPUTATION.getValue(),
-            TestUtils.TEST_WDL_METHOD_NAME_1,
+            TestUtils.TEST_TOOL_NAME_1,
             TestUtils.TEST_PIPELINE_INPUTS_DEFINITION_LIST,
             TestUtils.TEST_PIPELINE_OUTPUTS_DEFINITION_LIST,
-            TestUtils.TEST_WDL_METHOD_VERSION_1))
+            TestUtils.TEST_TOOL_VERSION_1))
         .thenReturn(false);
     when(rawlsService.setMethodConfigForMethod(
             "thisToken",
             null,
             TestUtils.CONTROL_WORKSPACE_BILLING_PROJECT,
             TestUtils.CONTROL_WORKSPACE_NAME,
-            TestUtils.TEST_WDL_METHOD_NAME_1))
+            TestUtils.TEST_TOOL_NAME_1))
         .thenThrow(new RawlsServiceApiException("rawls is bad"));
     // do the step
     submitCromwellSubmissionStep =
@@ -220,7 +220,7 @@ class SubmitCromwellSubmissionStepTest extends BaseEmbeddedDbTest {
             "thisToken",
             TestUtils.CONTROL_WORKSPACE_BILLING_PROJECT,
             TestUtils.CONTROL_WORKSPACE_NAME,
-            TestUtils.TEST_WDL_METHOD_NAME_1))
+            TestUtils.TEST_TOOL_NAME_1))
         .thenThrow(new RawlsServiceApiException("rawls is bad"));
     // do the step
     submitCromwellSubmissionStep =

--- a/service/src/test/java/bio/terra/pipelines/testutils/MockMvcUtils.java
+++ b/service/src/test/java/bio/terra/pipelines/testutils/MockMvcUtils.java
@@ -51,7 +51,7 @@ public class MockMvcUtils {
   public static final String TEST_WORKSPACE_NAME = "testTerraWorkspaceName";
   public static final String TEST_WORKSPACE_STORAGE_CONTAINER_NAME = "test-bucket-name";
   public static final String TEST_WORKSPACE_GOOGLE_PROJECT = "testGoogleProject";
-  public static final String TEST_WDL_METHOD_VERSION = "0.12.1";
+  public static final String TEST_TOOL_VERSION = "0.12.1";
   // using this function to build a pipeline with a value set for the id field.  Normally this would
   // be populated
   // by calling `save()` from the repository but since these tests mock that out, we have to set the
@@ -66,8 +66,8 @@ public class MockMvcUtils {
             "description",
             "pipelineType",
             "wdlUrl",
-            "wdlMethodName",
-            TEST_WDL_METHOD_VERSION,
+            "toolName",
+            TEST_TOOL_VERSION,
             TEST_WORKSPACE_UUID,
             TEST_WORKSPACE_BILLING_PROJECT,
             TEST_WORKSPACE_NAME,

--- a/service/src/test/java/bio/terra/pipelines/testutils/StairwayTestUtils.java
+++ b/service/src/test/java/bio/terra/pipelines/testutils/StairwayTestUtils.java
@@ -44,8 +44,8 @@ public class StairwayTestUtils {
           TestUtils.CONTROL_WORKSPACE_NAME,
           TestUtils.CONTROL_WORKSPACE_CONTAINER_NAME,
           TestUtils.GCP_STORAGE_PROTOCOL,
-          TestUtils.TEST_WDL_METHOD_NAME_1,
-          TestUtils.TEST_WDL_METHOD_VERSION_1,
+          TestUtils.TEST_TOOL_NAME_1,
+          TestUtils.TEST_TOOL_VERSION_1,
           TestUtils.TEST_DOMAIN);
   public static final FlightMap EMPTY_WORKING_MAP = new FlightMap();
   public static final String TEST_DESCRIPTION = "Test PipelineRun Description";
@@ -145,8 +145,8 @@ public class StairwayTestUtils {
       String controlWorkspaceName,
       String controlWorkspaceStorageContainerUrl,
       String controlWorkspaceStorageContainerProtocol,
-      String wdlMethodName,
-      String wdlMethodVersion,
+      String toolName,
+      String toolVersion,
       String resultPath) {
     FlightMap inputParameters = new FlightMap();
     return constructCreateJobInputs(
@@ -162,8 +162,8 @@ public class StairwayTestUtils {
         controlWorkspaceName,
         controlWorkspaceStorageContainerUrl,
         controlWorkspaceStorageContainerProtocol,
-        wdlMethodName,
-        wdlMethodVersion,
+        toolName,
+        toolVersion,
         resultPath);
   }
 
@@ -180,8 +180,8 @@ public class StairwayTestUtils {
       String controlWorkspaceName,
       String controlWorkspaceStorageContainerUrl,
       String controlWorkspaceStorageContainerProtocol,
-      String wdlMethodName,
-      String wdlMethodVersion,
+      String toolName,
+      String toolVersion,
       String domainName) {
     inputParameters.put(JobMapKeys.USER_ID, userId);
     inputParameters.put(JobMapKeys.PIPELINE_NAME, pipelineName);
@@ -205,8 +205,8 @@ public class StairwayTestUtils {
     inputParameters.put(
         ImputationJobMapKeys.CONTROL_WORKSPACE_STORAGE_CONTAINER_PROTOCOL,
         controlWorkspaceStorageContainerProtocol);
-    inputParameters.put(ImputationJobMapKeys.WDL_METHOD_NAME, wdlMethodName);
-    inputParameters.put(ImputationJobMapKeys.WDL_METHOD_VERSION, wdlMethodVersion);
+    inputParameters.put(ImputationJobMapKeys.WDL_METHOD_NAME, toolName);
+    inputParameters.put(ImputationJobMapKeys.WDL_METHOD_VERSION, toolVersion);
 
     return inputParameters;
   }
@@ -225,8 +225,8 @@ public class StairwayTestUtils {
         TestUtils.CONTROL_WORKSPACE_NAME,
         TestUtils.CONTROL_WORKSPACE_CONTAINER_NAME,
         TestUtils.GCP_STORAGE_PROTOCOL,
-        TestUtils.TEST_WDL_METHOD_NAME_1,
-        TestUtils.TEST_WDL_METHOD_VERSION_1,
+        TestUtils.TEST_TOOL_NAME_1,
+        TestUtils.TEST_TOOL_VERSION_1,
         TestUtils.TEST_DOMAIN);
   }
 

--- a/service/src/test/java/bio/terra/pipelines/testutils/TestUtils.java
+++ b/service/src/test/java/bio/terra/pipelines/testutils/TestUtils.java
@@ -28,8 +28,8 @@ public class TestUtils {
   public static final String TEST_PIPELINE_DESCRIPTION_1 = "Test Pipeline Description";
   public static final String TEST_PIPELINE_TYPE_1 = "imputation1";
   public static final String TEST_WDL_URL_1 = "http://nowhere1";
-  public static final String TEST_WDL_METHOD_NAME_1 = "methodName1";
-  public static final String TEST_WDL_METHOD_VERSION_1 = "0.1.12";
+  public static final String TEST_TOOL_NAME_1 = "methodName1";
+  public static final String TEST_TOOL_VERSION_1 = "0.1.12";
   public static final UUID TEST_WORKSPACE_ID_1 = UUID.randomUUID();
 
   public static final int TEST_PIPELINE_VERSION_2 = 1;
@@ -37,8 +37,8 @@ public class TestUtils {
   public static final String TEST_PIPELINE_DESCRIPTION_2 = "Test Pipeline Description Two";
   public static final String TEST_PIPELINE_TYPE_2 = "imputation2";
   public static final String TEST_WDL_URL_2 = "http://nowhere2";
-  public static final String TEST_WDL_METHOD_NAME_2 = "methodName2";
-  public static final String TEST_WDL_METHOD_VERSION_2 = "1.1.12";
+  public static final String TEST_TOOL_NAME_2 = "methodName2";
+  public static final String TEST_TOOL_VERSION_2 = "1.1.12";
   public static final UUID TEST_WORKSPACE_ID_2 = UUID.randomUUID();
   public static final UUID CONTROL_WORKSPACE_ID =
       UUID.fromString("fafafafa-fafa-fafa-fafa-fafafafafafa");
@@ -134,8 +134,8 @@ public class TestUtils {
           TEST_PIPELINE_DESCRIPTION_1,
           TEST_PIPELINE_TYPE_1,
           TEST_WDL_URL_1,
-          TEST_WDL_METHOD_NAME_1,
-          TEST_WDL_METHOD_VERSION_1,
+          TEST_TOOL_NAME_1,
+          TEST_TOOL_VERSION_1,
           TEST_WORKSPACE_ID_1,
           CONTROL_WORKSPACE_BILLING_PROJECT,
           CONTROL_WORKSPACE_NAME,
@@ -151,8 +151,8 @@ public class TestUtils {
           TEST_PIPELINE_DESCRIPTION_2,
           TEST_PIPELINE_TYPE_2,
           TEST_WDL_URL_2,
-          TEST_WDL_METHOD_NAME_2,
-          TEST_WDL_METHOD_VERSION_2,
+          TEST_TOOL_NAME_2,
+          TEST_TOOL_VERSION_2,
           TEST_WORKSPACE_ID_2,
           CONTROL_WORKSPACE_BILLING_PROJECT,
           CONTROL_WORKSPACE_NAME,
@@ -170,8 +170,8 @@ public class TestUtils {
             TestUtils.TEST_PIPELINE_1.getDescription(),
             TestUtils.TEST_PIPELINE_1.getPipelineType(),
             TestUtils.TEST_PIPELINE_1.getWdlUrl(),
-            TestUtils.TEST_PIPELINE_1.getWdlMethodName(),
-            TestUtils.TEST_PIPELINE_1.getWdlMethodVersion(),
+            TestUtils.TEST_PIPELINE_1.getToolName(),
+            TestUtils.TEST_PIPELINE_1.getToolVersion(),
             TestUtils.TEST_PIPELINE_1.getWorkspaceId(),
             TestUtils.TEST_PIPELINE_1.getWorkspaceBillingProject(),
             TestUtils.TEST_PIPELINE_1.getWorkspaceName(),
@@ -225,7 +225,7 @@ public class TestUtils {
         jobId,
         userId,
         TEST_PIPELINE_ID_1,
-        TEST_WDL_METHOD_VERSION_1,
+        TEST_TOOL_VERSION_1,
         CONTROL_WORKSPACE_BILLING_PROJECT,
         CONTROL_WORKSPACE_NAME,
         CONTROL_WORKSPACE_CONTAINER_NAME,


### PR DESCRIPTION


### Description 
We want to update our tables / api to not be so wdl specific where possible so its easier to add non wdl pipelines in the future w/o having to change terminology as much

* rename wdl_method_version to tool_version and wdl_method_name to tool_name in pipelines and pipeline_runs tables
* also update deprecated MockBeans annotation to MockitoBean

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-384

### Checklist (provide links to changes)

- [ ] Updated external documentation (if applicable)
- [x] Updated internal documentation (if applicable)
PR to update e2e test - https://github.com/broadinstitute/dsp-reusable-workflows/pull/71
- [ ] Planned non patch version bump (if applicable)
- [x] Updated CLI PR (if applicable)
https://github.com/DataBiosphere/terra-scientific-pipelines-service-cli/pull/43
