### PR TITLE
TSPS-405 Add quota units to pipeline quotas

### DIFF
--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -932,11 +932,16 @@ components:
         Maximum allowable quota for the pipeline
       type: integer
 
+    QuotaUnits:
+      description: |
+        Units for pipeline quota
+      type: string
+
     QuotaWithDetails:
       description: |
         Object containing the pipeline identifier, quota limit, and quota usage of a Pipeline.
       type: object
-      required: [ pipelineName, quotaLimit, quotaConsumed ]
+      required: [ pipelineName, quotaLimit, quotaConsumed, quotaUnits ]
       properties:
         pipelineName:
           $ref: "#/components/schemas/PipelineName"
@@ -944,6 +949,8 @@ components:
           $ref: "#/components/schemas/QuotaLimit"
         quotaConsumed:
           $ref: "#/components/schemas/QuotaConsumed"
+        quotaUnits:
+          $ref: "#/components/schemas/QuotaUnits"
 
     StartPipelineRunRequestBody:
       description: |

--- a/service/src/main/java/bio/terra/pipelines/app/controller/QuotasController.java
+++ b/service/src/main/java/bio/terra/pipelines/app/controller/QuotasController.java
@@ -51,15 +51,17 @@ public class QuotasController implements QuotasApi {
     UserQuota userQuota =
         quotasService.getOrCreateQuotaForUserAndPipeline(
             user.getSubjectId(), validatedPipelineName);
+    String quotaUnits = quotasService.getPipelineQuota(validatedPipelineName).getQuotaUnits();
 
-    return new ResponseEntity<>(quotasToApiQuotaWithDetails(userQuota), HttpStatus.OK);
+    return new ResponseEntity<>(quotasToApiQuotaWithDetails(userQuota, quotaUnits), HttpStatus.OK);
   }
 
-  static ApiQuotaWithDetails quotasToApiQuotaWithDetails(UserQuota userQuota) {
+  static ApiQuotaWithDetails quotasToApiQuotaWithDetails(UserQuota userQuota, String quotaUnits) {
 
     return new ApiQuotaWithDetails()
         .pipelineName(userQuota.getPipelineName().getValue())
         .quotaConsumed(userQuota.getQuotaConsumed())
-        .quotaLimit(userQuota.getQuota());
+        .quotaLimit(userQuota.getQuota())
+        .quotaUnits(quotaUnits);
   }
 }

--- a/service/src/main/java/bio/terra/pipelines/app/controller/QuotasController.java
+++ b/service/src/main/java/bio/terra/pipelines/app/controller/QuotasController.java
@@ -4,6 +4,7 @@ import bio.terra.common.iam.SamUser;
 import bio.terra.common.iam.SamUserFactory;
 import bio.terra.pipelines.app.configuration.external.SamConfiguration;
 import bio.terra.pipelines.common.utils.PipelinesEnum;
+import bio.terra.pipelines.common.utils.QuotaUnitsEnum;
 import bio.terra.pipelines.db.entities.UserQuota;
 import bio.terra.pipelines.generated.api.QuotasApi;
 import bio.terra.pipelines.generated.model.ApiQuotaWithDetails;
@@ -51,17 +52,18 @@ public class QuotasController implements QuotasApi {
     UserQuota userQuota =
         quotasService.getOrCreateQuotaForUserAndPipeline(
             user.getSubjectId(), validatedPipelineName);
-    String quotaUnits = quotasService.getPipelineQuota(validatedPipelineName).getQuotaUnits();
+    QuotaUnitsEnum quotaUnits = quotasService.getQuotaUnitsForPipeline(validatedPipelineName);
 
     return new ResponseEntity<>(quotasToApiQuotaWithDetails(userQuota, quotaUnits), HttpStatus.OK);
   }
 
-  static ApiQuotaWithDetails quotasToApiQuotaWithDetails(UserQuota userQuota, String quotaUnits) {
+  static ApiQuotaWithDetails quotasToApiQuotaWithDetails(
+      UserQuota userQuota, QuotaUnitsEnum quotaUnits) {
 
     return new ApiQuotaWithDetails()
         .pipelineName(userQuota.getPipelineName().getValue())
         .quotaConsumed(userQuota.getQuotaConsumed())
         .quotaLimit(userQuota.getQuota())
-        .quotaUnits(quotaUnits);
+        .quotaUnits(quotaUnits.getValue());
   }
 }

--- a/service/src/main/java/bio/terra/pipelines/common/utils/QuotaUnitsEnum.java
+++ b/service/src/main/java/bio/terra/pipelines/common/utils/QuotaUnitsEnum.java
@@ -1,0 +1,15 @@
+package bio.terra.pipelines.common.utils;
+
+public enum QuotaUnitsEnum {
+  SAMPLES("samples");
+
+  private final String value;
+
+  QuotaUnitsEnum(String value) {
+    this.value = value;
+  }
+
+  public String getValue() {
+    return value;
+  }
+}

--- a/service/src/main/java/bio/terra/pipelines/db/entities/PipelineQuota.java
+++ b/service/src/main/java/bio/terra/pipelines/db/entities/PipelineQuota.java
@@ -1,6 +1,7 @@
 package bio.terra.pipelines.db.entities;
 
 import bio.terra.pipelines.common.utils.PipelinesEnum;
+import bio.terra.pipelines.common.utils.QuotaUnitsEnum;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -29,10 +30,13 @@ public class PipelineQuota {
   private int minQuotaConsumed;
 
   @Column(name = "quota_units")
-  private String quotaUnits;
+  private QuotaUnitsEnum quotaUnits;
 
   public PipelineQuota(
-      PipelinesEnum pipelineName, int defaultQuota, int minQuotaConsumed, String quotaUnits) {
+      PipelinesEnum pipelineName,
+      int defaultQuota,
+      int minQuotaConsumed,
+      QuotaUnitsEnum quotaUnits) {
     this.pipelineName = pipelineName;
     this.defaultQuota = defaultQuota;
     this.minQuotaConsumed = minQuotaConsumed;

--- a/service/src/main/java/bio/terra/pipelines/db/entities/PipelineQuota.java
+++ b/service/src/main/java/bio/terra/pipelines/db/entities/PipelineQuota.java
@@ -28,9 +28,14 @@ public class PipelineQuota {
   @Column(name = "min_quota_consumed")
   private int minQuotaConsumed;
 
-  public PipelineQuota(PipelinesEnum pipelineName, int defaultQuota, int minQuotaConsumed) {
+  @Column(name = "quota_units")
+  private String quotaUnits;
+
+  public PipelineQuota(
+      PipelinesEnum pipelineName, int defaultQuota, int minQuotaConsumed, String quotaUnits) {
     this.pipelineName = pipelineName;
     this.defaultQuota = defaultQuota;
     this.minQuotaConsumed = minQuotaConsumed;
+    this.quotaUnits = quotaUnits;
   }
 }

--- a/service/src/main/java/bio/terra/pipelines/db/entities/converters/QuotaUnitsConverter.java
+++ b/service/src/main/java/bio/terra/pipelines/db/entities/converters/QuotaUnitsConverter.java
@@ -1,0 +1,19 @@
+package bio.terra.pipelines.db.entities.converters;
+
+import bio.terra.pipelines.common.utils.QuotaUnitsEnum;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+// inspired by https://www.baeldung.com/jpa-persisting-enums-in-jpa
+@Converter(autoApply = true)
+public class QuotaUnitsConverter implements AttributeConverter<QuotaUnitsEnum, String> {
+  @Override
+  public String convertToDatabaseColumn(QuotaUnitsEnum quotaUnitsEnum) {
+    return quotaUnitsEnum.getValue();
+  }
+
+  @Override
+  public QuotaUnitsEnum convertToEntityAttribute(String quotaUnitsString) {
+    return QuotaUnitsEnum.valueOf(quotaUnitsString.toUpperCase());
+  }
+}

--- a/service/src/main/java/bio/terra/pipelines/db/repositories/PipelineQuotasRepository.java
+++ b/service/src/main/java/bio/terra/pipelines/db/repositories/PipelineQuotasRepository.java
@@ -1,9 +1,14 @@
 package bio.terra.pipelines.db.repositories;
 
 import bio.terra.pipelines.common.utils.PipelinesEnum;
+import bio.terra.pipelines.common.utils.QuotaUnitsEnum;
 import bio.terra.pipelines.db.entities.PipelineQuota;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 
 public interface PipelineQuotasRepository extends CrudRepository<PipelineQuota, Long> {
   PipelineQuota findByPipelineName(PipelinesEnum pipelineName);
+
+  @Query("SELECT p.quotaUnits FROM PipelineQuota p WHERE p.pipelineName = ?1")
+  QuotaUnitsEnum findQuotaUnitsByPipeline(PipelinesEnum pipelineName);
 }

--- a/service/src/main/java/bio/terra/pipelines/db/repositories/PipelineQuotasRepository.java
+++ b/service/src/main/java/bio/terra/pipelines/db/repositories/PipelineQuotasRepository.java
@@ -10,5 +10,5 @@ public interface PipelineQuotasRepository extends CrudRepository<PipelineQuota, 
   PipelineQuota findByPipelineName(PipelinesEnum pipelineName);
 
   @Query("SELECT p.quotaUnits FROM PipelineQuota p WHERE p.pipelineName = ?1")
-  QuotaUnitsEnum findQuotaUnitsByPipeline(PipelinesEnum pipelineName);
+  QuotaUnitsEnum findQuotaUnitsByPipelineName(PipelinesEnum pipelineName);
 }

--- a/service/src/main/java/bio/terra/pipelines/service/QuotasService.java
+++ b/service/src/main/java/bio/terra/pipelines/service/QuotasService.java
@@ -3,6 +3,7 @@ package bio.terra.pipelines.service;
 import bio.terra.common.db.WriteTransaction;
 import bio.terra.common.exception.InternalServerErrorException;
 import bio.terra.pipelines.common.utils.PipelinesEnum;
+import bio.terra.pipelines.common.utils.QuotaUnitsEnum;
 import bio.terra.pipelines.db.entities.PipelineQuota;
 import bio.terra.pipelines.db.entities.UserQuota;
 import bio.terra.pipelines.db.repositories.PipelineQuotasRepository;
@@ -31,6 +32,11 @@ public class QuotasService {
   /** This method gets the PipelineQuota object for a given pipeline. */
   public PipelineQuota getPipelineQuota(PipelinesEnum pipelineName) {
     return pipelineQuotasRepository.findByPipelineName(pipelineName);
+  }
+
+  /** This method gets the quota units value for a given pipeline. */
+  public QuotaUnitsEnum getQuotaUnitsForPipeline(PipelinesEnum pipelineName) {
+    return pipelineQuotasRepository.findQuotaUnitsByPipeline(pipelineName);
   }
 
   /**

--- a/service/src/main/java/bio/terra/pipelines/service/QuotasService.java
+++ b/service/src/main/java/bio/terra/pipelines/service/QuotasService.java
@@ -36,7 +36,7 @@ public class QuotasService {
 
   /** This method gets the quota units value for a given pipeline. */
   public QuotaUnitsEnum getQuotaUnitsForPipeline(PipelinesEnum pipelineName) {
-    return pipelineQuotasRepository.findQuotaUnitsByPipeline(pipelineName);
+    return pipelineQuotasRepository.findQuotaUnitsByPipelineName(pipelineName);
   }
 
   /**

--- a/service/src/main/resources/db/changelog.xml
+++ b/service/src/main/resources/db/changelog.xml
@@ -11,6 +11,7 @@
   <include file="changesets/20241212_add_quota_consumed_update_pipeline_display_name.yaml" relativeToChangelogFile="true"/>
   <include file="changesets/20250127_add_expects_custom_value_field_to_input_defs.yaml" relativeToChangelogFile="true"/>
   <include file="changesets/20250220_rename_wdl_method_version_and_wdl_method_name.yaml" relativeToChangelogFile="true"/>
+  <include file="changesets/20250225_add_quota_units.yaml" relativeToChangelogFile="true"/>
 
   <include file="changesets/testdata.yaml" relativeToChangelogFile="true"/>
 

--- a/service/src/main/resources/db/changesets/20250225_add_quota_units.yaml
+++ b/service/src/main/resources/db/changesets/20250225_add_quota_units.yaml
@@ -1,0 +1,28 @@
+# add quota_units field to pipeline_quotas table and set value for array_imputation pipeline
+
+databaseChangeLog:
+  -  changeSet:
+       id:  add and populate quota_units column in pipeline_quotas table
+       author:  mma
+       changes:
+         # add quota_units column to pipeline_quotas table
+         - addColumn:
+             tableName: pipeline_quotas
+             columns:
+               - column:
+                   name: quota_units
+                   type: text
+                   constraints:
+                     nullable: true
+         # update quota_units value for array_imputation pipeline
+         - update:
+             tableName: pipeline_quotas
+             columns:
+               - column:
+                  name: quota_units
+                  value: 'samples'
+             where: pipeline_name='array_imputation'
+        # make quota_units non-nullable
+         -  addNotNullConstraint:
+                tableName: pipeline_quotas
+                columnName: quota_units

--- a/service/src/test/java/bio/terra/pipelines/controller/QuotasControllerTest.java
+++ b/service/src/test/java/bio/terra/pipelines/controller/QuotasControllerTest.java
@@ -15,6 +15,7 @@ import bio.terra.pipelines.app.configuration.external.SamConfiguration;
 import bio.terra.pipelines.app.controller.GlobalExceptionHandler;
 import bio.terra.pipelines.app.controller.QuotasController;
 import bio.terra.pipelines.common.utils.PipelinesEnum;
+import bio.terra.pipelines.common.utils.QuotaUnitsEnum;
 import bio.terra.pipelines.db.entities.UserQuota;
 import bio.terra.pipelines.db.exception.InvalidPipelineException;
 import bio.terra.pipelines.generated.model.ApiQuotaWithDetails;
@@ -53,7 +54,7 @@ class QuotasControllerTest {
             testUser.getSubjectId(), PipelinesEnum.ARRAY_IMPUTATION))
         .thenReturn(testUserQuota);
     when(quotasServiceMock.getQuotaUnitsForPipeline(PipelinesEnum.ARRAY_IMPUTATION))
-        .thenReturn(MockMvcUtils.PIPELINE_QUOTA_UNITS);
+        .thenReturn(QuotaUnitsEnum.SAMPLES);
   }
 
   @Test
@@ -73,7 +74,7 @@ class QuotasControllerTest {
     assertEquals(testUserQuota.getQuota(), response.getQuotaLimit());
     assertEquals(testUserQuota.getQuotaConsumed(), response.getQuotaConsumed());
     assertEquals(testUserQuota.getPipelineName().getValue(), response.getPipelineName());
-    assertEquals(MockMvcUtils.PIPELINE_QUOTA_UNITS.getValue(), response.getQuotaUnits());
+    assertEquals(QuotaUnitsEnum.SAMPLES.getValue(), response.getQuotaUnits());
   }
 
   @Test

--- a/service/src/test/java/bio/terra/pipelines/controller/QuotasControllerTest.java
+++ b/service/src/test/java/bio/terra/pipelines/controller/QuotasControllerTest.java
@@ -52,6 +52,8 @@ class QuotasControllerTest {
     when(quotasServiceMock.getOrCreateQuotaForUserAndPipeline(
             testUser.getSubjectId(), PipelinesEnum.ARRAY_IMPUTATION))
         .thenReturn(testUserQuota);
+    when(quotasServiceMock.getPipelineQuota(PipelinesEnum.ARRAY_IMPUTATION))
+        .thenReturn(MockMvcUtils.TEST_PIPELINE_QUOTA_ARRAY_IMPUTATION);
   }
 
   @Test
@@ -71,6 +73,7 @@ class QuotasControllerTest {
     assertEquals(testUserQuota.getQuota(), response.getQuotaLimit());
     assertEquals(testUserQuota.getQuotaConsumed(), response.getQuotaConsumed());
     assertEquals(testUserQuota.getPipelineName().getValue(), response.getPipelineName());
+    assertEquals(MockMvcUtils.PIPELINE_QUOTA_UNITS, response.getQuotaUnits());
   }
 
   @Test

--- a/service/src/test/java/bio/terra/pipelines/controller/QuotasControllerTest.java
+++ b/service/src/test/java/bio/terra/pipelines/controller/QuotasControllerTest.java
@@ -52,8 +52,8 @@ class QuotasControllerTest {
     when(quotasServiceMock.getOrCreateQuotaForUserAndPipeline(
             testUser.getSubjectId(), PipelinesEnum.ARRAY_IMPUTATION))
         .thenReturn(testUserQuota);
-    when(quotasServiceMock.getPipelineQuota(PipelinesEnum.ARRAY_IMPUTATION))
-        .thenReturn(MockMvcUtils.TEST_PIPELINE_QUOTA_ARRAY_IMPUTATION);
+    when(quotasServiceMock.getQuotaUnitsForPipeline(PipelinesEnum.ARRAY_IMPUTATION))
+        .thenReturn(MockMvcUtils.PIPELINE_QUOTA_UNITS);
   }
 
   @Test
@@ -73,7 +73,7 @@ class QuotasControllerTest {
     assertEquals(testUserQuota.getQuota(), response.getQuotaLimit());
     assertEquals(testUserQuota.getQuotaConsumed(), response.getQuotaConsumed());
     assertEquals(testUserQuota.getPipelineName().getValue(), response.getPipelineName());
-    assertEquals(MockMvcUtils.PIPELINE_QUOTA_UNITS, response.getQuotaUnits());
+    assertEquals(MockMvcUtils.PIPELINE_QUOTA_UNITS.getValue(), response.getQuotaUnits());
   }
 
   @Test

--- a/service/src/test/java/bio/terra/pipelines/db/entities/PipelineQuotaTest.java
+++ b/service/src/test/java/bio/terra/pipelines/db/entities/PipelineQuotaTest.java
@@ -3,6 +3,7 @@ package bio.terra.pipelines.db.entities;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import bio.terra.pipelines.common.utils.PipelinesEnum;
+import bio.terra.pipelines.common.utils.QuotaUnitsEnum;
 import bio.terra.pipelines.testutils.BaseTest;
 import org.junit.jupiter.api.Test;
 
@@ -11,10 +12,10 @@ class PipelineQuotaTest extends BaseTest {
   @Test
   void testPipelineQuotaConstructor() {
     PipelineQuota pipelineQuota =
-        new PipelineQuota(PipelinesEnum.ARRAY_IMPUTATION, 10000, 500, "samples");
+        new PipelineQuota(PipelinesEnum.ARRAY_IMPUTATION, 10000, 500, QuotaUnitsEnum.SAMPLES);
     assertEquals(PipelinesEnum.ARRAY_IMPUTATION, pipelineQuota.getPipelineName());
     assertEquals(10000, pipelineQuota.getDefaultQuota());
     assertEquals(500, pipelineQuota.getMinQuotaConsumed());
-    assertEquals("samples", pipelineQuota.getQuotaUnits());
+    assertEquals(QuotaUnitsEnum.SAMPLES, pipelineQuota.getQuotaUnits());
   }
 }

--- a/service/src/test/java/bio/terra/pipelines/db/entities/PipelineQuotaTest.java
+++ b/service/src/test/java/bio/terra/pipelines/db/entities/PipelineQuotaTest.java
@@ -10,9 +10,11 @@ class PipelineQuotaTest extends BaseTest {
 
   @Test
   void testPipelineQuotaConstructor() {
-    PipelineQuota pipelineQuota = new PipelineQuota(PipelinesEnum.ARRAY_IMPUTATION, 10000, 500);
+    PipelineQuota pipelineQuota =
+        new PipelineQuota(PipelinesEnum.ARRAY_IMPUTATION, 10000, 500, "samples");
     assertEquals(PipelinesEnum.ARRAY_IMPUTATION, pipelineQuota.getPipelineName());
     assertEquals(10000, pipelineQuota.getDefaultQuota());
     assertEquals(500, pipelineQuota.getMinQuotaConsumed());
+    assertEquals("samples", pipelineQuota.getQuotaUnits());
   }
 }

--- a/service/src/test/java/bio/terra/pipelines/service/QuotasServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/QuotasServiceTest.java
@@ -30,6 +30,14 @@ class QuotasServiceTest extends BaseEmbeddedDbTest {
   }
 
   @Test
+  void getQuotaUnitsForPipeline() {
+    QuotaUnitsEnum quotaUnits =
+        quotasService.getQuotaUnitsForPipeline(PipelinesEnum.ARRAY_IMPUTATION);
+
+    assertEquals(QuotaUnitsEnum.SAMPLES, quotaUnits);
+  }
+
+  @Test
   void getQuotaForUserAndPipeline() {
     // add row to user_quotas table
     createAndSaveUserQuota(TestUtils.TEST_USER_ID_1, PipelinesEnum.ARRAY_IMPUTATION, 30, 100);

--- a/service/src/test/java/bio/terra/pipelines/service/QuotasServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/QuotasServiceTest.java
@@ -25,6 +25,7 @@ class QuotasServiceTest extends BaseEmbeddedDbTest {
     assertEquals(PipelinesEnum.ARRAY_IMPUTATION, pipelineQuota.getPipelineName());
     assertEquals(10000, pipelineQuota.getDefaultQuota());
     assertEquals(500, pipelineQuota.getMinQuotaConsumed());
+    assertEquals("samples", pipelineQuota.getQuotaUnits());
   }
 
   @Test

--- a/service/src/test/java/bio/terra/pipelines/service/QuotasServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/QuotasServiceTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import bio.terra.common.exception.InternalServerErrorException;
 import bio.terra.pipelines.common.utils.PipelinesEnum;
+import bio.terra.pipelines.common.utils.QuotaUnitsEnum;
 import bio.terra.pipelines.db.entities.PipelineQuota;
 import bio.terra.pipelines.db.entities.UserQuota;
 import bio.terra.pipelines.db.repositories.PipelineQuotasRepository;
@@ -25,7 +26,7 @@ class QuotasServiceTest extends BaseEmbeddedDbTest {
     assertEquals(PipelinesEnum.ARRAY_IMPUTATION, pipelineQuota.getPipelineName());
     assertEquals(10000, pipelineQuota.getDefaultQuota());
     assertEquals(500, pipelineQuota.getMinQuotaConsumed());
-    assertEquals("samples", pipelineQuota.getQuotaUnits());
+    assertEquals(QuotaUnitsEnum.SAMPLES, pipelineQuota.getQuotaUnits());
   }
 
   @Test

--- a/service/src/test/java/bio/terra/pipelines/testutils/MockMvcUtils.java
+++ b/service/src/test/java/bio/terra/pipelines/testutils/MockMvcUtils.java
@@ -4,6 +4,7 @@ import bio.terra.common.iam.BearerToken;
 import bio.terra.common.iam.SamUser;
 import bio.terra.pipelines.common.utils.PipelinesEnum;
 import bio.terra.pipelines.db.entities.Pipeline;
+import bio.terra.pipelines.db.entities.PipelineQuota;
 import bio.terra.pipelines.db.entities.UserQuota;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -79,6 +80,13 @@ public class MockMvcUtils {
     return testPipeline;
   }
 
+  public static final String PIPELINE_QUOTA_UNITS = "samples";
+  public static final PipelineQuota TEST_PIPELINE_QUOTA_ARRAY_IMPUTATION =
+      new PipelineQuota(
+          PipelinesEnum.ARRAY_IMPUTATION,
+          1000,
+          10,
+          PIPELINE_QUOTA_UNITS); // 1000 GB, 10 GB consumed
   public static final UserQuota TEST_USER_QUOTA_1 =
       new UserQuota(PipelinesEnum.ARRAY_IMPUTATION, TEST_SAM_USER.getSubjectId(), 1000, 10);
 }

--- a/service/src/test/java/bio/terra/pipelines/testutils/MockMvcUtils.java
+++ b/service/src/test/java/bio/terra/pipelines/testutils/MockMvcUtils.java
@@ -3,9 +3,7 @@ package bio.terra.pipelines.testutils;
 import bio.terra.common.iam.BearerToken;
 import bio.terra.common.iam.SamUser;
 import bio.terra.pipelines.common.utils.PipelinesEnum;
-import bio.terra.pipelines.common.utils.QuotaUnitsEnum;
 import bio.terra.pipelines.db.entities.Pipeline;
-import bio.terra.pipelines.db.entities.PipelineQuota;
 import bio.terra.pipelines.db.entities.UserQuota;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -81,13 +79,6 @@ public class MockMvcUtils {
     return testPipeline;
   }
 
-  public static final QuotaUnitsEnum PIPELINE_QUOTA_UNITS = QuotaUnitsEnum.SAMPLES;
-  public static final PipelineQuota TEST_PIPELINE_QUOTA_ARRAY_IMPUTATION =
-      new PipelineQuota(
-          PipelinesEnum.ARRAY_IMPUTATION,
-          1000,
-          10,
-          PIPELINE_QUOTA_UNITS); // 1000 GB, 10 GB consumed
   public static final UserQuota TEST_USER_QUOTA_1 =
       new UserQuota(PipelinesEnum.ARRAY_IMPUTATION, TEST_SAM_USER.getSubjectId(), 1000, 10);
 }

--- a/service/src/test/java/bio/terra/pipelines/testutils/MockMvcUtils.java
+++ b/service/src/test/java/bio/terra/pipelines/testutils/MockMvcUtils.java
@@ -3,6 +3,7 @@ package bio.terra.pipelines.testutils;
 import bio.terra.common.iam.BearerToken;
 import bio.terra.common.iam.SamUser;
 import bio.terra.pipelines.common.utils.PipelinesEnum;
+import bio.terra.pipelines.common.utils.QuotaUnitsEnum;
 import bio.terra.pipelines.db.entities.Pipeline;
 import bio.terra.pipelines.db.entities.PipelineQuota;
 import bio.terra.pipelines.db.entities.UserQuota;
@@ -80,7 +81,7 @@ public class MockMvcUtils {
     return testPipeline;
   }
 
-  public static final String PIPELINE_QUOTA_UNITS = "samples";
+  public static final QuotaUnitsEnum PIPELINE_QUOTA_UNITS = QuotaUnitsEnum.SAMPLES;
   public static final PipelineQuota TEST_PIPELINE_QUOTA_ARRAY_IMPUTATION =
       new PipelineQuota(
           PipelinesEnum.ARRAY_IMPUTATION,


### PR DESCRIPTION
### Description 

Each pipeline should have its quota unit defined. This PR adds a `quota_units` field to the `pipeline_quotas` table in the teaspoons database; the string value of `QuotaUnitsEnum` is meant to be the plural version of the unit, e.g. "samples" rather than "sample". We include this field in the `QuotaWithDetails` API response that users receive when they query their quota status for a pipeline.

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-405

### Checklist (provide links to changes)

- [ ] Updated external documentation (if applicable)
- [ ] Updated internal documentation (if applicable)
- [ ] Planned non patch version bump (if applicable)
- [ ] Updated CLI PR: https://github.com/DataBiosphere/terra-scientific-pipelines-service-cli/pull/45
