### PR TITLE
[TSPS-506] Add `totalResults` and `quotaConsumed` fields to getAllPipelineRuns response

### DIFF
--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -771,6 +771,8 @@ components:
           $ref: "#/components/schemas/JobTimeSubmitted"
         timeCompleted:
           $ref: "#/components/schemas/JobTimeCompleted"
+        quotaConsumed:
+          $ref: "#/components/schemas/QuotaConsumed"
 
     PipelineRunDescription:
       description: |

--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -658,6 +658,8 @@ components:
       properties:
         pageToken:
           type: string
+        totalResults:
+          type: integer
         results:
           description: List of pipeline runs
           type: array

--- a/service/src/main/java/bio/terra/pipelines/app/controller/PipelineRunsApiController.java
+++ b/service/src/main/java/bio/terra/pipelines/app/controller/PipelineRunsApiController.java
@@ -228,6 +228,7 @@ public class PipelineRunsApiController implements PipelineRunsApi {
                         .jobId(pipelineRun.getJobId())
                         .pipelineName(pipelineIdToNameMap.get(pipelineRun.getPipelineId()))
                         .status(pipelineRun.getStatus().name())
+                        .quotaConsumed(pipelineRun.getQuotaConsumed())
                         .description(pipelineRun.getDescription())
                         .timeSubmitted(pipelineRun.getCreated().toString())
                         .timeCompleted(

--- a/service/src/main/java/bio/terra/pipelines/app/controller/PipelineRunsApiController.java
+++ b/service/src/main/java/bio/terra/pipelines/app/controller/PipelineRunsApiController.java
@@ -217,6 +217,8 @@ public class PipelineRunsApiController implements PipelineRunsApi {
         pipelinesService.getPipelines().stream()
             .collect(Collectors.toMap(Pipeline::getId, pipeline -> pipeline.getName().getValue()));
 
+    int totalResults = Math.toIntExact(pipelineRunsService.getPipelineRunCount(userId));
+
     // convert PageResponse object to list of ApiPipelineRun objects for response
     List<ApiPipelineRun> apiPipelineRuns =
         pageResults.content().stream()
@@ -237,6 +239,7 @@ public class PipelineRunsApiController implements PipelineRunsApi {
     ApiGetPipelineRunsResponse apiGetPipelineRunsResponse =
         new ApiGetPipelineRunsResponse()
             .results(apiPipelineRuns)
+            .totalResults(totalResults)
             .pageToken(pageResults.nextPageCursor());
     return new ResponseEntity<>(apiGetPipelineRunsResponse, HttpStatus.OK);
   }

--- a/service/src/main/java/bio/terra/pipelines/db/repositories/PipelineRunsRepository.java
+++ b/service/src/main/java/bio/terra/pipelines/db/repositories/PipelineRunsRepository.java
@@ -16,4 +16,6 @@ public interface PipelineRunsRepository
   Optional<PipelineRun> findByJobIdAndUserId(UUID jobId, String userId);
 
   boolean existsByIdGreaterThan(Long id);
+
+  int countByUserId(String userId);
 }

--- a/service/src/main/java/bio/terra/pipelines/service/PipelineRunsService.java
+++ b/service/src/main/java/bio/terra/pipelines/service/PipelineRunsService.java
@@ -355,6 +355,6 @@ public class PipelineRunsService {
   }
 
   public long getPipelineRunCount(String userId) {
-    return pipelineRunsRepository.count(new FieldEqualsSpecification<>("userId", userId));
+    return pipelineRunsRepository.countByUserId(userId);
   }
 }

--- a/service/src/main/java/bio/terra/pipelines/service/PipelineRunsService.java
+++ b/service/src/main/java/bio/terra/pipelines/service/PipelineRunsService.java
@@ -353,4 +353,8 @@ public class PipelineRunsService {
         CursorBasedPageable.getEncodedCursor(
             pipelineRuns.get(pipelineRuns.size() - 1).getId().toString(), postSlice.hasNext()));
   }
+
+  public long getPipelineRunCount(String userId) {
+    return pipelineRunsRepository.count(new FieldEqualsSpecification<>("userId", userId));
+  }
 }

--- a/service/src/test/java/bio/terra/pipelines/controller/PipelineRunsApiControllerTest.java
+++ b/service/src/test/java/bio/terra/pipelines/controller/PipelineRunsApiControllerTest.java
@@ -861,10 +861,10 @@ class PipelineRunsApiControllerTest {
     PageResponse<List<PipelineRun>> pageResponse =
         new PageResponse<>(
             List.of(
-                    pipelineRunPreparing1,
-                    pipelineRunPreparing2,
-                    pipelineRunPreparing3,
-                    pipelineRunPreparing4),
+                  pipelineRunPreparing1,
+                  pipelineRunPreparing2,
+                  pipelineRunPreparing3,
+                  pipelineRunPreparing4),
             null,
             null);
 
@@ -872,8 +872,7 @@ class PipelineRunsApiControllerTest {
             limit, pageToken, testUser.getSubjectId()))
         .thenReturn(pageResponse);
 
-    when(pipelineRunsServiceMock.getPipelineRunCount(testUser.getSubjectId()))
-        .thenReturn(4L);
+    when(pipelineRunsServiceMock.getPipelineRunCount(testUser.getSubjectId())).thenReturn(4L);
 
     MvcResult result =
         mockMvc

--- a/service/src/test/java/bio/terra/pipelines/controller/PipelineRunsApiControllerTest.java
+++ b/service/src/test/java/bio/terra/pipelines/controller/PipelineRunsApiControllerTest.java
@@ -861,10 +861,10 @@ class PipelineRunsApiControllerTest {
     PageResponse<List<PipelineRun>> pageResponse =
         new PageResponse<>(
             List.of(
-                  pipelineRunPreparing1,
-                  pipelineRunPreparing2,
-                  pipelineRunPreparing3,
-                  pipelineRunPreparing4),
+                pipelineRunPreparing1,
+                pipelineRunPreparing2,
+                pipelineRunPreparing3,
+                pipelineRunPreparing4),
             null,
             null);
 

--- a/service/src/test/java/bio/terra/pipelines/controller/PipelineRunsApiControllerTest.java
+++ b/service/src/test/java/bio/terra/pipelines/controller/PipelineRunsApiControllerTest.java
@@ -768,6 +768,7 @@ class PipelineRunsApiControllerTest {
     assertEquals(pipelineRunPreparing.getStatus().name(), responsePipelineRun1.getStatus());
     assertEquals(pipelineRunPreparing.getDescription(), responsePipelineRun1.getDescription());
     assertEquals(pipelineRunPreparing.getJobId(), responsePipelineRun1.getJobId());
+    assertEquals(pipelineRunPreparing.getQuotaConsumed(), responsePipelineRun1.getQuotaConsumed());
     assertEquals(getTestPipeline().getName().getValue(), responsePipelineRun1.getPipelineName());
     assertEquals(
         pipelineRunPreparing.getCreated().toString(), responsePipelineRun1.getTimeSubmitted());
@@ -780,6 +781,7 @@ class PipelineRunsApiControllerTest {
     assertEquals(pipelineRunSucceeded.getStatus().name(), responsePipelineRun2.getStatus());
     assertEquals(pipelineRunSucceeded.getDescription(), responsePipelineRun2.getDescription());
     assertEquals(pipelineRunSucceeded.getJobId(), responsePipelineRun2.getJobId());
+    assertEquals(pipelineRunSucceeded.getQuotaConsumed(), responsePipelineRun2.getQuotaConsumed());
     assertEquals(getTestPipeline().getName().getValue(), responsePipelineRun2.getPipelineName());
     assertEquals(
         pipelineRunSucceeded.getCreated().toString(), responsePipelineRun2.getTimeSubmitted());
@@ -795,6 +797,7 @@ class PipelineRunsApiControllerTest {
     assertEquals(pipelineRunFailed.getStatus().name(), responsePipelineRun3.getStatus());
     assertEquals(pipelineRunFailed.getDescription(), responsePipelineRun3.getDescription());
     assertEquals(pipelineRunFailed.getJobId(), responsePipelineRun3.getJobId());
+    assertEquals(pipelineRunFailed.getQuotaConsumed(), responsePipelineRun3.getQuotaConsumed());
     assertEquals(getTestPipeline().getName().getValue(), responsePipelineRun3.getPipelineName());
     assertEquals(
         pipelineRunFailed.getCreated().toString(), responsePipelineRun3.getTimeSubmitted());

--- a/service/src/test/java/bio/terra/pipelines/service/PipelineRunsServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/PipelineRunsServiceTest.java
@@ -604,4 +604,18 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
     // test that results are coming with most recent first
     assertTrue(firstResultTime.isAfter(thirdResultTime));
   }
+
+  @Test
+  void getPipelineRunCountForUser() {
+    // A test row already exists for this user. Confirm the initial count is 1.
+    long initialResultsCount = pipelineRunsService.getPipelineRunCount(testUserId);
+    assertEquals(1, initialResultsCount);
+
+    // Add a new pipeline run for the same user and confirm the count is now 2.
+    PipelineRun pipelineRun = createNewPipelineRunWithJobId(testJobId);
+    pipelineRunsRepository.save(pipelineRun);
+
+    long totalResultsCount = pipelineRunsService.getPipelineRunCount(testUserId);
+    assertEquals(2, totalResultsCount);
+  }
 }


### PR DESCRIPTION
### Description 

Adds a couple of new fields to the getAllPipelineRuns response, which will help populate the Job History page in the Imputation UI.

Related Imputation UI PR: https://github.com/DataBiosphere/terra-ui/pull/5327

### Jira Ticket

https://broadworkbench.atlassian.net/browse/TSPS-506

### Checklist (provide links to changes)

- [ ] Updated external documentation (if applicable)
- [ ] Updated internal documentation (if applicable)
- [ ] Planned non patch version bump (if applicable)
- [ ] Updated CLI PR (if applicable)
