### PR TITLE
TSPS-532 update marketing text with explicit "not free in future" text

### DIFF
--- a/ui/allofus-anvil-imputation/index.html
+++ b/ui/allofus-anvil-imputation/index.html
@@ -64,7 +64,9 @@
           <div>
             <h3>No cost during Beta</h3>
             <div>
-              The Beta release of the service will be at no cost up to 2500 samples, thanks to NIH funding.
+              The Beta release of the service will be at no cost to users up to 2500 samples, thanks to NIH funding.
+              After the Beta release, access to the service will transition to a paid model,
+              with pricing based on the number of samples processed.
             </div>
           </div>
         </div>


### PR DESCRIPTION
### Description 

Based on feedback from users we want to update some of the text on our marketing page.  Changes can be seen on the dev version of the marketing page - https://allofus-anvil-imputation.dsde-dev.broadinstitute.org/. .  Once this gets merged we can push the changes to the prod marketing page which will update https://allofus-anvil-imputation.terra.bio/

Before
![Screenshot 2025-06-30 at 1 54 15 PM](https://github.com/user-attachments/assets/5f44716b-1df3-4733-99c4-d1352785f69b)

After
![Screenshot 2025-06-30 at 1 57 34 PM](https://github.com/user-attachments/assets/3f3b0579-3593-4c36-9521-12b9e1aac8d4)


### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-532

### Checklist (provide links to changes)

- [ ] Updated external documentation (if applicable)
- [ ] Updated internal documentation (if applicable)
- [ ] Planned non patch version bump (if applicable)
- [ ] Updated CLI PR (if applicable)
