### PR TITLE
TSPS-468 Fix layout for non-default browser font size

### DIFF
--- a/ui/allofus-anvil-imputation/css/style.css
+++ b/ui/allofus-anvil-imputation/css/style.css
@@ -175,7 +175,7 @@ body {
 }
 
 #frame-4 {
-  height: 705px;
+  height: 720px;
   color: #074770;
   display: flex;
 }
@@ -313,10 +313,12 @@ body {
 }
 
 .how-box {
+  font-weight: 500;
+  line-height: 22px;
   display: flex;
   align-items: center;
   width: 600px;
-  height: 150px;
+  min-height: 150px;
   border: 1px solid #A0A0A0;
   border-radius: 8px;
   background: white;
@@ -333,6 +335,7 @@ body {
 }
 
 .how-box h3 {
+  font-weight: 700;
   margin-top: 0;
 }
 


### PR DESCRIPTION
### Description 
This fixes a layout bug with non-default browser settings for font size.  

These settings can be changed in Chrome by opening the dot menu in top right, "Settings", "Appearance", then changing "Font size" from "Medium (Recommended)" to "Large" or "Very large".

### Before
Non-default, "Large" font size browser setting
<img width="1512" alt="Screenshot 2025-05-16 at 4 32 39 PM" src="https://github.com/user-attachments/assets/4aab8058-0b73-4c30-9ddd-f17cce6b078b" />

Default, "Medium" font size browser setting
<img width="1512" alt="Screenshot 2025-05-16 at 4 33 35 PM" src="https://github.com/user-attachments/assets/5e6b3776-2996-4928-84ff-2f26eeac0e23" />

### After
Non-default, "Large" font size browser setting
<img width="1512" alt="Screenshot 2025-05-16 at 4 33 18 PM" src="https://github.com/user-attachments/assets/f28dbfb7-2910-478c-9ffd-d8b748452c60" />

Default, "Medium" font size browser setting
<img width="1512" alt="Screenshot 2025-05-16 at 4 33 47 PM" src="https://github.com/user-attachments/assets/b48c6191-5ca5-4f19-a690-0cc1743c230a" />


_Please replace this description with a concise description of this Pull Request._

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-468

### Checklist (provide links to changes)

- [ ] Updated external documentation (if applicable)
- [ ] Updated internal documentation (if applicable)
- [ ] Planned non patch version bump (if applicable)
- [ ] Updated CLI PR (if applicable)
