### PR TITLE
TSPS-468 Add deployment script

### DIFF
--- a/ui/allofus-anvil-imputation/acknowledgments/index.html
+++ b/ui/allofus-anvil-imputation/acknowledgments/index.html
@@ -3,8 +3,9 @@
 <head>
   <title>Acknowledgments | All of Us + AnVIL Imputation Service</title>
   <meta name='robots' content='index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1' />
-  <link rel="icon" type="image/png" sizes="32x32" href="img/imputation-favicon.png">
-  <link rel="stylesheet" href="css/style.css">
+  <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
+  <link rel="icon" type="image/png" sizes="32x32" href="/img/imputation-favicon.png">
+  <link rel="stylesheet" href="/css/style.css">
   <link rel="stylesheet" id="google-fonts-1-css"
     href="https://fonts.googleapis.com/css?family=Montserrat%3A100%2C100italic%2C200%2C200italic%2C300%2C300italic%2C400%2C400italic%2C500%2C500italic%2C600%2C600italic%2C700%2C700italic%2C800%2C800italic%2C900%2C900italic&amp;display=swap&amp;ver=6.7.2"
     media="all">
@@ -13,15 +14,15 @@
 <body id="acknowledgments">
   <div class="header">
     <div class="top-logos">
-      <img src="img/all-of-us-research-program-logo-white.png" style="width: 110px; height: 38.33px; left: -1px; top: -2px;"  alt="All of Us logo" />
+      <img src="/img/all-of-us-research-program-logo-white.png" style="width: 110px; height: 38.33px; left: -1px; top: -2px;"  alt="All of Us logo" />
       <div class="top-vertical-bar"></div>
-      <img src="img/anvil-logo.png" style="filter: brightness(0) invert(1); width: 110px; height: 38.33px;" alt="AnVIL logo" />
+      <img src="/img/anvil-logo.png" style="filter: brightness(0) invert(1); width: 110px; height: 38.33px;" alt="AnVIL logo" />
     </div>
   </div>
 
   <div class="main">
-    <a class="go-back" href="../allofus-anvil-imputation">
-      <img src="img/back-arrow.png" class="button-icon" alt="Go back" />
+    <a class="go-back" href="/">
+      <img src="/img/back-arrow.png" class="button-icon" alt="Go back" />
       Go back
     </a>
     <h1>Scientific acknowledgments</h1>

--- a/ui/allofus-anvil-imputation/css/style.css
+++ b/ui/allofus-anvil-imputation/css/style.css
@@ -394,7 +394,7 @@ body {
 #acknowledgments .header {
   height: 100px;
   width: 100%;
-  background-image: url('../img/imputation-top-background.png');
+  background-image: url('/img/imputation-top-background.png');
   background-position: "bottom center";
   text-align: center;
 }

--- a/ui/allofus-anvil-imputation/deploy.py
+++ b/ui/allofus-anvil-imputation/deploy.py
@@ -1,0 +1,116 @@
+"""
+Deploy files to Google Cloud Storage.
+
+Recursively uploads files from the current directory to the specified GCS bucket
+based on the target environment. Certain files are excluded from the upload
+(e.g. .DS_Store, deploy.py, readme.md).
+
+Usage:
+    python3 deploy.py --environment dev
+"""
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+# Define destination configurations
+ENV_CONFIG = {
+    "dev": {
+        "bucket": "gs://allofus-anvil-imputation-dev",
+        "project": "broad-dsde-dev"
+    },
+    "prod": {
+        "bucket": "gs://allofus-anvil-imputation-prod",
+        "project": "broad-dsde-prod"
+    }
+}
+
+EXCLUDED_FILES = {".DS_Store", "deploy.py", "readme.md", "README.md"}
+
+def validate_working_directory():
+    expected_suffix = "ui/allofus-anvil-imputation"
+    cwd = os.getcwd()
+    if not cwd.endswith(expected_suffix):
+        print(f"Error: This script must be run from a directory ending in '{expected_suffix}'")
+        print(f"Current directory: {cwd}")
+        sys.exit(1)
+
+def get_current_gcloud_account() -> str:
+    try:
+        result = subprocess.run(
+            ["gcloud", "auth", "list", "--filter=status:ACTIVE", "--format=value(account)"],
+            check=True,
+            stdout=subprocess.PIPE,
+            text=True
+        )
+        return result.stdout.strip()
+    except subprocess.CalledProcessError:
+        print("Error: Failed to retrieve active gcloud account.")
+        sys.exit(1)
+
+def check_account_for_prod():
+    account = get_current_gcloud_account()
+    if not account.endswith("@firecloud.org"):
+        print("Error: For 'prod' deployments, the active gcloud account must end in '@firecloud.org'.")
+        print(f"Current account: {account}")
+        sys.exit(1)
+
+def should_exclude(path: str) -> bool:
+    return os.path.basename(path) in EXCLUDED_FILES
+
+def copy_files_to_temp_dir(source_dir=".") -> str:
+    temp_dir = tempfile.mkdtemp()
+    for root, dirs, files in os.walk(source_dir):
+        for file in files:
+            full_path = os.path.join(root, file)
+            rel_path = os.path.relpath(full_path, source_dir)
+            if should_exclude(rel_path):
+                continue
+            dest_path = os.path.join(temp_dir, rel_path)
+            os.makedirs(os.path.dirname(dest_path), exist_ok=True)
+            shutil.copy2(full_path, dest_path)
+    return temp_dir
+
+def run_gcloud_copy(environment: str):
+    if environment not in ENV_CONFIG:
+        print(f"Error: Unknown environment '{environment}'. Available: {', '.join(ENV_CONFIG.keys())}")
+        sys.exit(1)
+
+    if environment == "prod":
+        check_account_for_prod()
+
+    validate_working_directory()
+
+    bucket = ENV_CONFIG[environment]["bucket"]
+    project = ENV_CONFIG[environment]["project"]
+
+    print("Collecting files to upload (excluding ignored files)...")
+    temp_dir = copy_files_to_temp_dir()
+
+    command = [
+        "gcloud", "storage", "cp", "-r", ".", bucket,
+        "--project", project,
+         "--cache-control", "max-age=600, must-revalidate"
+    ]
+
+    try:
+        print(f"Uploading from temporary directory: {temp_dir}")
+        subprocess.run(command, check=True, cwd=temp_dir)
+        print("✅ Upload completed successfully.")
+    except subprocess.CalledProcessError as e:
+        print(f"❌ Upload failed (code {e.returncode})")
+        sys.exit(e.returncode)
+    finally:
+        shutil.rmtree(temp_dir)
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("-e", "--environment", type=str, required=True, help="Target environment (e.g. dev, prod)")
+    args = parser.parse_args()
+    run_gcloud_copy(args.environment)
+
+if __name__ == "__main__":
+    main()

--- a/ui/allofus-anvil-imputation/deploy.py
+++ b/ui/allofus-anvil-imputation/deploy.py
@@ -1,9 +1,15 @@
 """
-Deploy files to Google Cloud Storage.
+Deploy updates for the Imputation marketing UI
 
 Recursively uploads files from the current directory to the specified GCS bucket
 based on the target environment. Certain files are excluded from the upload
 (e.g. .DS_Store, deploy.py, readme.md).
+
+Destination URLs:
+* Development: https://allofus-anvil-imputation.dsde-dev.broadinstitute.org
+* Production: https://allofus-anvil-imputation.terra.bio
+
+See readme.md for more context.
 
 Usage:
     python3 deploy.py --environment dev

--- a/ui/allofus-anvil-imputation/index.html
+++ b/ui/allofus-anvil-imputation/index.html
@@ -3,7 +3,8 @@
 <head>
   <title>All of Us + AnVIL Imputation Service</title>
   <meta name='robots' content='index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1' />
-  <meta name="description" content="All of Us + AnVIL Imputation Service can help complete your datasets efficient and accurately" />
+  <meta name="description" content="All of Us + AnVIL Imputation Service can help complete your datasets efficiently and accurately" />
+  <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
   <link rel="icon" type="image/png" sizes="32x32" href="img/imputation-favicon.png">
   <link rel="stylesheet" href="css/style.css">
   <link rel="stylesheet" id="google-fonts-1-css"
@@ -206,7 +207,7 @@
     <img src="img/broad-white-logo.png" alt="Broad logo" />
     <br/>
     <div class="support-detail">
-      This work was made possible by National Institutes of Health (NIH) awards: (1) OT2OD035404, "<i>All of Us</i> Data and Research Center (DRC);" (2) OT2OD03821, “Broad-Color: The Genome Center for the Future of <i>All of Us</i>;" (3) OT2OD002750, "The Broad-LMM-Color Genome Center for <i>All of Us</i>," funded by the NIH Office of the Director; and (4) U24HG010262, "AnVIL: A National Resource for Genomic Data Analysis and Visualization," funded by the National Human Genome Research Institute.
+      This work was made possible by National Institutes of Health (NIH) awards: (1) OT2OD035404, "<i>All of Us</i> Data and Research Center (DRC);" (2) OT2OD03821, "Broad-Color: The Genome Center for the Future of <i>All of Us</i>;" (3) OT2OD002750, "The Broad-LMM-Color Genome Center for <i>All of Us</i>," funded by the NIH Office of the Director; and (4) U24HG010262, "AnVIL: A National Resource for Genomic Data Analysis and Visualization," funded by the National Human Genome Research Institute.
       <br/>
       <br/>
       <i>All of Us</i> and the <i>All of Us</i> logo are registered trademarks of the U.S. Department of Health and Human Services.
@@ -215,7 +216,7 @@
     </div>
     <br/>
     <div class="main-acknowledgments">
-      <a href="acknowledgments">Scientific acknowledgments</a>
+      <a href="acknowledgments/">Scientific acknowledgments</a>
     </div>
   </div>
 

--- a/ui/allofus-anvil-imputation/index.html
+++ b/ui/allofus-anvil-imputation/index.html
@@ -3,7 +3,7 @@
 <head>
   <title>All of Us + AnVIL Imputation Service</title>
   <meta name='robots' content='index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1' />
-  <meta name="description" content="All of Us + AnVIL Imputation Service can help complete your datasets efficiently and accurately" />
+  <meta name="description" content="Efficiently and accurately complete your datasets with All of Us + AnVIL Imputation Service" />
   <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
   <link rel="icon" type="image/png" sizes="32x32" href="img/imputation-favicon.png">
   <link rel="stylesheet" href="css/style.css">

--- a/ui/allofus-anvil-imputation/readme.md
+++ b/ui/allofus-anvil-imputation/readme.md
@@ -1,8 +1,29 @@
 # All of US + AnVIL Imputation Service marketing UI
 This code is for user education and landing zones in the All of US + AnVIL Imputation Service.
 
-The UI is plain HTML, CSS, images, and JavaScript that is simple and easy to update and deploy.  The intended destination URL for this marketing UI is https://terra.bio/allofus-anvil-imputation.  More detail will be added here when deployment is configured.
+The UI is plain HTML, CSS, images, and JavaScript that is simple and easy to update and deploy.
 
-The main page is index.html, which will map to https://terra.bio/allofus-anvil-imputation.  A secondary page is acknowledgments.html, which will map to https://terra.bio/allofus-anvil-imputation/acknowledgments.  To develop and test, you can use e.g. [Simple Web Server](https://simplewebserver.org/) to see your local web code rendered as web pages.
+The main page is index.html, which maps to https://allofus-anvil-imputation.terra.bio.  A secondary page is acknowledgments.html, which maps to https://terra.bio/allofus-anvil-imputation/acknowledgments/.
+
+Files are hosted in Google Cloud Storage buckets, and configured for HTTPS with a Google-managed SSL certificate via a load balancer.  These resources are configured through Terraform; see [terraform-ap-deployments/teaspoons-imputation-marketing](https://github.com/broadinstitute/terraform-ap-deployments/tree/master/teaspoons-imputation-marketing).
+
+### Development
+To develop and test, you can use e.g. [Simple Web Server](https://simplewebserver.org/) to see your local web code rendered as web pages.
+
+### Deployment
+To make this UI available at a public URL, use the deployment script like so:
+
+```
+cd ui/allofus-anvil-imputation
+gcloud auth login # Sign in with your firecloud.org account if deploying to production
+python3 deploy.py --environment dev # use "--environment prod"  if deploying to production
+```
+
+That will copy files into the appropriate bucket, while ignoring extraneous files, refining cache settings, and adding error handling conveniences.  You can see your deployment at:
+
+* Development: https://allofus-anvil-imputation.dsde-dev.broadinstitute.org
+* Production: https://allofus-anvil-imputation.terra.bio
+
+Updates may take up to 10 minutes to appear at the default URL, due to caching.  To see the uncached page, append a random URL parameter to the URL, e.g. https://allofus-anvil-imputation.terra.bio?foo=bar.  To update cache TTL for subsequent deployments, change `max-age=600` in deploy.py.
 
 Please send any questions to scientific-services-support@broadinstitute.org or #imputation-service in Broad Slack.


### PR DESCRIPTION
This adds a Python script  to deploy changes to a GCS bucket for each environment, and related documentation for the marketing UI.  It also refines some web content.

The dev and prod deployments now use GCS buckets instead of GitHub Pages, given SSL certificate issues with the latter.  So I'll disable GitHub Pages upon merging this PR, unless anyone objects.

### Description 

https://broadworkbench.atlassian.net/browse/TSPS-468

### Jira Ticket

### Checklist (provide links to changes)

- [ ] Updated external documentation (if applicable)
- [ ] Updated internal documentation (if applicable)
- [ ] Planned non patch version bump (if applicable)
- [ ] Updated CLI PR (if applicable)
