### PR TITLE
TSPS-477 add pipeline header line input for array imputation v1 pipeline 

### DIFF
--- a/service/src/main/resources/db/changelog.xml
+++ b/service/src/main/resources/db/changelog.xml
@@ -18,6 +18,7 @@
   <include file="changesets/20250808_update_array_imputation_description.yaml" relativeToChangelogFile="true"/>
   <include file="changesets/20250821_update_array_imputation_default_quota_to_2500.yaml" relativeToChangelogFile="true"/>
   <include file="changesets/20250825_drop_workspace_id_columns.yaml" relativeToChangelogFile="true"/>
+  <include file="changesets/20250903_add_imputation_pipeline_header_input.yaml" relativeToChangelogFile="true"/>
 
   <include file="changesets/testdata.yaml" relativeToChangelogFile="true"/>
 

--- a/service/src/main/resources/db/changesets/20250903_add_imputation_pipeline_header_input.yaml
+++ b/service/src/main/resources/db/changesets/20250903_add_imputation_pipeline_header_input.yaml
@@ -1,0 +1,32 @@
+# drop workspace_id columns from pipelines and pipline_runs tables
+
+databaseChangeLog:
+  -  changeSet:
+       id:  drop workspace_id columns from pipelines and pipline_runs tables
+       author:  mma
+       changes:
+         # add pipeline header input definition for array_imputation v1 pipeline
+         - insert:
+             tableName: pipeline_input_definitions
+             columns:
+               - column:
+                   name: pipeline_id
+                   valueComputed: (SELECT id FROM pipelines WHERE name='array_imputation' and version='1')
+               - column:
+                   name: name
+                   value: pipelineHeaderLine
+               - column:
+                   name: type
+                   value: STRING
+               - column:
+                   name: is_required
+                   value: true
+               - column:
+                   name: user_provided
+                   value: false
+               - column:
+                   name: default_value
+                   value: ScientificServicesPipeline=ArrayImputation_v1
+               - column:
+                   name: wdl_variable_name
+                   value: pipeline_header_line

--- a/service/src/test/java/bio/terra/pipelines/service/PipelinesServiceDatabaseTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/PipelinesServiceDatabaseTest.java
@@ -108,14 +108,14 @@ class PipelinesServiceDatabaseTest extends BaseEmbeddedDbTest {
     List<PipelineInputDefinition> allPipelineInputDefinitions =
         pipeline.getPipelineInputDefinitions();
 
-    // there should be 2 user-provided inputs and 4 service-provided inputs
+    // there should be 2 user-provided inputs and 5 service-provided inputs
     assertEquals(
         2,
         allPipelineInputDefinitions.stream()
             .filter(PipelineInputDefinition::isUserProvided)
             .count());
     assertEquals(
-        4,
+        5,
         allPipelineInputDefinitions.stream()
             .filter(Predicate.not(PipelineInputDefinition::isUserProvided))
             .count());
@@ -148,7 +148,12 @@ class PipelinesServiceDatabaseTest extends BaseEmbeddedDbTest {
             .map(PipelineInputDefinition::getWdlVariableName)
             .collect(Collectors.toSet())
             .containsAll(
-                Set.of("contigs", "genetic_maps_path", "ref_dict", "reference_panel_path_prefix")));
+                Set.of(
+                    "contigs",
+                    "genetic_maps_path",
+                    "ref_dict",
+                    "reference_panel_path_prefix",
+                    "pipeline_header_line")));
 
     assertTrue(
         allPipelineInputDefinitions.stream()
@@ -158,7 +163,12 @@ class PipelinesServiceDatabaseTest extends BaseEmbeddedDbTest {
             .map(PipelineInputDefinition::getName)
             .collect(Collectors.toSet())
             .containsAll(
-                Set.of("contigs", "geneticMapsPath", "refDict", "referencePanelPathPrefix")));
+                Set.of(
+                    "contigs",
+                    "geneticMapsPath",
+                    "refDict",
+                    "referencePanelPathPrefix",
+                    "pipelineHeaderLine")));
 
     // make sure the inputs are associated with the correct pipeline
     assertEquals(


### PR DESCRIPTION

### Description 

We want to add a line to the array imputation output vcf header.  In order to do this we need to pass in a value for pipeline_header_line when submitting the wdl to cromwell.  This must be released after the changes made in https://github.com/broadinstitute/warp/pull/1667 are released.

### Jira Ticket

### Checklist (provide links to changes)

- [ ] Updated external documentation (if applicable)
- [ ] Updated internal documentation (if applicable)
- [ ] Planned non patch version bump (if applicable)
- [ ] Updated CLI PR (if applicable)
