### PR TITLE
TSPS-568 part 1 FIX: support integer and boolean outputs

### DIFF
--- a/service/src/main/java/bio/terra/pipelines/common/utils/PipelineVariableTypesEnum.java
+++ b/service/src/main/java/bio/terra/pipelines/common/utils/PipelineVariableTypesEnum.java
@@ -53,6 +53,31 @@ public enum PipelineVariableTypesEnum {
       return null;
     }
   },
+  BOOLEAN {
+    @Override
+    public <T> T cast(String fieldName, Object value, TypeReference<T> typeReference) {
+      if (value instanceof Boolean booleanValue) {
+        return (T) booleanValue;
+      } else if (value instanceof String stringValue) {
+        String trimmedString = stringValue.trim().toLowerCase();
+        if (trimmedString.equals("true")) {
+          return (T) Boolean.TRUE;
+        } else if (trimmedString.equals("false")) {
+          return (T) Boolean.FALSE;
+        }
+      }
+      return null;
+    }
+
+    @Override
+    public String validate(PipelineInputDefinition pipelineInputDefinition, Object value) {
+      String fieldName = pipelineInputDefinition.getName();
+      if (cast(fieldName, value, new TypeReference<Boolean>() {}) == null) {
+        return "%s must be a boolean".formatted(fieldName);
+      }
+      return null;
+    }
+  },
   FILE {
     @Override
     public <T> T cast(String fieldName, Object value, TypeReference<T> typeReference) {

--- a/service/src/main/java/bio/terra/pipelines/service/PipelineInputsOutputsService.java
+++ b/service/src/main/java/bio/terra/pipelines/service/PipelineInputsOutputsService.java
@@ -375,23 +375,23 @@ public class PipelineInputsOutputsService {
    * @param entity
    * @return a map of pipeline outputs
    */
-  public Map<String, String> extractPipelineOutputsFromEntity(
+  public Map<String, Object> extractPipelineOutputsFromEntity(
       List<PipelineOutputDefinition> pipelineOutputDefinitions, Entity entity) {
-    Map<String, String> outputs = new HashMap<>();
+    Map<String, Object> outputs = new HashMap<>();
     for (PipelineOutputDefinition outputDefinition : pipelineOutputDefinitions) {
       String keyName = outputDefinition.getName();
       String wdlVariableName = outputDefinition.getWdlVariableName();
-      String outputValue =
-          (String)
-              entity
-                  .getAttributes()
-                  .get(wdlVariableName); // .get() returns null if the key is missing, or if the
+      PipelineVariableTypesEnum outputType = outputDefinition.getType();
+      Object outputValue =
+          entity
+              .getAttributes()
+              .get(wdlVariableName); // .get() returns null if the key is missing, or if the
       // value is empty
       if (outputValue == null) {
         throw new InternalServerErrorException(
             "Output %s is empty or missing".formatted(wdlVariableName));
       }
-      outputs.put(keyName, outputValue);
+      outputs.put(keyName, outputType.cast(keyName, outputValue, new TypeReference<>() {}));
     }
     return outputs;
   }

--- a/service/src/main/java/bio/terra/pipelines/stairway/steps/common/FetchOutputsFromDataTableStep.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/steps/common/FetchOutputsFromDataTableStep.java
@@ -90,7 +90,7 @@ public class FetchOutputsFromDataTableStep implements Step {
 
     // this will throw an error and fail the task without retries if any of the output definitions
     // are missing or empty
-    Map<String, String> outputs =
+    Map<String, ?> outputs =
         pipelineInputsOutputsService.extractPipelineOutputsFromEntity(outputDefinitions, entity);
 
     logger.info("Found outputs {} for {}", outputs, toolConfig.methodName());

--- a/service/src/test/java/bio/terra/pipelines/common/utils/PipelineVariableTypesEnumTest.java
+++ b/service/src/test/java/bio/terra/pipelines/common/utils/PipelineVariableTypesEnumTest.java
@@ -1,5 +1,6 @@
 package bio.terra.pipelines.common.utils;
 
+import static bio.terra.pipelines.common.utils.PipelineVariableTypesEnum.BOOLEAN;
 import static bio.terra.pipelines.common.utils.PipelineVariableTypesEnum.FILE;
 import static bio.terra.pipelines.common.utils.PipelineVariableTypesEnum.FILE_ARRAY;
 import static bio.terra.pipelines.common.utils.PipelineVariableTypesEnum.INTEGER;
@@ -27,6 +28,7 @@ class PipelineVariableTypesEnumTest extends BaseTest {
     // error messages
     String stringTypeErrorMessage = "%s must be a string".formatted(commonInputName);
     String integerTypeErrorMessage = "%s must be an integer".formatted(commonInputName);
+    String booleanTypeErrorMessage = "%s must be a boolean".formatted(commonInputName);
     String vcfTypeErrorMessage =
         "%s must be a path to a file ending in .vcf.gz".formatted(commonInputName);
     String stringArrayTypeErrorMessage =
@@ -42,6 +44,9 @@ class PipelineVariableTypesEnumTest extends BaseTest {
     PipelineInputDefinition stringInputDefinition =
         new PipelineInputDefinition(
             1L, commonInputName, "string_input", STRING, null, true, true, false, null);
+    PipelineInputDefinition booleanInputDefinition =
+        new PipelineInputDefinition(
+            1L, commonInputName, "boolean_input", BOOLEAN, null, true, true, false, null);
     PipelineInputDefinition fileVcfInputDefinition =
         new PipelineInputDefinition(
             1L, commonInputName, "file_vcf_input", FILE, ".vcf.gz", true, true, false, null);
@@ -111,6 +116,17 @@ class PipelineVariableTypesEnumTest extends BaseTest {
         arguments(stringInputDefinition, 123, null, stringTypeErrorMessage),
         arguments(stringInputDefinition, null, null, stringTypeErrorMessage),
         arguments(stringInputDefinition, "", null, stringTypeErrorMessage),
+
+        // BOOLEAN
+        arguments(booleanInputDefinition, true, true, null),
+        arguments(booleanInputDefinition, false, false, null),
+        arguments(booleanInputDefinition, "true", true, null),
+        arguments(booleanInputDefinition, " false ", false, null),
+        arguments(booleanInputDefinition, "TRUE", true, null),
+        arguments(booleanInputDefinition, "FALSE", false, null),
+        arguments(booleanInputDefinition, "foo", null, booleanTypeErrorMessage),
+        arguments(booleanInputDefinition, 1, null, booleanTypeErrorMessage),
+        arguments(booleanInputDefinition, null, null, booleanTypeErrorMessage),
 
         // FILE
         arguments(fileVcfInputDefinition, "path/to/file.vcf.gz", "path/to/file.vcf.gz", null),

--- a/service/src/test/java/bio/terra/pipelines/service/PipelineInputsOutputsServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/PipelineInputsOutputsServiceTest.java
@@ -95,15 +95,16 @@ class PipelineInputsOutputsServiceTest extends BaseEmbeddedDbTest {
         TestUtils.TEST_PIPELINE_OUTPUTS_DEFINITION_LIST;
     Entity entity = new Entity();
     entity.setAttributes(
-        Map.of("output_name", "gs://bucket/file1", "testNonOutputKey", "doesn't matter"));
+        Map.of("output_string", "string", "output_integer", 123, "output_boolean", false));
 
-    Map<String, String> extractedOutputs =
+    Map<String, Object> extractedOutputs =
         pipelineInputsOutputsService.extractPipelineOutputsFromEntity(outputDefinitions, entity);
 
-    assertEquals(1, extractedOutputs.size());
-    // the meethod should also have converted the wdlVariableName key to the camelCase outputName
-    // key
-    assertEquals("gs://bucket/file1", extractedOutputs.get("outputName"));
+    assertEquals(3, extractedOutputs.size());
+    // the method should also have converted the wdlVariableName key to the camelCase outputName key
+    assertEquals("string", extractedOutputs.get("outputString"));
+    assertEquals(123, extractedOutputs.get("outputInteger"));
+    assertEquals(false, extractedOutputs.get("outputBoolean"));
   }
 
   @Test

--- a/service/src/test/java/bio/terra/pipelines/stairway/steps/common/FetchOutputsFromDataTableStepTest.java
+++ b/service/src/test/java/bio/terra/pipelines/stairway/steps/common/FetchOutputsFromDataTableStepTest.java
@@ -35,11 +35,8 @@ class FetchOutputsFromDataTableStepTest extends BaseEmbeddedDbTest {
   private final String toolConfigKey = TestUtils.TOOL_CONFIG_KEY;
   private final String toolOutputsKey = TestUtils.TOOL_OUTPUTS_KEY;
   private final ToolConfig toolConfig = TestUtils.TOOL_CONFIG_GENERIC;
-  private final Map<String, Object> entityOutputs =
-      Map.of("output_name", "test.tsv"); // matches TestUtils.TOOL_CONFIG output definitions
-  private final Map<String, String> expectedOutputs =
-      new HashMap<>(
-          Map.of("outputName", "test.tsv")); // matches TestUtils.TOOL_CONFIG output definitions
+  private final Map<String, Object> entityOutputs = TestUtils.TEST_PIPELINE_OUTPUTS_FROM_ENTITY;
+  private final Map<String, Object> expectedOutputs = TestUtils.TEST_PIPELINE_OUTPUTS_PROCESSED;
 
   @BeforeEach
   void setup() {
@@ -69,14 +66,8 @@ class FetchOutputsFromDataTableStepTest extends BaseEmbeddedDbTest {
             PipelinesEnum.ARRAY_IMPUTATION.getValue(),
             TestUtils.TEST_NEW_UUID.toString()))
         .thenReturn(entity);
-    Map<String, String> outputsProcessedFromEntity =
-        new HashMap<>(Map.of("outputName", "some/file.vcf.gz"));
     when(pipelineInputsOutputsService.extractPipelineOutputsFromEntity(
             TestUtils.TEST_PIPELINE_OUTPUTS_DEFINITION_LIST, entity))
-        .thenReturn(outputsProcessedFromEntity);
-
-    when(pipelineInputsOutputsService.extractPipelineOutputsFromEntity(
-            toolConfig.outputDefinitions(), entity))
         .thenReturn(expectedOutputs);
 
     FetchOutputsFromDataTableStep fetchOutputsFromDataTableStep =

--- a/service/src/test/java/bio/terra/pipelines/testutils/TestUtils.java
+++ b/service/src/test/java/bio/terra/pipelines/testutils/TestUtils.java
@@ -116,8 +116,30 @@ public class TestUtils {
       new ArrayList<>(
           List.of(
               new PipelineOutputDefinition(
-                  3L, "outputName", "output_name", PipelineVariableTypesEnum.FILE)));
+                  3L, "outputString", "output_string", PipelineVariableTypesEnum.STRING),
+              new PipelineOutputDefinition(
+                  3L, "outputInteger", "output_integer", PipelineVariableTypesEnum.INTEGER),
+              new PipelineOutputDefinition(
+                  3L, "outputBoolean", "output_boolean", PipelineVariableTypesEnum.BOOLEAN)));
 
+  public static final Map<String, Object> TEST_PIPELINE_OUTPUTS_FROM_ENTITY =
+      new HashMap<>(
+          Map.of(
+              "output_string",
+              "test",
+              "output_integer",
+              123,
+              "output_boolean",
+              false)); // matches TestUtils.TOOL_CONFIG_GENERIC output definitions
+  public static final Map<String, Object> TEST_PIPELINE_OUTPUTS_PROCESSED =
+      new HashMap<>(
+          Map.of(
+              "outputString",
+              "test",
+              "outputInteger",
+              123,
+              "outputBoolean",
+              false)); // matches TestUtils.TOOL_CONFIG_GENERIC output definitions
   public static final Pipeline TEST_PIPELINE_1 =
       new Pipeline(
           PipelinesEnum.ARRAY_IMPUTATION,


### PR DESCRIPTION
### Description 

[The previous PR](https://github.com/DataBiosphere/terra-scientific-pipelines-service/pull/242) refactored our process for extracting WDL outputs but failed to support the Integer output of the QuotaConsumed WDL.

Here we add processing of outputs to ensure the correct type, as well as support for boolean type inputs/outputs (which we will need shortly).

e2e test run: https://github.com/DataBiosphere/terra-scientific-pipelines-service/actions/runs/17413480419/job/49436988580

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-568

### Checklist (provide links to changes)

- [ ] Updated external documentation (if applicable)
- [ ] Updated internal documentation (if applicable)
- [ ] Planned non patch version bump (if applicable)
- [ ] Updated CLI PR (if applicable)
