### PR TITLE
TSPS-447 add file suffix to pipeline details response, update array_impuation version, remove admin update pipeline regex

### DIFF
--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -715,6 +715,12 @@ components:
       type: string
       format: string
 
+    PipelineInputFileSuffix:
+      description: |
+        The allowed file suffix for the file.
+      type: string
+      format: string
+
     PipelineInputIsRequired:
       description: |
         Whether the input field is required.
@@ -822,6 +828,8 @@ components:
           $ref: "#/components/schemas/PipelineInputType"
         isRequired:
           $ref: "#/components/schemas/PipelineInputIsRequired"
+        fileSuffix:
+          $ref: "#/components/schemas/PipelineInputFileSuffix"
 
     PipelineUserProvidedInputDefinitions:
       description: |

--- a/service/src/main/java/bio/terra/pipelines/app/controller/PipelinesApiController.java
+++ b/service/src/main/java/bio/terra/pipelines/app/controller/PipelinesApiController.java
@@ -91,7 +91,8 @@ public class PipelinesApiController implements PipelinesApi {
                     new ApiPipelineUserProvidedInputDefinition()
                         .name(input.getName())
                         .type(input.getType().toString())
-                        .isRequired(input.isRequired()))
+                        .isRequired(input.isRequired())
+                        .fileSuffix(input.getFileSuffix()))
             .toList());
     return new ApiPipelineWithDetails()
         .pipelineName(pipelineInfo.getName().getValue())

--- a/service/src/main/java/bio/terra/pipelines/common/utils/CommonPipelineRunStatusEnum.java
+++ b/service/src/main/java/bio/terra/pipelines/common/utils/CommonPipelineRunStatusEnum.java
@@ -2,7 +2,6 @@ package bio.terra.pipelines.common.utils;
 
 public enum CommonPipelineRunStatusEnum {
   PREPARING,
-  SUBMITTED,
   RUNNING,
   SUCCEEDED,
   FAILED;

--- a/service/src/main/java/bio/terra/pipelines/service/PipelinesService.java
+++ b/service/src/main/java/bio/terra/pipelines/service/PipelinesService.java
@@ -133,18 +133,8 @@ public class PipelinesService {
               "toolVersion %s does not follow semantic versioning regex %s",
               toolVersion, SEM_VER_REGEX_STRING));
     }
+    pipeline.setToolVersion(toolVersion);
 
-    // ensure that major version of toolVersion matches the value of the pipeline version.
-    // split toolVersion by 'v' and take the last element of the resulting array
-    String wdlMethodExtractedSemVer = toolVersion.split("v")[toolVersion.split("v").length - 1];
-    if (pipeline.getVersion().equals(Integer.parseInt(wdlMethodExtractedSemVer.split("\\.")[0]))) {
-      pipeline.setToolVersion(toolVersion);
-    } else {
-      throw new ValidationException(
-          String.format(
-              "toolVersion %s does not align with pipeline version %s. The major version of toolVersion must match pipeline version",
-              toolVersion, pipeline.getVersion()));
-    }
     pipelinesRepository.save(pipeline);
     return pipeline;
   }

--- a/service/src/main/resources/db/changelog.xml
+++ b/service/src/main/resources/db/changelog.xml
@@ -11,6 +11,7 @@
   <include file="changesets/20241212_add_quota_consumed_update_pipeline_display_name.yaml" relativeToChangelogFile="true"/>
   <include file="changesets/20250127_add_expects_custom_value_field_to_input_defs.yaml" relativeToChangelogFile="true"/>
   <include file="changesets/20250220_rename_wdl_method_version_and_wdl_method_name.yaml" relativeToChangelogFile="true"/>
+  <include file="changesets/20250305_update_array_imputation_version.yaml" relativeToChangelogFile="true"/>
   <include file="changesets/20250225_add_quota_units.yaml" relativeToChangelogFile="true"/>
 
   <include file="changesets/testdata.yaml" relativeToChangelogFile="true"/>

--- a/service/src/main/resources/db/changesets/20250305_update_array_imputation_version.yaml
+++ b/service/src/main/resources/db/changesets/20250305_update_array_imputation_version.yaml
@@ -1,0 +1,15 @@
+# update the version of the array_imputation pipeline NEVER DO THIS AGAIN THIS IS ONLY CUZ WE"RE PREPROD RELEASE
+
+databaseChangeLog:
+  -  changeSet:
+       id:  update version of array_imputation pipeline
+       author:  js
+       changes:
+         # update array_imputation pipeline version to 1
+         - update:
+             tableName: pipelines
+             columns:
+               - column:
+                  name: version
+                  value: 1
+             where: name='array_imputation' and version=0

--- a/service/src/test/java/bio/terra/pipelines/service/PipelinesServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/PipelinesServiceTest.java
@@ -46,6 +46,7 @@ class PipelinesServiceTest extends BaseEmbeddedDbTest {
   @Autowired PipelinesRepository pipelinesRepository;
   @MockitoBean SamService samService;
   @MockitoBean RawlsService rawlsService;
+  Integer currentPipelineVersion = 1;
 
   @Test
   void getCorrectNumberOfPipelines() {
@@ -62,7 +63,7 @@ class PipelinesServiceTest extends BaseEmbeddedDbTest {
     pipelinesRepository.save(
         new Pipeline(
             PipelinesEnum.ARRAY_IMPUTATION,
-            2,
+            currentPipelineVersion + 1,
             "pipelineDisplayName",
             "description",
             "pipelineType",
@@ -81,7 +82,7 @@ class PipelinesServiceTest extends BaseEmbeddedDbTest {
     assertEquals(2, pipelineList.size());
     Pipeline savedPipeline = pipelineList.get(1);
     assertEquals(PipelinesEnum.ARRAY_IMPUTATION, savedPipeline.getName());
-    assertEquals(2, savedPipeline.getVersion());
+    assertEquals(currentPipelineVersion + 1, savedPipeline.getVersion());
     assertEquals("pipelineDisplayName", savedPipeline.getDisplayName());
     assertEquals("description", savedPipeline.getDescription());
     assertEquals("pipelineType", savedPipeline.getPipelineType());
@@ -113,7 +114,7 @@ class PipelinesServiceTest extends BaseEmbeddedDbTest {
     pipelinesRepository.save(
         new Pipeline(
             PipelinesEnum.ARRAY_IMPUTATION,
-            2,
+            currentPipelineVersion + 1,
             "pipelineDisplayName",
             "description",
             "pipelineType",
@@ -130,11 +131,12 @@ class PipelinesServiceTest extends BaseEmbeddedDbTest {
     PipelinesEnum imputationPipeline = PipelinesEnum.ARRAY_IMPUTATION;
     // this should return the highest version of the pipeline
     Pipeline nullVersionPipeline = pipelinesService.getPipeline(imputationPipeline, null);
-    assertEquals(2, nullVersionPipeline.getVersion());
+    assertEquals(currentPipelineVersion + 1, nullVersionPipeline.getVersion());
 
     // this should return the specific version of the pipeline that exists
-    Pipeline specificVersionPipeline = pipelinesService.getPipeline(imputationPipeline, 1);
-    assertEquals(1, specificVersionPipeline.getVersion());
+    Pipeline specificVersionPipeline =
+        pipelinesService.getPipeline(imputationPipeline, currentPipelineVersion);
+    assertEquals(currentPipelineVersion, specificVersionPipeline.getVersion());
 
     // if asking for unknown version pipeline combo, throw exception
     assertThrows(
@@ -146,7 +148,7 @@ class PipelinesServiceTest extends BaseEmbeddedDbTest {
     PipelinesEnum imputationPipeline = PipelinesEnum.ARRAY_IMPUTATION;
     // this should return the highest version of the pipeline
     Pipeline getLatestPipeline = pipelinesService.getLatestPipeline(imputationPipeline);
-    assertEquals(1, getLatestPipeline.getVersion());
+    assertEquals(currentPipelineVersion, getLatestPipeline.getVersion());
 
     // save a new version of the same pipeline that exists in the table
     pipelinesRepository.save(

--- a/service/src/test/java/bio/terra/pipelines/service/PipelinesServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/PipelinesServiceTest.java
@@ -62,7 +62,7 @@ class PipelinesServiceTest extends BaseEmbeddedDbTest {
     pipelinesRepository.save(
         new Pipeline(
             PipelinesEnum.ARRAY_IMPUTATION,
-            1,
+            2,
             "pipelineDisplayName",
             "description",
             "pipelineType",
@@ -81,7 +81,7 @@ class PipelinesServiceTest extends BaseEmbeddedDbTest {
     assertEquals(2, pipelineList.size());
     Pipeline savedPipeline = pipelineList.get(1);
     assertEquals(PipelinesEnum.ARRAY_IMPUTATION, savedPipeline.getName());
-    assertEquals(1, savedPipeline.getVersion());
+    assertEquals(2, savedPipeline.getVersion());
     assertEquals("pipelineDisplayName", savedPipeline.getDisplayName());
     assertEquals("description", savedPipeline.getDescription());
     assertEquals("pipelineType", savedPipeline.getPipelineType());
@@ -113,7 +113,7 @@ class PipelinesServiceTest extends BaseEmbeddedDbTest {
     pipelinesRepository.save(
         new Pipeline(
             PipelinesEnum.ARRAY_IMPUTATION,
-            1,
+            2,
             "pipelineDisplayName",
             "description",
             "pipelineType",
@@ -130,11 +130,11 @@ class PipelinesServiceTest extends BaseEmbeddedDbTest {
     PipelinesEnum imputationPipeline = PipelinesEnum.ARRAY_IMPUTATION;
     // this should return the highest version of the pipeline
     Pipeline nullVersionPipeline = pipelinesService.getPipeline(imputationPipeline, null);
-    assertEquals(1, nullVersionPipeline.getVersion());
+    assertEquals(2, nullVersionPipeline.getVersion());
 
     // this should return the specific version of the pipeline that exists
-    Pipeline specificVersionPipeline = pipelinesService.getPipeline(imputationPipeline, 0);
-    assertEquals(0, specificVersionPipeline.getVersion());
+    Pipeline specificVersionPipeline = pipelinesService.getPipeline(imputationPipeline, 1);
+    assertEquals(1, specificVersionPipeline.getVersion());
 
     // if asking for unknown version pipeline combo, throw exception
     assertThrows(
@@ -146,7 +146,7 @@ class PipelinesServiceTest extends BaseEmbeddedDbTest {
     PipelinesEnum imputationPipeline = PipelinesEnum.ARRAY_IMPUTATION;
     // this should return the highest version of the pipeline
     Pipeline getLatestPipeline = pipelinesService.getLatestPipeline(imputationPipeline);
-    assertEquals(0, getLatestPipeline.getVersion());
+    assertEquals(1, getLatestPipeline.getVersion());
 
     // save a new version of the same pipeline that exists in the table
     pipelinesRepository.save(
@@ -278,7 +278,6 @@ class PipelinesServiceTest extends BaseEmbeddedDbTest {
 
   private static Stream<Arguments> badToolVersions() {
     return Stream.of(
-        arguments("1.13.1"), // current imputation beagle pipeline is version 0 so this should fail
         arguments("blah.3.2"),
         arguments("0.2"),
         arguments("0.bhmm.2"),
@@ -316,7 +315,8 @@ class PipelinesServiceTest extends BaseEmbeddedDbTest {
         arguments("ImputationBeagle_development_v0.0.0"),
         arguments("stringwithvinthemiddlev0.0.0"),
         arguments("v0.1.32"),
-        arguments("stringv0.1.32"));
+        arguments("stringv0.1.32"),
+        arguments("1.13.1"));
   }
 
   @ParameterizedTest

--- a/service/src/test/java/bio/terra/pipelines/testutils/TestUtils.java
+++ b/service/src/test/java/bio/terra/pipelines/testutils/TestUtils.java
@@ -16,10 +16,6 @@ public class TestUtils {
   // Pipelines test constants
   public static final PipelinesEnum TEST_PIPELINE_1_IMPUTATION_ENUM =
       PipelinesEnum.ARRAY_IMPUTATION;
-  public static final String TEST_PIPELINE_NAME_1_IMPUTATION =
-      TEST_PIPELINE_1_IMPUTATION_ENUM
-          .getValue(); // this matches the job pre-populated in the db for tests in that it is in
-  // the jobs table
 
   public static final Long TEST_PIPELINE_ID_1 = 1L;
   public static final int TEST_PIPELINE_VERSION_1 = 0;


### PR DESCRIPTION
add file_suffix value to pipeline details inputs section
removed regex that forced tool version to match pipeline version
update array_imputation version to 1

### Description 

_Please replace this description with a concise description of this Pull Request._

### Jira Ticket

https://broadworkbench.atlassian.net/browse/TSPS-447

### Checklist (provide links to changes)

- [ ] Updated external documentation (if applicable)
updated e2e test to match these version changes - https://github.com/broadinstitute/dsp-reusable-workflows/pull/73
- [ ] Updated internal documentation (if applicable)
- [ ] Planned non patch version bump (if applicable)
- [ ] Updated CLI PR (if applicable)


![Screenshot 2025-03-05 at 4 35 27 PM](https://github.com/user-attachments/assets/aa36c5da-f705-445f-b34f-bbeccffe1872)

![Screenshot 2025-03-05 at 4 35 50 PM](https://github.com/user-attachments/assets/70cc9e70-8461-4c55-bbcd-6c50d110a196)

