### PR TITLE
TSPS-439 update array_imputation default quota to 2500

### DIFF
--- a/service/src/main/resources/db/changelog.xml
+++ b/service/src/main/resources/db/changelog.xml
@@ -13,6 +13,7 @@
   <include file="changesets/20250220_rename_wdl_method_version_and_wdl_method_name.yaml" relativeToChangelogFile="true"/>
   <include file="changesets/20250305_update_array_imputation_version.yaml" relativeToChangelogFile="true"/>
   <include file="changesets/20250225_add_quota_units.yaml" relativeToChangelogFile="true"/>
+  <include file="changesets/20250324_update_array_imputation_default_quota_to_2500.yaml" relativeToChangelogFile="true"/>
 
   <include file="changesets/testdata.yaml" relativeToChangelogFile="true"/>
 

--- a/service/src/main/resources/db/changesets/20250324_update_array_imputation_default_quota_to_2500.yaml
+++ b/service/src/main/resources/db/changesets/20250324_update_array_imputation_default_quota_to_2500.yaml
@@ -1,0 +1,15 @@
+# update the default of the array_imputation pipeline quota to 2500
+
+databaseChangeLog:
+  -  changeSet:
+       id:  update default quota of array_imputation pipeline
+       author:  js
+       changes:
+         # update array_imputation default quota to 2500
+         - update:
+             tableName: pipeline_quotas
+             columns:
+               - column:
+                  name: default_quota
+                  value: 2500
+             where: pipeline_name='array_imputation'

--- a/service/src/test/java/bio/terra/pipelines/service/QuotasServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/QuotasServiceTest.java
@@ -24,7 +24,7 @@ class QuotasServiceTest extends BaseEmbeddedDbTest {
     PipelineQuota pipelineQuota = quotasService.getPipelineQuota(PipelinesEnum.ARRAY_IMPUTATION);
 
     assertEquals(PipelinesEnum.ARRAY_IMPUTATION, pipelineQuota.getPipelineName());
-    assertEquals(10000, pipelineQuota.getDefaultQuota());
+    assertEquals(2500, pipelineQuota.getDefaultQuota());
     assertEquals(500, pipelineQuota.getMinQuotaConsumed());
     assertEquals(QuotaUnitsEnum.SAMPLES, pipelineQuota.getQuotaUnits());
   }

--- a/service/src/test/java/bio/terra/pipelines/stairway/steps/common/QuotaConsumedValidationStepTest.java
+++ b/service/src/test/java/bio/terra/pipelines/stairway/steps/common/QuotaConsumedValidationStepTest.java
@@ -79,7 +79,7 @@ class QuotaConsumedValidationStepTest extends BaseEmbeddedDbTest {
   void doStepSuccessUseQuotaWdlConsumedValue() {
     // setup
     StairwayTestUtils.constructCreateJobInputs(flightContext.getInputParameters());
-    flightContext.getWorkingMap().put(ImputationJobMapKeys.RAW_QUOTA_CONSUMED, 3000);
+    flightContext.getWorkingMap().put(ImputationJobMapKeys.RAW_QUOTA_CONSUMED, 2000);
 
     // before running make sure quota consumed for user is 0
     UserQuota userQuota =
@@ -100,10 +100,10 @@ class QuotaConsumedValidationStepTest extends BaseEmbeddedDbTest {
     userQuota =
         quotasService.getOrCreateQuotaForUserAndPipeline(
             TestUtils.TEST_USER_ID_1, PipelinesEnum.ARRAY_IMPUTATION);
-    assertEquals(3000, userQuota.getQuotaConsumed());
+    assertEquals(2000, userQuota.getQuotaConsumed());
     // assert effective quota consumed is correctly stored in the working map
     assertEquals(
-        3000,
+        2000,
         flightContext
             .getWorkingMap()
             .get(ImputationJobMapKeys.EFFECTIVE_QUOTA_CONSUMED, Integer.class));


### PR DESCRIPTION
### Description 

For our prod release we want to only give users 2500 default quota.  This is so we can allow more users to use our service for free.

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-439

### Checklist (provide links to changes)

- [ ] Updated external documentation (if applicable)
- [ ] Updated internal documentation (if applicable)
- [ ] Planned non patch version bump (if applicable)
- [ ] Updated CLI PR (if applicable)
