### PR TITLE
TSPS-631 Update email notifications to point to UI

### DIFF
--- a/notification-templates/job_failed.html
+++ b/notification-templates/job_failed.html
@@ -211,8 +211,8 @@
                             </tr>
                             <tr>
                                 <td align="center" style="font-family: 'Montserrat', Arial, sans-serif; color:#333F52; font-size:20px; line-height: 24px; letter-spacing:1px;">
-                                    View your jobs in the <a href="https://services.terra.bio/#pipelines/imputation/history">Scientific Services UI</a>.<br><br>
-                                    For help troubleshooting, see our <a href="https://broadscientificservices.zendesk.com/hc/en-us/articles/39901328838427">documentation</a>.<br><br>
+                                    View your jobs in the <a href="https://services.terra.bio/#pipelines/imputation/history">Scientific Services UI</a>, or use the <a href="https://pypi.org/project/terralab-cli/">terralab CLI</a>.<br><br>
+                                    For help troubleshooting, see our <a href="https://broadscientificservices.zendesk.com/hc/en-us/articles/39901328838427">documentation</a>.
                                     If you still need help, email <a href="mailto:scientific-services-support@broadinstitute.org">scientific-services-support@broadinstitute.org</a>.
                                 </td>
                             </tr>

--- a/notification-templates/job_failed.html
+++ b/notification-templates/job_failed.html
@@ -211,7 +211,7 @@
                             </tr>
                             <tr>
                                 <td align="center" style="font-family: 'Montserrat', Arial, sans-serif; color:#333F52; font-size:20px; line-height: 24px; letter-spacing:1px;">
-                                    View your jobs in the <a href="https://services.terra.bio/#pipelines/imputation/history">Scientific Services UI</a>, or use the <a href="https://pypi.org/project/terralab-cli/">terralab CLI</a>.<br><br>
+                                    View your jobs in the <a href="https://services.terra.bio/#pipelines/imputation/history">Scientific Services UI</a>, or use the <a href="https://broadscientificservices.zendesk.com/hc/en-us/articles/39901313672859">terralab CLI</a>.<br><br>
                                     For help troubleshooting, see our <a href="https://broadscientificservices.zendesk.com/hc/en-us/articles/39901328838427">documentation</a>.
                                     If you still need help, email <a href="mailto:scientific-services-support@broadinstitute.org">scientific-services-support@broadinstitute.org</a>.
                                 </td>

--- a/notification-templates/job_failed.html
+++ b/notification-templates/job_failed.html
@@ -211,7 +211,9 @@
                             </tr>
                             <tr>
                                 <td align="center" style="font-family: 'Montserrat', Arial, sans-serif; color:#333F52; font-size:20px; line-height: 24px; letter-spacing:1px;">
-                                    For help troubleshooting, see our <a href="https://broadscientificservices.zendesk.com/hc/en-us/articles/39901328838427">documentation</a>. If you still need help, email <a href="mailto:scientific-services-support@broadinstitute.org">scientific-services-support@broadinstitute.org</a>.
+                                    View your jobs in the <a href=https://services.terra.bio/#pipelines/imputation/history>Scientific Services UI</a>.<br><br>
+                                    For help troubleshooting, see our <a href="https://broadscientificservices.zendesk.com/hc/en-us/articles/39901328838427">documentation</a>.<br><br>
+                                    If you still need help, email <a href="mailto:scientific-services-support@broadinstitute.org">scientific-services-support@broadinstitute.org</a>.
                                 </td>
                             </tr>
                             <tr>

--- a/notification-templates/job_failed.html
+++ b/notification-templates/job_failed.html
@@ -211,7 +211,7 @@
                             </tr>
                             <tr>
                                 <td align="center" style="font-family: 'Montserrat', Arial, sans-serif; color:#333F52; font-size:20px; line-height: 24px; letter-spacing:1px;">
-                                    View your jobs in the <a href=https://services.terra.bio/#pipelines/imputation/history>Scientific Services UI</a>.<br><br>
+                                    View your jobs in the <a href="https://services.terra.bio/#pipelines/imputation/history">Scientific Services UI</a>.<br><br>
                                     For help troubleshooting, see our <a href="https://broadscientificservices.zendesk.com/hc/en-us/articles/39901328838427">documentation</a>.<br><br>
                                     If you still need help, email <a href="mailto:scientific-services-support@broadinstitute.org">scientific-services-support@broadinstitute.org</a>.
                                 </td>

--- a/notification-templates/job_succeeded.html
+++ b/notification-templates/job_succeeded.html
@@ -211,8 +211,8 @@
                                 <td height="15"></td>
                             </tr>
                             <tr>
-                                <td align="center" style="font-family: 'Montserrat', Arial, sans-serif; color:#333F52; font-size:20px; line-height: 24px; letter-spacing: 1px;">View your jobs and download your data using the <a href=https://services.terra.bio/#pipelines/imputation/history>Scientific Services UI</a>. <br><br>
-                                    Alternatively, you can use the <a href=https://pypi.org/project/terralab-cli/>terralab CLI</a> with the following command:<br>
+                                <td align="center" style="font-family: 'Montserrat', Arial, sans-serif; color:#333F52; font-size:20px; line-height: 24px; letter-spacing: 1px;">View your jobs and download your data using the <a href="https://services.terra.bio/#pipelines/imputation/history>Scientific Services UI"</a>. <br><br>
+                                    Alternatively, you can use the <a href="https://pypi.org/project/terralab-cli/">terralab CLI</a> with the following command:<br>
                                     <span style="font-family: Consolas, Courier New; color: #333F52; background-color: #fff;">
                                     terralab download %jobId%</span>
                                 </td>

--- a/notification-templates/job_succeeded.html
+++ b/notification-templates/job_succeeded.html
@@ -211,14 +211,14 @@
                                 <td height="15"></td>
                             </tr>
                             <tr>
-                                <td align="center" style="font-family: 'Montserrat', Arial, sans-serif; color:#333F52; font-size:20px; line-height: 24px; letter-spacing: 1px;">Download your data using the <a href=https://pypi.org/project/terralab-cli/>terralab CLI</a> with the following command:
+                                <td align="center" style="font-family: 'Montserrat', Arial, sans-serif; color:#333F52; font-size:20px; line-height: 24px; letter-spacing: 1px;">Download your data using the <a href=https://services.terra.bio/#pipelines/imputation/history>Scientific Services UI</a>, <br></be>or use the <a href=https://pypi.org/project/terralab-cli/>terralab CLI</a> with the following command:
                                 </td>
                             </tr>
                             <tr>
                                 <td height="5"></td>
                             </tr>
                             <tr>
-                                <td align="center" style="font-size: 24px; font-family: Consolas, Courier New; color: #333F52; background-color: #fff; padding: 2px; line-height: 28px">
+                                <td align="center" style="font-size: 20px; font-family: Consolas, Courier New; color: #333F52; background-color: #fff; padding: 2px; line-height: 28px">
                                     terralab download %jobId%
                                 </td>
                             </tr>

--- a/notification-templates/job_succeeded.html
+++ b/notification-templates/job_succeeded.html
@@ -211,10 +211,7 @@
                                 <td height="15"></td>
                             </tr>
                             <tr>
-                                <td align="center" style="font-family: 'Montserrat', Arial, sans-serif; color:#333F52; font-size:20px; line-height: 24px; letter-spacing: 1px;">View your jobs and download your data using the <a href="https://services.terra.bio/#pipelines/imputation/history">Scientific Services UI</a>. <br><br>
-                                    Alternatively, you can use the <a href="https://pypi.org/project/terralab-cli/">terralab CLI</a> with the following command:<br>
-                                    <span style="font-family: Consolas, Courier New; color: #333F52; background-color: #fff;">
-                                    terralab download %jobId%</span>
+                                <td align="center" style="font-family: 'Montserrat', Arial, sans-serif; color:#333F52; font-size:20px; line-height: 24px; letter-spacing: 1px;">View your jobs and download your data using the <a href="https://services.terra.bio/#pipelines/imputation/history">Scientific Services UI</a>, or use the <a href="https://broadscientificservices.zendesk.com/hc/en-us/articles/39901313672859">terralab CLI</a>.
                                 </td>
                             </tr>
                             <tr>

--- a/notification-templates/job_succeeded.html
+++ b/notification-templates/job_succeeded.html
@@ -211,7 +211,7 @@
                                 <td height="15"></td>
                             </tr>
                             <tr>
-                                <td align="center" style="font-family: 'Montserrat', Arial, sans-serif; color:#333F52; font-size:20px; line-height: 24px; letter-spacing: 1px;">View your jobs and download your data using the <a href="https://services.terra.bio/#pipelines/imputation/history>Scientific Services UI"</a>. <br><br>
+                                <td align="center" style="font-family: 'Montserrat', Arial, sans-serif; color:#333F52; font-size:20px; line-height: 24px; letter-spacing: 1px;">View your jobs and download your data using the <a href="https://services.terra.bio/#pipelines/imputation/history">Scientific Services UI</a>. <br><br>
                                     Alternatively, you can use the <a href="https://pypi.org/project/terralab-cli/">terralab CLI</a> with the following command:<br>
                                     <span style="font-family: Consolas, Courier New; color: #333F52; background-color: #fff;">
                                     terralab download %jobId%</span>

--- a/notification-templates/job_succeeded.html
+++ b/notification-templates/job_succeeded.html
@@ -211,19 +211,14 @@
                                 <td height="15"></td>
                             </tr>
                             <tr>
-                                <td align="center" style="font-family: 'Montserrat', Arial, sans-serif; color:#333F52; font-size:20px; line-height: 24px; letter-spacing: 1px;">Download your data using the <a href=https://services.terra.bio/#pipelines/imputation/history>Scientific Services UI</a>, <br></be>or use the <a href=https://pypi.org/project/terralab-cli/>terralab CLI</a> with the following command:
+                                <td align="center" style="font-family: 'Montserrat', Arial, sans-serif; color:#333F52; font-size:20px; line-height: 24px; letter-spacing: 1px;">View your jobs and download your data using the <a href=https://services.terra.bio/#pipelines/imputation/history>Scientific Services UI</a>. <br><br>
+                                    Alternatively, you can use the <a href=https://pypi.org/project/terralab-cli/>terralab CLI</a> with the following command:<br>
+                                    <span style="font-family: Consolas, Courier New; color: #333F52; background-color: #fff;">
+                                    terralab download %jobId%</span>
                                 </td>
                             </tr>
                             <tr>
-                                <td height="5"></td>
-                            </tr>
-                            <tr>
-                                <td align="center" style="font-size: 20px; font-family: Consolas, Courier New; color: #333F52; background-color: #fff; padding: 2px; line-height: 28px">
-                                    terralab download %jobId%
-                                </td>
-                            </tr>
-                            <tr>
-                                <td height="5"></td>
+                                <td height="25"></td>
                             </tr>
                             <tr>
                                 <td align="center" style="font-family: 'Montserrat', Arial, sans-serif; color:#333F52; font-size:20px; line-height: 24px; letter-spacing: 1px;">Results are available to download for %userDataTtlDays% days.


### PR DESCRIPTION
### Description 

Now that the UI is publicly available, we want to advertise it and point users there. This PR corresponds to updates to the job completion email notifications, which now instruct the users to use either the UI or the CLI to view their jobs and download their data.

Succeeded notification before:
<img width="781" height="553" alt="Screenshot 2025-09-22 at 10 46 46 AM" src="https://github.com/user-attachments/assets/251f427e-8885-4bb9-96ae-07c0f99c4c4e" />

Succeeded notification after:
<img width="778" height="500" alt="image" src="https://github.com/user-attachments/assets/c056830d-2373-40b8-bdd5-20c3b7f0541d" />


Failed notification before:
<img width="778" height="479" alt="Screenshot 2025-09-22 at 10 46 37 AM" src="https://github.com/user-attachments/assets/f987c7d6-1367-4fd4-9667-108afcf78ac6" />

Failed notification after:
<img width="778" height="514" alt="image" src="https://github.com/user-attachments/assets/e3af46d7-e21d-4195-91ea-56441e58705e" />



### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-631

### Checklist (provide links to changes)

- [ ] Updated external documentation (if applicable)
- [ ] Updated internal documentation (if applicable)
- [ ] Planned non patch version bump (if applicable)
- [ ] Updated CLI PR (if applicable)
- [x] Prod Sendgrid updated: 
<img width="881" height="442" alt="image" src="https://github.com/user-attachments/assets/cfa34b55-beb7-4ffc-962a-fbc78df72e11" />

