### PR TITLE
TSPS-351 Add progress bar to curl upload command

### DIFF
--- a/service/src/main/java/bio/terra/pipelines/service/PipelineInputsOutputsService.java
+++ b/service/src/main/java/bio/terra/pipelines/service/PipelineInputsOutputsService.java
@@ -96,7 +96,7 @@ public class PipelineInputsOutputsService {
               "signedUrl",
               signedUrl,
               "curlCommand",
-              "curl --progress-bar -X PUT -H 'Content-Type: application/octet-stream' --upload-file %s '%s'"
+              "curl --progress-bar -X PUT -H 'Content-Type: application/octet-stream' --upload-file %s '%s' | cat"
                   .formatted(fileInputValue, signedUrl)));
     }
 

--- a/service/src/main/java/bio/terra/pipelines/service/PipelineInputsOutputsService.java
+++ b/service/src/main/java/bio/terra/pipelines/service/PipelineInputsOutputsService.java
@@ -96,7 +96,7 @@ public class PipelineInputsOutputsService {
               "signedUrl",
               signedUrl,
               "curlCommand",
-              "curl -X PUT -H 'Content-Type: application/octet-stream' --upload-file %s '%s'"
+              "curl --progress-bar -X PUT -H 'Content-Type: application/octet-stream' --upload-file %s '%s'"
                   .formatted(fileInputValue, signedUrl)));
     }
 

--- a/service/src/test/java/bio/terra/pipelines/service/PipelineInputsOutputsServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/PipelineInputsOutputsServiceTest.java
@@ -83,7 +83,7 @@ class PipelineInputsOutputsServiceTest extends BaseEmbeddedDbTest {
     assertEquals(
         fakeUrl.toString(), formattedPipelineFileInputs.get(fileInputKeyName).get("signedUrl"));
     assertEquals(
-        "curl --progress-bar -X PUT -H 'Content-Type: application/octet-stream' --upload-file %s '%s'"
+        "curl --progress-bar -X PUT -H 'Content-Type: application/octet-stream' --upload-file %s '%s' | cat"
             .formatted(fileInputValue, fakeUrl.toString()),
         formattedPipelineFileInputs.get(fileInputKeyName).get("curlCommand"));
   }

--- a/service/src/test/java/bio/terra/pipelines/service/PipelineInputsOutputsServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/PipelineInputsOutputsServiceTest.java
@@ -83,7 +83,7 @@ class PipelineInputsOutputsServiceTest extends BaseEmbeddedDbTest {
     assertEquals(
         fakeUrl.toString(), formattedPipelineFileInputs.get(fileInputKeyName).get("signedUrl"));
     assertEquals(
-        "curl -X PUT -H 'Content-Type: application/octet-stream' --upload-file %s '%s'"
+        "curl --progress-bar -X PUT -H 'Content-Type: application/octet-stream' --upload-file %s '%s'"
             .formatted(fileInputValue, fakeUrl.toString()),
         formattedPipelineFileInputs.get(fileInputKeyName).get("curlCommand"));
   }

--- a/service/src/test/java/bio/terra/pipelines/service/PipelineRunsServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/PipelineRunsServiceTest.java
@@ -320,7 +320,7 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
     assertEquals(
         fakeUrl.toString(), formattedPipelineFileInputs.get(fileInputKeyName).get("signedUrl"));
     assertEquals(
-        "curl --progress-bar -X PUT -H 'Content-Type: application/octet-stream' --upload-file %s '%s'"
+        "curl --progress-bar -X PUT -H 'Content-Type: application/octet-stream' --upload-file %s '%s' | cat"
             .formatted(fileInputValue, fakeUrl.toString()),
         formattedPipelineFileInputs.get(fileInputKeyName).get("curlCommand"));
 

--- a/service/src/test/java/bio/terra/pipelines/service/PipelineRunsServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/PipelineRunsServiceTest.java
@@ -320,7 +320,7 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
     assertEquals(
         fakeUrl.toString(), formattedPipelineFileInputs.get(fileInputKeyName).get("signedUrl"));
     assertEquals(
-        "curl -X PUT -H 'Content-Type: application/octet-stream' --upload-file %s '%s'"
+        "curl --progress-bar -X PUT -H 'Content-Type: application/octet-stream' --upload-file %s '%s'"
             .formatted(fileInputValue, fakeUrl.toString()),
         formattedPipelineFileInputs.get(fileInputKeyName).get("curlCommand"));
 


### PR DESCRIPTION
### Description 

Adds a progress bar to the curl upload command that's supplied to users after preparing their pipeline run.

Api response before:

```
{
  "jobId": "3fa85f64-5717-4562-b3fc-2c963f66afa2",
  "fileInputUploadUrls": {
    "multiSampleVcf": {
      "curlCommand": "curl -X PUT -H 'Content-Type: application/octet-stream' --upload-file /Users/mbemis/Desktop/test-upload.vcf.gz '<SIGNED URL REDACTED>'",
      "signedUrl": "<SIGNED URL REDACTED>"
    }
  }
}
```

Api response after:

```
{
  "jobId": "3fa85f64-5717-4562-b3fc-2c963f66afa1",
  "fileInputUploadUrls": {
    "multiSampleVcf": {
      "curlCommand": "curl --progress-bar -X PUT -H 'Content-Type: application/octet-stream' --upload-file /Users/mbemis/Desktop/test-upload.vcf.gz '<SIGNED URL REDACTED>' | cat",
      "signedUrl": "<SIGNED URL REDACTED>"
    }
  }
}
```


Command run before:

```
mbemis ~  $ curl -X PUT -H 'Content-Type: application/octet-stream' --upload-file /Users/mbemis/Desktop/test-upload.vcf.gz '<SIGNED URL REDACTED>'
mbemis ~  $
```

(note no output at all)

Command run after:
```
mbemis ~ $ curl --progress-bar -X PUT -H 'Content-Type: application/octet-stream'--upload-file /U
sers/mbemis/Desktop/test-upload.vcf.gz '<SIGNED URL REDACTED>' | cat
########################################################################################### 100.0%
```

### Jira Ticket

https://broadworkbench.atlassian.net/browse/TSPS-351

### Checklist (provide links to changes)

- [ ] Updated external documentation (if applicable)
- [ ] Updated internal documentation (if applicable)
- [ ] Planned non patch version bump (if applicable)
- [ ] Updated CLI PR (if applicable)
