### PR TITLE
TSPS-533 Update 'about us' section of notification emails to DSP

### DIFF
--- a/notification-templates/job_failed.html
+++ b/notification-templates/job_failed.html
@@ -98,25 +98,6 @@
                                                 <table width="100%" border="0" align="center" cellpadding="0" cellspacing="0">
                                                     <tr>
                                                         <td align="center" style="text-align:center;vertical-align:top;font-size:0;">
-                                                            <!--bar logo-->
-                                                            <div style="display:inline-block;vertical-align:top;">
-                                                                <table class="table-full" align="center" border="0" cellpadding="0" cellspacing="0">
-                                                                    <tr>
-                                                                        <td width="180" align="center">
-                                                                            <table class="fade" style="background-color:rgba(0,0,0,0.0)" width="400" border="0" align="center" cellpadding="0" cellspacing="0">
-                                                                                <tr>
-                                                                                    <td width="80" height="55" align="center" style="line-height: 0px;">
-                                                                                        <img style="display:block; line-height:0px; font-size:0px; border:0px;" src="https://drive.google.com/thumbnail?id=1RSVYO6csPFsupnsHNT6HAToci9UPQfXJ" alt="img" width="40" />
-                                                                                    </td>
-                                                                                    <td width="325" align="left" style="text-decoration: none; color:#FFFFFF;font-family: 'Montserrat', Arial, sans-serif;font-size:12px;"><strong>Focus on your science</strong></td>
-                                                                                </tr>
-                                                                            </table>
-
-                                                                        </td>
-                                                                    </tr>
-                                                                </table>
-                                                            </div>
-
                                                             <div style="display:inline-block;vertical-align:top;">
                                                                 <table class="table-full" align="center" border="0" cellpadding="0" cellspacing="0">
                                                                     <tr>

--- a/notification-templates/job_failed.html
+++ b/notification-templates/job_failed.html
@@ -309,7 +309,7 @@
                                                             <td align="left">
                                                                 <table width="100%" border="0" align="left" cellpadding="0" cellspacing="0">
                                                                     <tr>
-                                                                        <td align="left" style="font-family: 'Montserrat', Arial, sans-serif; color:#333F52; font-size:16px;font-weight: bold; line-height: 28px;padding-left: 0px;">About Terra Scientific Services</td>
+                                                                        <td align="left" style="font-family: 'Montserrat', Arial, sans-serif; color:#333F52; font-size:16px;font-weight: bold; line-height: 28px;padding-left: 0px;">About Scientific Services from Broad’s Data Sciences Platform</td>
                                                                     </tr>
                                                                 </table>
                                                             </td>
@@ -320,7 +320,7 @@
                                                         </tr>
                                                         <!--content-->
                                                         <tr align="left">
-                                                            <td style="font-family: 'Montserrat', Arial, sans-serif; color:#333F52; font-size:14px; line-height: 24px;width: 650px;">Terra Scientific Services provide the community with fast and secure analysis capabilities against valuable data resources.</td>
+                                                            <td style="font-family: 'Montserrat', Arial, sans-serif; color:#333F52; font-size:14px; line-height: 24px;width: 650px;">Our scientific services offer the community fast, secure analysis of their data against valuable reference panels. Learn more about our current <a href="https://allofus-anvil-imputation.terra.bio/" >products</a>.</td>
                                                         </tr>
                                                         <!--end content-->
                                                         <tr> </tr>
@@ -380,6 +380,7 @@
 
 <!--footer-->
 <table class="full" align="center" width="100%" border="0" cellspacing="0" cellpadding="0">
+
 </table></td></tr></table>
 </body>
 

--- a/notification-templates/job_failed.html
+++ b/notification-templates/job_failed.html
@@ -301,7 +301,7 @@
                                                         </tr>
                                                         <!--content-->
                                                         <tr align="left">
-                                                            <td style="font-family: 'Montserrat', Arial, sans-serif; color:#333F52; font-size:14px; line-height: 24px;width: 650px;">Our scientific services offer the community fast, secure analysis of their data against valuable reference panels. Learn more about our current <a href="https://allofus-anvil-imputation.terra.bio/" >products</a>.</td>
+                                                            <td style="font-family: 'Montserrat', Arial, sans-serif; color:#333F52; font-size:14px; line-height: 24px;width: 650px;">Our scientific services offer the community fast, secure analysis of their data. Learn more <a href="https://allofus-anvil-imputation.terra.bio/" >here</a>.</td>
                                                         </tr>
                                                         <!--end content-->
                                                         <tr> </tr>

--- a/notification-templates/job_succeeded.html
+++ b/notification-templates/job_succeeded.html
@@ -314,7 +314,7 @@
                                                         </tr>
                                                         <!--content-->
                                                         <tr align="left">
-                                                            <td style="font-family: 'Montserrat', Arial, sans-serif; color:#333F52; font-size:14px; line-height: 24px;width: 650px;">Our scientific services offer the community fast, secure analysis of their data against valuable reference panels. Learn more about our current <a href="https://allofus-anvil-imputation.terra.bio/" >products</a>.</td>
+                                                            <td style="font-family: 'Montserrat', Arial, sans-serif; color:#333F52; font-size:14px; line-height: 24px;width: 650px;">Our scientific services offer the community fast, secure analysis of their data. Learn more <a href="https://allofus-anvil-imputation.terra.bio/" >here</a>.</td>
                                                         </tr>
                                                         <!--end content-->
                                                         <tr> </tr>

--- a/notification-templates/job_succeeded.html
+++ b/notification-templates/job_succeeded.html
@@ -322,7 +322,7 @@
                                                             <td align="left">
                                                                 <table width="100%" border="0" align="left" cellpadding="0" cellspacing="0">
                                                                     <tr>
-                                                                        <td align="left" style="font-family: 'Montserrat', Arial, sans-serif; color:#333F52; font-size:16px;font-weight: bold; line-height: 28px;padding-left: 0px;">About Terra Scientific Services</td>
+                                                                        <td align="left" style="font-family: 'Montserrat', Arial, sans-serif; color:#333F52; font-size:16px;font-weight: bold; line-height: 28px;padding-left: 0px;">About Scientific Services from Broad’s Data Sciences Platform</td>
                                                                     </tr>
                                                                 </table>
                                                             </td>
@@ -333,7 +333,7 @@
                                                         </tr>
                                                         <!--content-->
                                                         <tr align="left">
-                                                            <td style="font-family: 'Montserrat', Arial, sans-serif; color:#333F52; font-size:14px; line-height: 24px;width: 650px;">Terra Scientific Services provide the community with fast and secure analysis capabilities against valuable data resources.</td>
+                                                            <td style="font-family: 'Montserrat', Arial, sans-serif; color:#333F52; font-size:14px; line-height: 24px;width: 650px;">Our scientific services offer the community fast, secure analysis of their data against valuable reference panels. Learn more about our current <a href="https://allofus-anvil-imputation.terra.bio/" >products</a>.</td>
                                                         </tr>
                                                         <!--end content-->
                                                         <tr> </tr>

--- a/notification-templates/job_succeeded.html
+++ b/notification-templates/job_succeeded.html
@@ -99,25 +99,6 @@
                                                 <table width="100%" border="0" align="center" cellpadding="0" cellspacing="0">
                                                     <tr>
                                                         <td align="center" style="text-align:center;vertical-align:top;font-size:0;">
-                                                            <!--bar logo-->
-                                                            <div style="display:inline-block;vertical-align:top;">
-                                                                <table class="table-full" align="center" border="0" cellpadding="0" cellspacing="0">
-                                                                    <tr>
-                                                                        <td width="180" align="center">
-                                                                            <table class="fade" style="background-color:rgba(0,0,0,0.0)" width="400" border="0" align="center" cellpadding="0" cellspacing="0">
-                                                                                <tr>
-                                                                                    <td width="80" height="55" align="center" style="line-height: 0px;">
-                                                                                        <img style="display:block; line-height:0px; font-size:0px; border:0px;" src="https://drive.google.com/thumbnail?id=1RSVYO6csPFsupnsHNT6HAToci9UPQfXJ" alt="img" width="40" />
-                                                                                    </td>
-                                                                                    <td width="325" align="left" style="text-decoration: none; color:#FFFFFF;font-family: 'Montserrat', Arial, sans-serif;font-size:12px;"><strong>Focus on your science</strong></td>
-                                                                                </tr>
-                                                                            </table>
-
-                                                                        </td>
-                                                                    </tr>
-                                                                </table>
-                                                            </div>
-
                                                             <div style="display:inline-block;vertical-align:top;">
                                                                 <table class="table-full" align="center" border="0" cellpadding="0" cellspacing="0">
                                                                     <tr>


### PR DESCRIPTION
### Description 

We want to move away from advertising Terra in favor of advertising DSP/Broad, so here we're changing the "about" text at the bottom of notification emails as well as removing the top green Terra bar.

Before:
<img width="708" height="589" alt="image" src="https://github.com/user-attachments/assets/590ac0f5-93a6-4987-9e48-56a73ea08331" />

After:
<img width="704" height="538" alt="image" src="https://github.com/user-attachments/assets/27734852-56c6-403e-96de-6e95da4e1d64" />



After approval but before merging, need to update the prod templates in sendgrid.

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-533

### Checklist (provide links to changes)

- [ ] Updated external documentation (if applicable)
- [ ] Updated internal documentation (if applicable)
- [ ] Planned non patch version bump (if applicable)
- [ ] Updated CLI PR (if applicable)
- [x] Updated dev templates in Sendgrid
- [x] Updated prod templates in Sendgrid
