### PR TITLE
TSPS-466 Update description for array_imputation v1

### DIFF
--- a/service/src/main/resources/db/changelog.xml
+++ b/service/src/main/resources/db/changelog.xml
@@ -15,6 +15,7 @@
   <include file="changesets/20250225_add_quota_units.yaml" relativeToChangelogFile="true"/>
   <include file="changesets/20250324_update_array_imputation_default_quota_to_2500.yaml" relativeToChangelogFile="true"/>
   <include file="changesets/20250530_update_array_imputation_default_quota_to_0.yaml" relativeToChangelogFile="true"/>
+  <include file="changesets/20250808_update_array_imputation_description.yaml" relativeToChangelogFile="true"/>
 
   <include file="changesets/testdata.yaml" relativeToChangelogFile="true"/>
 

--- a/service/src/main/resources/db/changesets/20250808_update_array_imputation_description.yaml
+++ b/service/src/main/resources/db/changesets/20250808_update_array_imputation_description.yaml
@@ -2,14 +2,16 @@
 
 databaseChangeLog:
   -  changeSet:
-       id:  update the description of the array_imputation v1 pipeline
+       id:  update the description and display_name of the array_imputation v1 pipeline
        author:  mma
        changes:
-         # update array_imputation pipeline version to 1
          - update:
              tableName: pipelines
              columns:
                - column:
                   name: description
                   value: 'Phase and impute genotypes using Beagle 5.5 with the All of Us + AnVIL reference panel of 515,579 samples.'
+               - column:
+                  name: display_name
+                  value: 'All of Us + AnVIL Array Imputation'
              where: name='array_imputation' and version=1

--- a/service/src/main/resources/db/changesets/20250808_update_array_imputation_description.yaml
+++ b/service/src/main/resources/db/changesets/20250808_update_array_imputation_description.yaml
@@ -1,0 +1,15 @@
+# update the description of the array_imputation v1 pipeline
+
+databaseChangeLog:
+  -  changeSet:
+       id:  update the description of the array_imputation v1 pipeline
+       author:  mma
+       changes:
+         # update array_imputation pipeline version to 1
+         - update:
+             tableName: pipelines
+             columns:
+               - column:
+                  name: description
+                  value: 'Phase and impute genotypes using Beagle 5.5 with the All of Us + AnVIL reference panel of 515,579 samples.'
+             where: name='array_imputation' and version=1


### PR DESCRIPTION
### Description 

Updating the user-facing pipeline display name and description ahead of public launch. 

Previous pipeline info:
```
  "pipelineName": "array_imputation",
  "displayName": "All of Us/AnVIL Array Imputation",
  "pipelineVersion": 1,
  "description": "Phase and impute genotypes using Beagle 5.4 with the AoU/AnVIL reference panel of 515,579 samples.",
```

Updated pipeline info
```
  "pipelineName": "array_imputation",
  "displayName": "All of Us + AnVIL Array Imputation",
  "pipelineVersion": 1,
  "description": "Phase and impute genotypes using Beagle 5.5 with the All of Us + AnVIL reference panel of 515,579 samples.",
```

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-466

### Checklist (provide links to changes)

- [ ] Updated external documentation (if applicable)
- [ ] Updated internal documentation (if applicable)
- [ ] Planned non patch version bump (if applicable)
- [ ] Updated CLI PR (if applicable)
