### PR TITLE
TSPS-448 allow user quota consumed to be updated to 0

### DIFF
--- a/service/src/main/java/bio/terra/pipelines/service/QuotasService.java
+++ b/service/src/main/java/bio/terra/pipelines/service/QuotasService.java
@@ -82,7 +82,7 @@ public class QuotasService {
    * @return - the updated user quota object
    */
   public UserQuota updateQuotaConsumed(UserQuota userQuota, int newQuotaConsumed) {
-    if (newQuotaConsumed <= 0 || newQuotaConsumed > userQuota.getQuota()) {
+    if (newQuotaConsumed < 0 || newQuotaConsumed > userQuota.getQuota()) {
       logger.error(
           "Issue with updating quota consumed: User quota: {}, current quota consumed: {}, new quota consumed {}",
           userQuota.getQuota(),

--- a/service/src/test/java/bio/terra/pipelines/service/QuotasServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/QuotasServiceTest.java
@@ -139,6 +139,22 @@ class QuotasServiceTest extends BaseEmbeddedDbTest {
   }
 
   @Test
+  void updateQuotaConsumedZero() {
+    // add row to user_quotas table
+    UserQuota userQuota =
+        createAndSaveUserQuota(TestUtils.TEST_USER_ID_1, PipelinesEnum.ARRAY_IMPUTATION, 30, 100);
+
+    // call service to update quota consumed
+    int newQuotaConsumed = 0;
+    UserQuota updatedUserQuota = quotasService.updateQuotaConsumed(userQuota, newQuotaConsumed);
+
+    assertEquals(userQuota.getUserId(), updatedUserQuota.getUserId());
+    assertEquals(userQuota.getPipelineName(), updatedUserQuota.getPipelineName());
+    assertEquals(newQuotaConsumed, updatedUserQuota.getQuotaConsumed());
+    assertEquals(userQuota.getQuota(), updatedUserQuota.getQuota());
+  }
+
+  @Test
   void updateQuotaConsumedLessThanZero() {
     // add row to user_quotas table
     UserQuota userQuota =


### PR DESCRIPTION
### Description 

This use case does happen in practice if a users first submission is rolled back by stairway.  The rollback would try to set the users quota back to 0

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-448

### Checklist (provide links to changes)

- [ ] Updated external documentation (if applicable)
- [ ] Updated internal documentation (if applicable)
- [ ] Planned non patch version bump (if applicable)
- [ ] Updated CLI PR (if applicable)
