### PR TITLE
TSPS-345 Mute sentry alerts for HttpRequestMethodNotSupportedException

### DIFF
--- a/service/src/main/java/bio/terra/pipelines/app/controller/GlobalExceptionHandler.java
+++ b/service/src/main/java/bio/terra/pipelines/app/controller/GlobalExceptionHandler.java
@@ -41,6 +41,7 @@ public class GlobalExceptionHandler {
   // -- validation exceptions - we don't control the exception raised
   @ExceptionHandler({
     MethodArgumentTypeMismatchException.class,
+    HttpRequestMethodNotSupportedException.class,
     IllegalArgumentException.class,
     NoHandlerFoundException.class
   })
@@ -114,8 +115,8 @@ public class GlobalExceptionHandler {
       @Nullable String messageForApiErrorReport) {
     // logging 4** & 5** errors to sentry
     if (statusCode.is5xxServerError() || statusCode.is4xxClientError()) {
-      if (ex instanceof NoResourceFoundException
-          || ex instanceof HttpRequestMethodNotSupportedException) {
+      if (ex.getClass() == NoResourceFoundException.class
+          || ex.getClass() == HttpRequestMethodNotSupportedException.class) {
         // NoResourceFoundExceptions arise from calls to nonexistent API paths and are generally
         // spam; HttpRequestMethodNotSupportedExceptions arise from calls to existing API paths with
         // unsupported methods (e.g. POST, PROPFIND) and are generally spam

--- a/service/src/main/java/bio/terra/pipelines/app/controller/GlobalExceptionHandler.java
+++ b/service/src/main/java/bio/terra/pipelines/app/controller/GlobalExceptionHandler.java
@@ -41,7 +41,6 @@ public class GlobalExceptionHandler {
   // -- validation exceptions - we don't control the exception raised
   @ExceptionHandler({
     MethodArgumentTypeMismatchException.class,
-    HttpRequestMethodNotSupportedException.class,
     IllegalArgumentException.class,
     NoHandlerFoundException.class
   })
@@ -115,9 +114,11 @@ public class GlobalExceptionHandler {
       @Nullable String messageForApiErrorReport) {
     // logging 4** & 5** errors to sentry
     if (statusCode.is5xxServerError() || statusCode.is4xxClientError()) {
-      if (ex.getClass() == NoResourceFoundException.class) {
+      if (ex instanceof NoResourceFoundException
+          || ex instanceof HttpRequestMethodNotSupportedException) {
         // NoResourceFoundExceptions arise from calls to nonexistent API paths and are generally
-        // spam
+        // spam; HttpRequestMethodNotSupportedExceptions arise from calls to existing API paths with
+        // unsupported methods (e.g. POST, PROPFIND) and are generally spam
         logger.warn("Not sending exception of type {} to Sentry", ex.getClass());
       } else {
         Sentry.captureException(ex);


### PR DESCRIPTION
### Description 

We get Sentry alerts often for seemingly spam/bot calls to existing paths with invalid methods (POST, PROPFIND). Similar to https://github.com/DataBiosphere/terra-scientific-pipelines-service/pull/89, we don't send these to Sentry but do log that we did so.  

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-345

### Checklist (provide links to changes)

- [ ] Updated external documentation (if applicable)
- [ ] Updated internal documentation (if applicable)
- [ ] Planned non patch version bump (if applicable)
- [ ] Updated CLI PR (if applicable)
