### PR TITLE
TSPS-353 change contigs to allowed_contigs

### DIFF
--- a/pipelines/imputation/testing/ImputationBeagleEmpty.wdl
+++ b/pipelines/imputation/testing/ImputationBeagleEmpty.wdl
@@ -12,7 +12,7 @@ workflow ImputationBeagle {
         File multi_sample_vcf
 
         File ref_dict
-        Array[String] contigs
+        Array[String] allowed_contigs
         String reference_panel_path_prefix
         String genetic_maps_path
         String output_basename

--- a/pipelines/imputation/testing/InputQCEmpty.wdl
+++ b/pipelines/imputation/testing/InputQCEmpty.wdl
@@ -10,7 +10,7 @@ workflow InputQC {
         File multi_sample_vcf
 
         File ref_dict
-        Array[String] contigs
+        Array[String] allowed_contigs
         String reference_panel_path_prefix
         String genetic_maps_path
         String output_basename

--- a/pipelines/imputation/testing/QuotaConsumedEmpty.wdl
+++ b/pipelines/imputation/testing/QuotaConsumedEmpty.wdl
@@ -10,7 +10,7 @@ workflow QuotaConsumed {
         File multi_sample_vcf
 
         File ref_dict
-        Array[String] contigs
+        Array[String] allowed_contigs
         String reference_panel_path_prefix
         String genetic_maps_path
         String output_basename

--- a/service/src/main/java/bio/terra/pipelines/stairway/steps/common/InputQcValidationStep.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/steps/common/InputQcValidationStep.java
@@ -9,7 +9,6 @@ import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 import java.util.Map;
-import java.util.Objects;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,11 +44,7 @@ public class InputQcValidationStep implements Step {
     boolean passesQc = (boolean) inputQcOutputs.get("passesQc");
     if (!passesQc) {
       // extract error messages
-      String qcMessagesRaw = (String) Objects.requireNonNull(inputQcOutputs.get("qcMessages"));
-      String qcMessages =
-          qcMessagesRaw.endsWith(";")
-              ? qcMessagesRaw.substring(0, qcMessagesRaw.length() - 1)
-              : qcMessagesRaw;
+      String qcMessages = (String) inputQcOutputs.get("qcMessages");
       return new StepResult(
           StepStatus.STEP_RESULT_FAILURE_FATAL,
           new PipelineCheckFailedException("Input failed QC: " + qcMessages));

--- a/service/src/main/resources/db/changelog.xml
+++ b/service/src/main/resources/db/changelog.xml
@@ -21,6 +21,7 @@
   <include file="changesets/20250903_add_imputation_pipeline_header_input.yaml" relativeToChangelogFile="true"/>
   <include file="changesets/20250903_add_output_required_column.yaml" relativeToChangelogFile="true"/>
   <include file="changesets/20250908_add_raw_quota_consumed.yaml" relativeToChangelogFile="true"/>
+  <include file="changesets/20250924_update_allowed_contigs_input.yaml" relativeToChangelogFile="true"/>
 
   <include file="changesets/testdata.yaml" relativeToChangelogFile="true"/>
 

--- a/service/src/main/resources/db/changesets/20250924_update_allowed_contigs_input.yaml
+++ b/service/src/main/resources/db/changesets/20250924_update_allowed_contigs_input.yaml
@@ -1,0 +1,18 @@
+# update input definition for array_imputation v1 pipeline - change contigs to allowed_contigs
+
+databaseChangeLog:
+  -  changeSet:
+       id:  update input definition for array_imputation v1 pipeline - change contigs to allowed_contigs
+       author:  mma
+       changes:
+         # change contig input definition for array_imputation v1 pipeline
+         - update:
+             tableName: pipeline_input_definitions
+             columns:
+               - column:
+                   name: name
+                   value: allowedContigs
+               - column:
+                   name: wdl_variable_name
+                   value: allowed_contigs
+             where: name='contigs' and pipeline_id=(SELECT id FROM pipelines WHERE name='array_imputation' and version='1')

--- a/service/src/test/java/bio/terra/pipelines/service/PipelinesServiceDatabaseTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/PipelinesServiceDatabaseTest.java
@@ -149,7 +149,7 @@ class PipelinesServiceDatabaseTest extends BaseEmbeddedDbTest {
             .collect(Collectors.toSet())
             .containsAll(
                 Set.of(
-                    "contigs",
+                    "allowed_contigs",
                     "genetic_maps_path",
                     "ref_dict",
                     "reference_panel_path_prefix",
@@ -164,7 +164,7 @@ class PipelinesServiceDatabaseTest extends BaseEmbeddedDbTest {
             .collect(Collectors.toSet())
             .containsAll(
                 Set.of(
-                    "contigs",
+                    "allowedContigs",
                     "geneticMapsPath",
                     "refDict",
                     "referencePanelPathPrefix",

--- a/service/src/test/java/bio/terra/pipelines/stairway/steps/common/InputQcValidationStepTest.java
+++ b/service/src/test/java/bio/terra/pipelines/stairway/steps/common/InputQcValidationStepTest.java
@@ -42,23 +42,7 @@ class InputQcValidationStepTest extends BaseEmbeddedDbTest {
   }
 
   @Test
-  void testDoStepFailsQcWithTrailingColon() {
-    Map<String, ?> inputQcOutputs =
-        new HashMap<>(Map.of("passesQc", false, "qcMessages", "File format error;"));
-    flightContext.getWorkingMap().put(ImputationJobMapKeys.INPUT_QC_OUTPUTS, inputQcOutputs);
-
-    // do the step
-    InputQcValidationStep inputQcValidationStep = new InputQcValidationStep();
-    StepResult result = inputQcValidationStep.doStep(flightContext);
-
-    // make sure the step failed fatally
-    assertEquals(StepStatus.STEP_RESULT_FAILURE_FATAL, result.getStepStatus());
-    assertTrue(
-        result.getException().get().getMessage().contains("Input failed QC: File format error"));
-  }
-
-  @Test
-  void testDoStepFailsQcNoTrailingColon() {
+  void testDoStepFailsQc() {
     Map<String, ?> inputQcOutputs =
         new HashMap<>(Map.of("passesQc", false, "qcMessages", "File format error"));
     flightContext.getWorkingMap().put(ImputationJobMapKeys.INPUT_QC_OUTPUTS, inputQcOutputs);


### PR DESCRIPTION
### Description 

We are updating the array_imputation pipeline to accept a subset of chromosomes rather than requiring all chromosomes (1-22) in user input VCFs. This involves a change to the ImputationBeagle and supporting (QC and Quota) wdls (see the [warp PR](https://github.com/broadinstitute/warp/pull/1678)), including a change in an input variable name. The changes in this PR update that input variable name (from `contig` to `allowed_contigs`) and also removes some qc message string cleanup that is no longer necessary.

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-353

### Checklist (provide links to changes)

- [ ] Updated external documentation - TO DO
- [ ] Updated internal documentation (if applicable)
- [ ] Planned non patch version bump (if applicable)
- [ ] Updated CLI PR (if applicable)
