### PR TITLE
TSPS-580 Set array_imputation default quota to 2500 for public release

### DIFF
--- a/.github/workflows/run-e2e-tests.yaml
+++ b/.github/workflows/run-e2e-tests.yaml
@@ -90,7 +90,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: broadinstitute/dsp-reusable-workflows/.github/workflows/run_teaspoons_e2e_service_tests.yaml@bd4f1c4ed324888b6517467780a54938a9e352f8
+    uses: broadinstitute/dsp-reusable-workflows/.github/workflows/run_teaspoons_e2e_service_tests.yaml@main
     with:
       billing-project-name: '${{ needs.init-github-context-and-params-gen.outputs.project-name }}'
       bee-name: '${{ needs.init-github-context-and-params-gen.outputs.bee-name }}'

--- a/.github/workflows/run-e2e-tests.yaml
+++ b/.github/workflows/run-e2e-tests.yaml
@@ -90,7 +90,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: broadinstitute/dsp-reusable-workflows/.github/workflows/run_teaspoons_e2e_service_tests.yaml@main
+    uses: broadinstitute/dsp-reusable-workflows/.github/workflows/run_teaspoons_e2e_service_tests.yaml@bd4f1c4ed324888b6517467780a54938a9e352f8
     with:
       billing-project-name: '${{ needs.init-github-context-and-params-gen.outputs.project-name }}'
       bee-name: '${{ needs.init-github-context-and-params-gen.outputs.bee-name }}'

--- a/service/src/main/resources/db/changelog.xml
+++ b/service/src/main/resources/db/changelog.xml
@@ -16,6 +16,7 @@
   <include file="changesets/20250324_update_array_imputation_default_quota_to_2500.yaml" relativeToChangelogFile="true"/>
   <include file="changesets/20250530_update_array_imputation_default_quota_to_0.yaml" relativeToChangelogFile="true"/>
   <include file="changesets/20250808_update_array_imputation_description.yaml" relativeToChangelogFile="true"/>
+  <include file="changesets/20250821_update_array_imputation_default_quota_to_2500.yaml" relativeToChangelogFile="true"/>
 
   <include file="changesets/testdata.yaml" relativeToChangelogFile="true"/>
 

--- a/service/src/main/resources/db/changesets/20250821_update_array_imputation_default_quota_to_2500.yaml
+++ b/service/src/main/resources/db/changesets/20250821_update_array_imputation_default_quota_to_2500.yaml
@@ -1,0 +1,15 @@
+# update the default of the array_imputation pipeline quota to 2500 for public release
+
+databaseChangeLog:
+  -  changeSet:
+       id:  update default quota of array_imputation pipeline for public release
+       author:  mma
+       changes:
+         # update array_imputation default quota to 2500
+         - update:
+             tableName: pipeline_quotas
+             columns:
+               - column:
+                  name: default_quota
+                  value: 2500
+             where: pipeline_name='array_imputation'


### PR DESCRIPTION
### Description 

For our public release, we are setting the default quota for array_imputation to 2500 samples.

Note this also involves changing our e2e tests.
PR here: https://github.com/broadinstitute/dsp-reusable-workflows/pull/78
Successful test run here: https://github.com/DataBiosphere/terra-scientific-pipelines-service/actions/runs/17135672520/job/48611518783

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-580

### Checklist (provide links to changes)

- [ ] Updated external documentation (if applicable)
- [ ] Updated internal documentation (if applicable)
- [ ] Planned non patch version bump (if applicable)
- [ ] Updated CLI PR (if applicable)
