### PR TITLE
TSPS-641 modify data table entity name to inclue pieline version

### DIFF
--- a/service/src/main/java/bio/terra/pipelines/dependencies/rawls/RawlsService.java
+++ b/service/src/main/java/bio/terra/pipelines/dependencies/rawls/RawlsService.java
@@ -1,6 +1,7 @@
 package bio.terra.pipelines.dependencies.rawls;
 
 import bio.terra.common.exception.InternalServerErrorException;
+import bio.terra.pipelines.common.utils.PipelinesEnum;
 import bio.terra.pipelines.db.entities.PipelineInputDefinition;
 import bio.terra.pipelines.db.entities.PipelineOutputDefinition;
 import bio.terra.pipelines.dependencies.common.HealthCheck;
@@ -313,5 +314,10 @@ public class RawlsService implements HealthCheck {
             throw new RawlsServiceApiException(e);
           }
         });
+  }
+
+  public static String createDataTableEntityName(
+      PipelinesEnum pipelineName, Integer pipelineVersion) {
+    return pipelineName.getValue() + "_v" + pipelineVersion;
   }
 }

--- a/service/src/main/java/bio/terra/pipelines/dependencies/stairway/JobMapKeys.java
+++ b/service/src/main/java/bio/terra/pipelines/dependencies/stairway/JobMapKeys.java
@@ -9,6 +9,7 @@ public class JobMapKeys {
   public static final String USER_ID = "user_id";
   public static final String PIPELINE_NAME = "pipeline_name";
   public static final String PIPELINE_ID = "pipeline_id";
+  public static final String PIPELINE_VERSION = "pipeline_version";
   public static final String STATUS_CODE = "status_code";
   public static final String RESPONSE = "response"; // result or output of the job
   // domain name for the service, used to generate the URL for the result api endpoint

--- a/service/src/main/java/bio/terra/pipelines/service/PipelineRunsService.java
+++ b/service/src/main/java/bio/terra/pipelines/service/PipelineRunsService.java
@@ -22,7 +22,7 @@ import bio.terra.pipelines.dependencies.stairway.JobBuilder;
 import bio.terra.pipelines.dependencies.stairway.JobMapKeys;
 import bio.terra.pipelines.dependencies.stairway.JobService;
 import bio.terra.pipelines.stairway.flights.imputation.ImputationJobMapKeys;
-import bio.terra.pipelines.stairway.flights.imputation.v20250911.RunImputationGcpJobFlight;
+import bio.terra.pipelines.stairway.flights.imputation.v20251002.RunImputationGcpJobFlight;
 import bio.terra.stairway.Flight;
 import java.util.List;
 import java.util.Map;
@@ -166,7 +166,7 @@ public class PipelineRunsService {
     Class<? extends Flight> flightClass;
     switch (pipelineName) {
       case ARRAY_IMPUTATION:
-        flightClass = RunImputationGcpJobFlight.class; // v20250911
+        flightClass = RunImputationGcpJobFlight.class; // v20251002
         break;
       default:
         throw new InternalServerErrorException(
@@ -179,6 +179,7 @@ public class PipelineRunsService {
             .jobId(jobId)
             .flightClass(flightClass)
             .addParameter(JobMapKeys.PIPELINE_NAME, pipelineName)
+            .addParameter(JobMapKeys.PIPELINE_VERSION, pipeline.getVersion())
             .addParameter(JobMapKeys.USER_ID, userId)
             .addParameter(JobMapKeys.DESCRIPTION, pipelineRun.getDescription())
             .addParameter(JobMapKeys.PIPELINE_ID, pipeline.getId())

--- a/service/src/main/java/bio/terra/pipelines/stairway/flights/imputation/v20251002/RunImputationGcpJobFlight.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/flights/imputation/v20251002/RunImputationGcpJobFlight.java
@@ -1,0 +1,160 @@
+package bio.terra.pipelines.stairway.flights.imputation.v20251002;
+
+import bio.terra.pipelines.app.common.MetricsUtils;
+import bio.terra.pipelines.common.utils.FlightBeanBag;
+import bio.terra.pipelines.common.utils.FlightUtils;
+import bio.terra.pipelines.common.utils.PipelinesEnum;
+import bio.terra.pipelines.dependencies.stairway.JobMapKeys;
+import bio.terra.pipelines.stairway.flights.imputation.ImputationJobMapKeys;
+import bio.terra.pipelines.stairway.steps.common.*;
+import bio.terra.pipelines.stairway.steps.imputation.AddDataTableRowStep;
+import bio.terra.pipelines.stairway.steps.imputation.PrepareImputationInputsStep;
+import bio.terra.stairway.*;
+
+public class RunImputationGcpJobFlight extends Flight {
+
+  /** Retry for short database operations which may fail due to transaction conflicts. */
+  private final RetryRule dbRetryRule =
+      new RetryRuleFixedInterval(/*intervalSeconds= */ 1, /* maxCount= */ 5);
+
+  /**
+   * Use for a short exponential backoff retry, for operations that should be completable within a
+   * few seconds.
+   */
+  private final RetryRule externalServiceRetryRule =
+      // maxOperationTimeSeconds must be larger than socket timeout (20s), otherwise a socket
+      // timeout
+      // won't be retried.
+      new RetryRuleExponentialBackoff(1, 8, /* maxOperationTimeSeconds */ 30);
+
+  // addStep is protected in Flight, so make an override that is public
+  @Override
+  public void addStep(Step step, RetryRule retryRule) {
+    super.addStep(step, retryRule);
+  }
+
+  public RunImputationGcpJobFlight(FlightMap inputParameters, Object beanBag) {
+    super(inputParameters, beanBag);
+    final FlightBeanBag flightBeanBag = FlightBeanBag.getFromObject(beanBag);
+
+    FlightUtils.validateRequiredEntries(
+        inputParameters,
+        JobMapKeys.USER_ID,
+        JobMapKeys.PIPELINE_NAME,
+        JobMapKeys.PIPELINE_VERSION,
+        JobMapKeys.PIPELINE_ID,
+        JobMapKeys.DOMAIN_NAME,
+        JobMapKeys.DO_SET_PIPELINE_RUN_STATUS_FAILED_HOOK,
+        JobMapKeys.DO_SEND_JOB_FAILURE_NOTIFICATION_HOOK,
+        JobMapKeys.DO_INCREMENT_METRICS_FAILED_COUNTER_HOOK,
+        ImputationJobMapKeys.USER_PROVIDED_PIPELINE_INPUTS,
+        ImputationJobMapKeys.CONTROL_WORKSPACE_BILLING_PROJECT,
+        ImputationJobMapKeys.CONTROL_WORKSPACE_NAME,
+        ImputationJobMapKeys.CONTROL_WORKSPACE_STORAGE_CONTAINER_NAME,
+        ImputationJobMapKeys.CONTROL_WORKSPACE_STORAGE_CONTAINER_PROTOCOL,
+        ImputationJobMapKeys.PIPELINE_TOOL_CONFIG,
+        ImputationJobMapKeys.QUOTA_TOOL_CONFIG,
+        ImputationJobMapKeys.INPUT_QC_TOOL_CONFIG);
+
+    PipelinesEnum pipelinesEnum =
+        PipelinesEnum.valueOf(inputParameters.get(JobMapKeys.PIPELINE_NAME, String.class));
+    MetricsUtils.incrementPipelineRun(pipelinesEnum);
+
+    addStep(
+        new PrepareImputationInputsStep(
+            flightBeanBag.getPipelineInputsOutputsService(),
+            flightBeanBag.getImputationConfiguration()),
+        dbRetryRule);
+
+    addStep(
+        new AddDataTableRowStep(flightBeanBag.getRawlsService(), flightBeanBag.getSamService()),
+        externalServiceRetryRule);
+
+    // Check input for quota to be consumed
+    addStep(
+        new SubmitCromwellSubmissionStep(
+            flightBeanBag.getRawlsService(),
+            flightBeanBag.getSamService(),
+            ImputationJobMapKeys.QUOTA_TOOL_CONFIG,
+            ImputationJobMapKeys.QUOTA_SUBMISSION_ID),
+        externalServiceRetryRule);
+
+    addStep(
+        new PollCromwellSubmissionStatusStep(
+            flightBeanBag.getRawlsService(),
+            flightBeanBag.getSamService(),
+            ImputationJobMapKeys.QUOTA_TOOL_CONFIG,
+            ImputationJobMapKeys.QUOTA_SUBMISSION_ID),
+        externalServiceRetryRule);
+
+    addStep(
+        new FetchOutputsFromDataTableStep(
+            flightBeanBag.getRawlsService(),
+            flightBeanBag.getSamService(),
+            flightBeanBag.getPipelineInputsOutputsService(),
+            ImputationJobMapKeys.QUOTA_TOOL_CONFIG,
+            ImputationJobMapKeys.QUOTA_OUTPUTS),
+        externalServiceRetryRule);
+
+    addStep(new QuotaConsumedValidationStep(flightBeanBag.getQuotasService()), dbRetryRule);
+
+    // run QC on user input
+    addStep(
+        new SubmitCromwellSubmissionStep(
+            flightBeanBag.getRawlsService(),
+            flightBeanBag.getSamService(),
+            ImputationJobMapKeys.INPUT_QC_TOOL_CONFIG,
+            ImputationJobMapKeys.INPUT_QC_SUBMISSION_ID),
+        externalServiceRetryRule);
+
+    addStep(
+        new PollCromwellSubmissionStatusStep(
+            flightBeanBag.getRawlsService(),
+            flightBeanBag.getSamService(),
+            ImputationJobMapKeys.INPUT_QC_TOOL_CONFIG,
+            ImputationJobMapKeys.INPUT_QC_SUBMISSION_ID),
+        externalServiceRetryRule);
+
+    addStep(
+        new FetchOutputsFromDataTableStep(
+            flightBeanBag.getRawlsService(),
+            flightBeanBag.getSamService(),
+            flightBeanBag.getPipelineInputsOutputsService(),
+            ImputationJobMapKeys.INPUT_QC_TOOL_CONFIG,
+            ImputationJobMapKeys.INPUT_QC_OUTPUTS),
+        externalServiceRetryRule);
+
+    addStep(new InputQcValidationStep(), dbRetryRule);
+
+    // run imputation
+    addStep(
+        new SubmitCromwellSubmissionStep(
+            flightBeanBag.getRawlsService(),
+            flightBeanBag.getSamService(),
+            ImputationJobMapKeys.PIPELINE_TOOL_CONFIG,
+            ImputationJobMapKeys.PIPELINE_SUBMISSION_ID),
+        externalServiceRetryRule);
+
+    addStep(
+        new PollCromwellSubmissionStatusStep(
+            flightBeanBag.getRawlsService(),
+            flightBeanBag.getSamService(),
+            ImputationJobMapKeys.PIPELINE_TOOL_CONFIG,
+            ImputationJobMapKeys.PIPELINE_SUBMISSION_ID),
+        externalServiceRetryRule);
+
+    addStep(
+        new FetchOutputsFromDataTableStep(
+            flightBeanBag.getRawlsService(),
+            flightBeanBag.getSamService(),
+            flightBeanBag.getPipelineInputsOutputsService(),
+            ImputationJobMapKeys.PIPELINE_TOOL_CONFIG,
+            ImputationJobMapKeys.PIPELINE_RUN_OUTPUTS),
+        externalServiceRetryRule);
+
+    addStep(new CompletePipelineRunStep(flightBeanBag.getPipelineRunsService()), dbRetryRule);
+
+    addStep(
+        new SendJobSucceededNotificationStep(flightBeanBag.getNotificationService()), dbRetryRule);
+  }
+}

--- a/service/src/main/java/bio/terra/pipelines/stairway/steps/common/FetchOutputsFromDataTableStep.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/steps/common/FetchOutputsFromDataTableStep.java
@@ -62,6 +62,7 @@ public class FetchOutputsFromDataTableStep implements Step {
     FlightUtils.validateRequiredEntries(
         inputParameters,
         JobMapKeys.PIPELINE_NAME,
+        JobMapKeys.PIPELINE_VERSION,
         ImputationJobMapKeys.CONTROL_WORKSPACE_BILLING_PROJECT,
         ImputationJobMapKeys.CONTROL_WORKSPACE_NAME,
         toolConfigKey);
@@ -71,6 +72,7 @@ public class FetchOutputsFromDataTableStep implements Step {
     String controlWorkspaceName =
         inputParameters.get(ImputationJobMapKeys.CONTROL_WORKSPACE_NAME, String.class);
     PipelinesEnum pipelineName = inputParameters.get(JobMapKeys.PIPELINE_NAME, PipelinesEnum.class);
+    Integer pipelineVersion = inputParameters.get(JobMapKeys.PIPELINE_VERSION, Integer.class);
     ToolConfig toolConfig = inputParameters.get(toolConfigKey, ToolConfig.class);
     List<PipelineOutputDefinition> outputDefinitions = toolConfig.outputDefinitions();
 
@@ -82,7 +84,7 @@ public class FetchOutputsFromDataTableStep implements Step {
               samService.getTeaspoonsServiceAccountToken(),
               controlWorkspaceBillingProject,
               controlWorkspaceName,
-              pipelineName.getValue(),
+              RawlsService.createDataTableEntityName(pipelineName, pipelineVersion),
               jobId);
     } catch (RawlsServiceApiException e) {
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, e);

--- a/service/src/main/java/bio/terra/pipelines/stairway/steps/common/SubmitCromwellSubmissionStep.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/steps/common/SubmitCromwellSubmissionStep.java
@@ -1,5 +1,7 @@
 package bio.terra.pipelines.stairway.steps.common;
 
+import static bio.terra.pipelines.dependencies.rawls.RawlsService.createDataTableEntityName;
+
 import bio.terra.pipelines.common.utils.FlightUtils;
 import bio.terra.pipelines.common.utils.PipelinesEnum;
 import bio.terra.pipelines.db.entities.PipelineInputDefinition;
@@ -57,12 +59,15 @@ public class SubmitCromwellSubmissionStep implements Step {
     FlightUtils.validateRequiredEntries(
         inputParameters,
         JobMapKeys.PIPELINE_NAME,
+        JobMapKeys.PIPELINE_VERSION,
         JobMapKeys.DESCRIPTION,
         ImputationJobMapKeys.CONTROL_WORKSPACE_BILLING_PROJECT,
         ImputationJobMapKeys.CONTROL_WORKSPACE_NAME,
         toolConfigKey);
 
     PipelinesEnum pipelineName = inputParameters.get(JobMapKeys.PIPELINE_NAME, PipelinesEnum.class);
+    Integer pipelineVersion = inputParameters.get(JobMapKeys.PIPELINE_VERSION, Integer.class);
+    String dataTableEntityName = createDataTableEntityName(pipelineName, pipelineVersion);
     String controlWorkspaceName =
         inputParameters.get(ImputationJobMapKeys.CONTROL_WORKSPACE_NAME, String.class);
     String controlWorkspaceProject =
@@ -84,7 +89,7 @@ public class SubmitCromwellSubmissionStep implements Step {
 
     Optional<StepResult> validationResponse =
         rawlsSubmissionStepHelper.validateRawlsSubmissionMethodHelper(
-            methodName, methodVersion, inputDefinitions, outputDefinitions, pipelineName);
+            methodName, methodVersion, inputDefinitions, outputDefinitions, dataTableEntityName);
 
     // if there is a validation response that means the validation failed so return it
     if (validationResponse.isPresent()) {
@@ -95,7 +100,7 @@ public class SubmitCromwellSubmissionStep implements Step {
     SubmissionRequest submissionRequest =
         new SubmissionRequest()
             .entityName(flightContext.getFlightId())
-            .entityType(pipelineName.getValue())
+            .entityType(dataTableEntityName)
             .useCallCache(toolConfig.callCache())
             .monitoringScript(toolConfig.monitoringScriptPath())
             .deleteIntermediateOutputFiles(toolConfig.deleteIntermediateOutputFiles())

--- a/service/src/main/java/bio/terra/pipelines/stairway/steps/imputation/AddDataTableRowStep.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/steps/imputation/AddDataTableRowStep.java
@@ -1,5 +1,7 @@
 package bio.terra.pipelines.stairway.steps.imputation;
 
+import static bio.terra.pipelines.dependencies.rawls.RawlsService.createDataTableEntityName;
+
 import bio.terra.pipelines.common.utils.FlightUtils;
 import bio.terra.pipelines.common.utils.PipelinesEnum;
 import bio.terra.pipelines.dependencies.rawls.RawlsService;
@@ -42,6 +44,7 @@ public class AddDataTableRowStep implements Step {
     FlightUtils.validateRequiredEntries(
         inputParameters,
         JobMapKeys.PIPELINE_NAME,
+        JobMapKeys.PIPELINE_VERSION,
         ImputationJobMapKeys.CONTROL_WORKSPACE_BILLING_PROJECT,
         ImputationJobMapKeys.CONTROL_WORKSPACE_NAME);
 
@@ -50,6 +53,7 @@ public class AddDataTableRowStep implements Step {
     String controlWorkspaceProject =
         inputParameters.get(ImputationJobMapKeys.CONTROL_WORKSPACE_BILLING_PROJECT, String.class);
     PipelinesEnum pipelineName = inputParameters.get(JobMapKeys.PIPELINE_NAME, PipelinesEnum.class);
+    Integer pipelineVersion = inputParameters.get(JobMapKeys.PIPELINE_VERSION, Integer.class);
 
     // validate and extract parameters from working map
     FlightMap workingMap = flightContext.getWorkingMap();
@@ -59,7 +63,7 @@ public class AddDataTableRowStep implements Step {
 
     Entity entity =
         new Entity()
-            .entityType(pipelineName.getValue())
+            .entityType(createDataTableEntityName(pipelineName, pipelineVersion))
             .name(flightContext.getFlightId())
             .attributes(allPipelineInputs)
             .putAttributesItem("timestamp_start", LocalDateTime.now());

--- a/service/src/main/java/bio/terra/pipelines/stairway/steps/utils/RawlsSubmissionStepHelper.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/steps/utils/RawlsSubmissionStepHelper.java
@@ -1,7 +1,6 @@
 package bio.terra.pipelines.stairway.steps.utils;
 
 import bio.terra.common.exception.InternalServerErrorException;
-import bio.terra.pipelines.common.utils.PipelinesEnum;
 import bio.terra.pipelines.db.entities.PipelineInputDefinition;
 import bio.terra.pipelines.db.entities.PipelineOutputDefinition;
 import bio.terra.pipelines.dependencies.rawls.RawlsService;
@@ -83,7 +82,7 @@ public class RawlsSubmissionStepHelper {
       String wdlMethodVersion,
       List<PipelineInputDefinition> inputDefinitions,
       List<PipelineOutputDefinition> outputDefinitions,
-      PipelinesEnum pipelineName) {
+      String dataTableEntityName) {
     MethodConfiguration methodConfiguration;
     try {
       // grab current method config and validate it
@@ -101,7 +100,7 @@ public class RawlsSubmissionStepHelper {
     boolean validMethodConfig =
         rawlsService.validateMethodConfig(
             methodConfiguration,
-            pipelineName.getValue(),
+            dataTableEntityName,
             wdlMethodName,
             inputDefinitions,
             outputDefinitions,
@@ -120,7 +119,7 @@ public class RawlsSubmissionStepHelper {
       MethodConfiguration updatedMethodConfiguration =
           rawlsService.updateMethodConfigToBeValid(
               methodConfiguration,
-              pipelineName.getValue(),
+              dataTableEntityName,
               wdlMethodName,
               inputDefinitions,
               outputDefinitions,

--- a/service/src/test/java/bio/terra/pipelines/dependencies/rawls/RawlsServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/dependencies/rawls/RawlsServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.doThrow;
 
 import bio.terra.common.exception.InternalServerErrorException;
 import bio.terra.pipelines.app.configuration.internal.RetryConfiguration;
+import bio.terra.pipelines.common.utils.PipelinesEnum;
 import bio.terra.pipelines.db.entities.PipelineInputDefinition;
 import bio.terra.pipelines.db.entities.PipelineOutputDefinition;
 import bio.terra.pipelines.dependencies.common.HealthCheck;
@@ -457,6 +458,13 @@ class RawlsServiceTest extends BaseEmbeddedDbTest {
     HealthCheck.Result actualResult = rawlsService.checkHealth();
 
     assertEquals(expectedResultOnFail, actualResult);
+  }
+
+  @Test
+  void createDataTableEntityName() {
+    assertEquals(
+        "array_imputation_v3",
+        RawlsService.createDataTableEntityName(PipelinesEnum.ARRAY_IMPUTATION, 3));
   }
 
   private PipelineInputDefinition generatePipelineInputDefinitionWithWdlVariableName(

--- a/service/src/test/java/bio/terra/pipelines/service/PipelineRunsServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/PipelineRunsServiceTest.java
@@ -23,7 +23,7 @@ import bio.terra.pipelines.dependencies.gcs.GcsService;
 import bio.terra.pipelines.dependencies.sam.SamService;
 import bio.terra.pipelines.dependencies.stairway.JobBuilder;
 import bio.terra.pipelines.dependencies.stairway.JobService;
-import bio.terra.pipelines.stairway.flights.imputation.v20250911.RunImputationGcpJobFlight;
+import bio.terra.pipelines.stairway.flights.imputation.v20251002.RunImputationGcpJobFlight;
 import bio.terra.pipelines.testutils.BaseEmbeddedDbTest;
 import bio.terra.pipelines.testutils.TestUtils;
 import bio.terra.stairway.Flight;

--- a/service/src/test/java/bio/terra/pipelines/stairway/flights/imputation/v20251002/RunImputationGcpFlightTest.java
+++ b/service/src/test/java/bio/terra/pipelines/stairway/flights/imputation/v20251002/RunImputationGcpFlightTest.java
@@ -1,0 +1,128 @@
+package bio.terra.pipelines.stairway.flights.imputation.v20251002;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import bio.terra.pipelines.common.utils.FlightBeanBag;
+import bio.terra.pipelines.common.utils.PipelinesEnum;
+import bio.terra.pipelines.dependencies.stairway.JobMapKeys;
+import bio.terra.pipelines.dependencies.stairway.JobService;
+import bio.terra.pipelines.stairway.flights.imputation.ImputationJobMapKeys;
+import bio.terra.pipelines.stairway.flights.imputation.v20250911.RunImputationGcpJobFlight;
+import bio.terra.pipelines.testutils.BaseEmbeddedDbTest;
+import bio.terra.pipelines.testutils.StairwayTestUtils;
+import bio.terra.pipelines.testutils.TestUtils;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class RunImputationGcpFlightTest extends BaseEmbeddedDbTest {
+
+  @Autowired private JobService jobService;
+
+  private final List<String> expectedStepNames =
+      List.of(
+          "PrepareImputationInputsStep",
+          "AddDataTableRowStep",
+          // quota wdl steps
+          "SubmitCromwellSubmissionStep",
+          "PollCromwellSubmissionStatusStep",
+          "FetchOutputsFromDataTableStep",
+          "QuotaConsumedValidationStep",
+          // input qc wdl steps
+          "SubmitCromwellSubmissionStep",
+          "PollCromwellSubmissionStatusStep",
+          "FetchOutputsFromDataTableStep",
+          "InputQcValidationStep",
+          // imputation wdl steps
+          "SubmitCromwellSubmissionStep",
+          "PollCromwellSubmissionStatusStep",
+          "FetchOutputsFromDataTableStep",
+          "CompletePipelineRunStep",
+          "SendJobSucceededNotificationStep");
+
+  @Autowired FlightBeanBag flightBeanBag;
+  private SimpleMeterRegistry meterRegistry;
+
+  @BeforeEach
+  void setup() {
+    meterRegistry = new SimpleMeterRegistry();
+    Metrics.globalRegistry.add(meterRegistry);
+  }
+
+  @AfterEach
+  void tearDown() {
+    meterRegistry.clear();
+    Metrics.globalRegistry.clear();
+  }
+
+  @Test
+  void createJobFlightSetup() {
+    // this tests the setters for this flight in JobBuilder. note this doesn't check for required
+    // input parameters
+    assertDoesNotThrow(
+        () ->
+            jobService
+                .newJob()
+                .jobId(TestUtils.TEST_NEW_UUID)
+                .flightClass(
+                    bio.terra.pipelines.stairway.flights.imputation.v20250911
+                        .RunImputationGcpJobFlight.class)
+                .addParameter(JobMapKeys.DESCRIPTION, "test RunImputationGcpJobFlight")
+                .addParameter(JobMapKeys.USER_ID, TestUtils.TEST_USER_ID_1)
+                .addParameter(JobMapKeys.PIPELINE_NAME, PipelinesEnum.ARRAY_IMPUTATION)
+                .addParameter(JobMapKeys.PIPELINE_VERSION, TestUtils.TEST_PIPELINE_VERSION_1)
+                .addParameter(JobMapKeys.PIPELINE_ID, TestUtils.TEST_PIPELINE_ID_1)
+                .addParameter(
+                    ImputationJobMapKeys.PIPELINE_INPUT_DEFINITIONS,
+                    TestUtils.TEST_PIPELINE_INPUTS_DEFINITION_LIST)
+                .addParameter(
+                    ImputationJobMapKeys.USER_PROVIDED_PIPELINE_INPUTS,
+                    TestUtils.TEST_PIPELINE_INPUTS)
+                .addParameter(
+                    ImputationJobMapKeys.PIPELINE_TOOL_CONFIG, TestUtils.TOOL_CONFIG_GENERIC)
+                .addParameter(ImputationJobMapKeys.QUOTA_TOOL_CONFIG, TestUtils.TOOL_CONFIG_GENERIC)
+                .addParameter(
+                    ImputationJobMapKeys.INPUT_QC_TOOL_CONFIG, TestUtils.TOOL_CONFIG_GENERIC));
+  }
+
+  @Test
+  void expectedStepsInFlight() {
+    bio.terra.pipelines.stairway.flights.imputation.v20250911.RunImputationGcpJobFlight
+        runImputationGcpJobFlight =
+            new bio.terra.pipelines.stairway.flights.imputation.v20250911.RunImputationGcpJobFlight(
+                StairwayTestUtils.CREATE_JOB_INPUT_PARAMS, flightBeanBag);
+    assertEquals(expectedStepNames.size(), runImputationGcpJobFlight.getSteps().size());
+
+    Set<String> stepNames =
+        runImputationGcpJobFlight.getSteps().stream()
+            .map(step -> step.getClass().getSimpleName())
+            .collect(Collectors.toSet());
+    for (String step : expectedStepNames) {
+      assertTrue(stepNames.contains(step));
+    }
+
+    Counter counter = meterRegistry.find("teaspoons.pipeline.run.count").counter();
+    assertNotNull(counter);
+    assertEquals(1, counter.count());
+  }
+
+  @Test
+  void pipelineRunCountIncremented() {
+    Counter counter = meterRegistry.find("teaspoons.pipeline.run.count").counter();
+    assertNull(counter);
+
+    // run setup so counter gets incremented
+    new RunImputationGcpJobFlight(StairwayTestUtils.CREATE_JOB_INPUT_PARAMS, flightBeanBag);
+
+    counter = meterRegistry.find("teaspoons.pipeline.run.count").counter();
+    assertNotNull(counter);
+    assertEquals(1, counter.count());
+  }
+}

--- a/service/src/test/java/bio/terra/pipelines/stairway/steps/common/FetchOutputsFromDataTableStepTest.java
+++ b/service/src/test/java/bio/terra/pipelines/stairway/steps/common/FetchOutputsFromDataTableStepTest.java
@@ -63,7 +63,7 @@ class FetchOutputsFromDataTableStepTest extends BaseEmbeddedDbTest {
             "thisToken",
             TestUtils.CONTROL_WORKSPACE_BILLING_PROJECT,
             TestUtils.CONTROL_WORKSPACE_NAME,
-            PipelinesEnum.ARRAY_IMPUTATION.getValue(),
+            PipelinesEnum.ARRAY_IMPUTATION.getValue() + "_v" + TestUtils.TEST_PIPELINE_VERSION_1,
             TestUtils.TEST_NEW_UUID.toString()))
         .thenReturn(entity);
     when(pipelineInputsOutputsService.extractPipelineOutputsFromEntity(
@@ -89,7 +89,7 @@ class FetchOutputsFromDataTableStepTest extends BaseEmbeddedDbTest {
             "thisToken",
             TestUtils.CONTROL_WORKSPACE_BILLING_PROJECT,
             TestUtils.CONTROL_WORKSPACE_NAME,
-            PipelinesEnum.ARRAY_IMPUTATION.getValue(),
+            PipelinesEnum.ARRAY_IMPUTATION.getValue() + "_v" + TestUtils.TEST_PIPELINE_VERSION_1,
             TestUtils.TEST_NEW_UUID.toString()))
         .thenThrow(new RawlsServiceApiException("Rawls Service Api Exception"));
 
@@ -115,7 +115,7 @@ class FetchOutputsFromDataTableStepTest extends BaseEmbeddedDbTest {
             "thisToken",
             TestUtils.CONTROL_WORKSPACE_BILLING_PROJECT,
             TestUtils.CONTROL_WORKSPACE_NAME,
-            PipelinesEnum.ARRAY_IMPUTATION.getValue(),
+            PipelinesEnum.ARRAY_IMPUTATION.getValue() + "_v" + TestUtils.TEST_PIPELINE_VERSION_1,
             TestUtils.TEST_NEW_UUID.toString()))
         .thenReturn(entity);
     when(pipelineInputsOutputsService.extractPipelineOutputsFromEntity(

--- a/service/src/test/java/bio/terra/pipelines/stairway/steps/common/SubmitCromwellSubmissionStepTest.java
+++ b/service/src/test/java/bio/terra/pipelines/stairway/steps/common/SubmitCromwellSubmissionStepTest.java
@@ -115,7 +115,7 @@ class SubmitCromwellSubmissionStepTest extends BaseEmbeddedDbTest {
         .thenReturn(returnedMethodConfiguration);
     when(rawlsService.validateMethodConfig(
             returnedMethodConfiguration,
-            PipelinesEnum.ARRAY_IMPUTATION.getValue(),
+            PipelinesEnum.ARRAY_IMPUTATION.getValue() + "_v" + TestUtils.TEST_PIPELINE_VERSION_1,
             toolConfig.methodName(),
             toolConfig.inputDefinitions(),
             toolConfig.outputDefinitions(),
@@ -123,7 +123,10 @@ class SubmitCromwellSubmissionStepTest extends BaseEmbeddedDbTest {
         .thenReturn(false);
     when(rawlsService.updateMethodConfigToBeValid(
             updateMethodConfigCaptor.capture(),
-            eq(PipelinesEnum.ARRAY_IMPUTATION.getValue()),
+            eq(
+                PipelinesEnum.ARRAY_IMPUTATION.getValue()
+                    + "_v"
+                    + TestUtils.TEST_PIPELINE_VERSION_1),
             eq(toolConfig.methodName()),
             eq(toolConfig.inputDefinitions()),
             eq(toolConfig.outputDefinitions()),

--- a/service/src/test/java/bio/terra/pipelines/stairway/steps/imputation/PrepareImputationInputsStepTest.java
+++ b/service/src/test/java/bio/terra/pipelines/stairway/steps/imputation/PrepareImputationInputsStepTest.java
@@ -70,6 +70,7 @@ class PrepareImputationInputsStepTest extends BaseEmbeddedDbTest {
     StairwayTestUtils.constructCreateJobInputs(
         flightContext.getInputParameters(),
         PipelinesEnum.ARRAY_IMPUTATION,
+        TestUtils.TEST_PIPELINE_VERSION_1,
         1L,
         TestUtils.TEST_USER_ID_1,
         TestUtils.TEST_PIPELINE_INPUTS_ARRAY_IMPUTATION,

--- a/service/src/test/java/bio/terra/pipelines/testutils/StairwayTestUtils.java
+++ b/service/src/test/java/bio/terra/pipelines/testutils/StairwayTestUtils.java
@@ -34,6 +34,7 @@ public class StairwayTestUtils {
       StairwayTestUtils.constructCreateJobInputs(
           TestUtils.TEST_PIPELINE_1_IMPUTATION_ENUM,
           TestUtils.TEST_PIPELINE_ID_1,
+          TestUtils.TEST_PIPELINE_VERSION_1,
           TestUtils.TEST_USER_ID_1,
           TestUtils.TEST_PIPELINE_INPUTS_ARRAY_IMPUTATION,
           TestUtils.CONTROL_WORKSPACE_BILLING_PROJECT,
@@ -133,6 +134,7 @@ public class StairwayTestUtils {
   public static FlightMap constructCreateJobInputs(
       PipelinesEnum pipelineName,
       Long pipelineId,
+      Integer pipelineVersion,
       String userId,
       Object pipelineInputs,
       String controlWorkspaceBillingProject,
@@ -147,6 +149,7 @@ public class StairwayTestUtils {
     return constructCreateJobInputs(
         inputParameters,
         pipelineName,
+        pipelineVersion,
         pipelineId,
         userId,
         pipelineInputs,
@@ -163,6 +166,7 @@ public class StairwayTestUtils {
   public static FlightMap constructCreateJobInputs(
       FlightMap inputParameters,
       PipelinesEnum pipelineName,
+      Integer pipelineVersion,
       Long pipelineId,
       String userId,
       Object pipelineInputs,
@@ -176,6 +180,7 @@ public class StairwayTestUtils {
       ToolConfig inputQcToolConfig) {
     inputParameters.put(JobMapKeys.USER_ID, userId);
     inputParameters.put(JobMapKeys.PIPELINE_NAME, pipelineName);
+    inputParameters.put(JobMapKeys.PIPELINE_VERSION, pipelineVersion);
     inputParameters.put(JobMapKeys.DESCRIPTION, TEST_DESCRIPTION);
     inputParameters.put(JobMapKeys.DOMAIN_NAME, domainName);
     inputParameters.put(JobMapKeys.PIPELINE_ID, pipelineId);
@@ -203,6 +208,7 @@ public class StairwayTestUtils {
     return constructCreateJobInputs(
         inputParameters,
         PipelinesEnum.ARRAY_IMPUTATION,
+        TestUtils.TEST_PIPELINE_VERSION_1,
         TestUtils.TEST_PIPELINE_ID_1,
         TestUtils.TEST_USER_ID_1,
         TestUtils.TEST_PIPELINE_INPUTS_ARRAY_IMPUTATION,


### PR DESCRIPTION
### Description 
Doing some pre work for when we have multiple versions per pipeline.  This PR add the version to the data table entity name and the related changes for that to work.

I tested running workflows with the old flight, killing the server, updating the code, then running the server.  If the old flight was passt the modified steps, it succeeded.  If the old flight was stopped beore the modified steps, then it failed when it got to those steps

### Jira Ticket

https://broadworkbench.atlassian.net/browse/TSPS-641

### Checklist (provide links to changes)

- [ ] Updated external documentation (if applicable)
- [ ] Updated internal documentation (if applicable)
- [ ] Planned non patch version bump (if applicable)
- [ ] Updated CLI PR (if applicable)
