### PR TITLE
TSPS-596 Add outputs to pipelines details response

### DIFF
--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -757,9 +757,38 @@ components:
       type: string
       format: string
 
+    PipelineOutputDefinition:
+      description: |
+        An output field and its specifications for the Pipeline.
+      type: object
+      properties:
+        name:
+          $ref: "#/components/schemas/PipelineOutputName"
+        type:
+          $ref: "#/components/schemas/PipelineOutputType"
+
+    PipelineOutputDefinitions:
+      description: |
+        A list of output fields and specifications for the Pipeline.
+      type: array
+      items:
+        $ref: "#/components/schemas/PipelineOutputDefinition"
+
     PipelineOutputExpirationDate:
       description: |
         The Date when the pipeline outputs will expire.
+      type: string
+      format: string
+
+    PipelineOutputName:
+      description: |
+        The name of the output field.
+      type: string
+      format: string
+
+    PipelineOutputType:
+      description: |
+        The type of the output field.
       type: string
       format: string
 
@@ -915,7 +944,7 @@ components:
       description: |
         Object containing the pipeline identifier, display name, description, type, and required inputs of a Pipeline.
       type: object
-      required: [ pipelineName, pipelineVersion, displayName, description, type, inputs, pipelineQuota ]
+      required: [ pipelineName, pipelineVersion, displayName, description, type, inputs, outputs, pipelineQuota ]
       properties:
         pipelineName:
           $ref: "#/components/schemas/PipelineName"
@@ -929,6 +958,8 @@ components:
           $ref: "#/components/schemas/PipelineType"
         inputs:
           $ref: "#/components/schemas/PipelineUserProvidedInputDefinitions"
+        outputs:
+          $ref: "#/components/schemas/PipelineOutputDefinitions"
         pipelineQuota:
           $ref: "#/components/schemas/PipelineQuota"
 

--- a/service/src/main/java/bio/terra/pipelines/app/controller/PipelinesApiController.java
+++ b/service/src/main/java/bio/terra/pipelines/app/controller/PipelinesApiController.java
@@ -112,13 +112,23 @@ public class PipelinesApiController implements PipelinesApi {
                         .isRequired(input.isRequired())
                         .fileSuffix(input.getFileSuffix()))
             .toList());
+    ApiPipelineOutputDefinitions outputs = new ApiPipelineOutputDefinitions();
+    outputs.addAll(
+        pipelineInfo.getPipelineOutputDefinitions().stream()
+            .map(
+                output ->
+                    new ApiPipelineOutputDefinition()
+                        .name(output.getName())
+                        .type(output.getType().toString()))
+            .toList());
     return new ApiPipelineWithDetails()
         .pipelineName(pipelineInfo.getName().getValue())
         .displayName(pipelineInfo.getDisplayName())
         .pipelineVersion(pipelineInfo.getVersion())
         .description(pipelineInfo.getDescription())
         .type(pipelineInfo.getPipelineType())
-        .inputs(inputs);
+        .inputs(inputs)
+        .outputs(outputs);
   }
 
   static ApiPipeline pipelineToApi(Pipeline pipelineInfo) {

--- a/service/src/test/java/bio/terra/pipelines/controller/PipelinesApiControllerTest.java
+++ b/service/src/test/java/bio/terra/pipelines/controller/PipelinesApiControllerTest.java
@@ -116,7 +116,7 @@ class PipelinesApiControllerTest {
     assertEquals(TestUtils.TEST_PIPELINE_1.getPipelineType(), response.getType());
     assertEquals(TestUtils.TEST_PIPELINE_1.getVersion(), response.getPipelineVersion());
 
-    // check that the response only includes user-provided inputs
+    // check that the response includes user-provided inputs, and outputs
     assertEquals(
         TestUtils.TEST_PIPELINE_INPUTS_DEFINITION_LIST.stream()
             .filter(PipelineInputDefinition::isUserProvided)
@@ -129,6 +129,15 @@ class PipelinesApiControllerTest {
       assertTrue(
           TestUtils.TEST_PIPELINE_INPUTS_DEFINITION_LIST.stream()
               .anyMatch(i -> i.getName().equals(p.getName()) && i.isUserProvided()));
+    }
+
+    assertEquals(
+        TestUtils.TEST_PIPELINE_OUTPUTS_DEFINITION_LIST.size(), response.getOutputs().size());
+    for (ApiPipelineOutputDefinition p : response.getOutputs()) {
+      // find the matching output definition in test pipeline outputs list
+      assertTrue(
+          TestUtils.TEST_PIPELINE_OUTPUTS_DEFINITION_LIST.stream()
+              .anyMatch(i -> i.getName().equals(p.getName())));
     }
   }
 
@@ -160,7 +169,7 @@ class PipelinesApiControllerTest {
     assertEquals(TestUtils.TEST_PIPELINE_1.getPipelineType(), response.getType());
     assertEquals(TestUtils.TEST_PIPELINE_1.getVersion(), response.getPipelineVersion());
 
-    // check that the response only includes user-provided inputs
+    // check that the response includes user-provided inputs, and outputs
     assertEquals(
         TestUtils.TEST_PIPELINE_INPUTS_DEFINITION_LIST.stream()
             .filter(PipelineInputDefinition::isUserProvided)
@@ -173,6 +182,15 @@ class PipelinesApiControllerTest {
       assertTrue(
           TestUtils.TEST_PIPELINE_INPUTS_DEFINITION_LIST.stream()
               .anyMatch(i -> i.getName().equals(p.getName()) && i.isUserProvided()));
+    }
+
+    assertEquals(
+        TestUtils.TEST_PIPELINE_OUTPUTS_DEFINITION_LIST.size(), response.getOutputs().size());
+    for (ApiPipelineOutputDefinition p : response.getOutputs()) {
+      // find the matching output definition in test pipeline outputs list
+      assertTrue(
+          TestUtils.TEST_PIPELINE_OUTPUTS_DEFINITION_LIST.stream()
+              .anyMatch(i -> i.getName().equals(p.getName())));
     }
   }
 

--- a/service/src/test/java/bio/terra/pipelines/controller/PipelinesApiControllerTest.java
+++ b/service/src/test/java/bio/terra/pipelines/controller/PipelinesApiControllerTest.java
@@ -116,7 +116,7 @@ class PipelinesApiControllerTest {
     assertEquals(TestUtils.TEST_PIPELINE_1.getPipelineType(), response.getType());
     assertEquals(TestUtils.TEST_PIPELINE_1.getVersion(), response.getPipelineVersion());
 
-    // check that the response includes user-provided inputs, and outputs
+    // check that the response includes only user-provided inputs, and outputs
     assertEquals(
         TestUtils.TEST_PIPELINE_INPUTS_DEFINITION_LIST.stream()
             .filter(PipelineInputDefinition::isUserProvided)
@@ -169,7 +169,7 @@ class PipelinesApiControllerTest {
     assertEquals(TestUtils.TEST_PIPELINE_1.getPipelineType(), response.getType());
     assertEquals(TestUtils.TEST_PIPELINE_1.getVersion(), response.getPipelineVersion());
 
-    // check that the response includes user-provided inputs, and outputs
+    // check that the response includes only user-provided inputs, and outputs
     assertEquals(
         TestUtils.TEST_PIPELINE_INPUTS_DEFINITION_LIST.stream()
             .filter(PipelineInputDefinition::isUserProvided)


### PR DESCRIPTION
### Description 

It would be useful for users to be able to see not only what inputs a pipeline takes, but also what they can expect to get as outputs. Here we're adding the output definitions to the getPipelineDetails response.

Before:
```
{
  "pipelineName": "array_imputation",
  "displayName": "All of Us + AnVIL Array Imputation",
  "pipelineVersion": 1,
  "description": "Phase and impute genotypes using Beagle 5.5 with the All of Us + AnVIL reference panel of 515,579 samples.",
  "type": "imputation",
  "inputs": [
    {
      "name": "multiSampleVcf",
      "type": "FILE",
      "isRequired": true,
      "fileSuffix": ".vcf.gz"
    },
    {
      "name": "outputBasename",
      "type": "STRING",
      "isRequired": true
    }
  ],
  "pipelineQuota": {
    "pipelineName": "array_imputation",
    "defaultQuota": 2500,
    "minQuotaConsumed": 500,
    "quotaUnits": "SAMPLES"
  }
}
```

After:
```
{
  "pipelineName": "array_imputation",
  "displayName": "All of Us + AnVIL Array Imputation",
  "pipelineVersion": 1,
  "description": "Phase and impute genotypes using Beagle 5.5 with the All of Us + AnVIL reference panel of 515,579 samples.",
  "type": "imputation",
  "inputs": [
    {
      "name": "multiSampleVcf",
      "type": "FILE",
      "isRequired": true,
      "fileSuffix": ".vcf.gz"
    },
    {
      "name": "outputBasename",
      "type": "STRING",
      "isRequired": true
    }
  ],
  "outputs": [
    {
      "name": "imputedMultiSampleVcf",
      "type": "FILE"
    },
    {
      "name": "imputedMultiSampleVcfIndex",
      "type": "FILE"
    },
    {
      "name": "chunksInfo",
      "type": "FILE"
    }
  ],
  "pipelineQuota": {
    "pipelineName": "array_imputation",
    "defaultQuota": 2500,
    "minQuotaConsumed": 500,
    "quotaUnits": "SAMPLES"
  }
}
```

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-596

### Checklist (provide links to changes)

- [ ] Updated external documentation (if applicable)
- [ ] Updated internal documentation (if applicable)
- [x] Planned non patch version bump: minor version update
- [ ] Updated CLI PR after merging this one: https://github.com/DataBiosphere/terra-scientific-pipelines-service-cli/pull/60
