### PR TITLE
TSPS-308 Update tests and local development instructions to postgreSQL 15

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -84,7 +84,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:13.1
+        image: postgres:15.12
         env:
           POSTGRES_PASSWORD: postgres
         options: >-

--- a/.github/workflows/workflow-tester.yml
+++ b/.github/workflows/workflow-tester.yml
@@ -48,7 +48,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:13.1
+        image: postgres:15.12
         env:
           POSTGRES_PASSWORD: postgres
         options: >-

--- a/README.md
+++ b/README.md
@@ -27,14 +27,14 @@ This codebase is in initial development.
 ### Requirements
 
 #### Technical
-This service is written in Java 17, and uses Postgres 13.
+This service is written in Java 17, and uses Postgres 15.
 
 To run locally, you'll also need:
 - jq - install with `brew install jq`
 - Java 17 - can be installed manually or through IntelliJ which will do it for you when importing the project
-- Postgres 13 - multiple solutions here as long as you have a postgres instance running on localhost:5432 the local app will connect appropriately. Be sure to use Postgres 13 (as of Feb 2025, Postgres 17 did not work)
+- Postgres 15 - multiple solutions here as long as you have a postgres instance running on localhost:5432 the local app will connect appropriately. Be sure to use Postgres 15 (as of Feb 2025, Postgres 17 did not work)
   - Download Postgres.app (recommended) from https://postgresapp.com/
-  - Brew https://formulae.brew.sh/formula/postgresql@13
+  - Brew https://formulae.brew.sh/formula/postgresql@15
 
 #### External Services
 Terra services
@@ -53,7 +53,7 @@ Terra services
 ### Tech stack
 
 - Java 17 temurin
-- Postgres 13.1
+- Postgres 15
 - Gradle - build automation tool
 - SonarQube - static code security and coverage
 - Trivy - security scanner for docker images
@@ -64,7 +64,7 @@ Terra services
 To run locally:
 1. Make sure you have the requirements installed from above. We recommend IntelliJ as an IDE.
 2. Clone the repo (if you see broken inputs build the project to get the generated sources)
-3. Spin up a local postgres instance (NOTE: use version 13.1)
+3. Spin up a local postgres instance (NOTE: use version 15)
 3. Run the commands in `scripts/postgres-init.sql` in your local postgres instance. You will need to be authenticated to access GSM.
 4. Run `scripts/write-config.sh` 
 5. Run `./gradlew bootRun` to spin up the server.

--- a/scripts/postgres-init.sql
+++ b/scripts/postgres-init.sql
@@ -1,4 +1,6 @@
 CREATE DATABASE pipelines_db;
 CREATE ROLE dbuser WITH LOGIN ENCRYPTED PASSWORD 'dbpwd';
+ALTER DATABASE pipelines_db OWNER TO dbuser;
 CREATE DATABASE teaspoons_stairway_db;
 CREATE ROLE stairwayuser WITH LOGIN ENCRYPTED PASSWORD 'stairwaypwd';
+ALTER DATABASE teaspoons_stairway_db OWNER TO stairwayuser;

--- a/service/src/test/resources/application-test.yml
+++ b/service/src/test/resources/application-test.yml
@@ -18,7 +18,7 @@ zonky:
     database:
       postgres:
         docker:
-          image: postgres:13.1
+          image: postgres:15.12
 
 imputation:
   cromwellSubmissionPollingIntervalInSeconds: 1 # only wait 1 second when testing


### PR DESCRIPTION
### Description 

Here we update the tests and instructions for local development to use postgreSQL version 15, up from 13.1, to match the version running in our live environments (currently 15.12). Version 15 will be supported until 2028.

Note this does NOT involve any change to our live environments, as they are already on version 15.

I've tested this in my local environment and am able to run the service locally using postgres 15. 

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-308

### Checklist (provide links to changes)

- [ ] Updated external documentation (if applicable)
- [x] Updated internal documentation (if applicable)
- [ ] Planned non patch version bump (if applicable)
- [ ] Updated CLI PR (if applicable)
