### PR TITLE
TSPS-732 Add new output signed URLs endpoint, remove signed URLs from result endpoint

### DIFF
--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -201,6 +201,7 @@ paths:
       summary: Retrieve result for a specified pipeline run
       operationId: getPipelineRunResult
       tags: [ pipelineRuns ]
+      deprecated: true
       responses:
         200:
           description: PipelineRun is complete (succeeded or failed)
@@ -288,7 +289,7 @@ paths:
         500:
           $ref: '#/components/responses/ServerError'
 
-  /api/pipelineruns/v1/result/{jobId}/output/signed-urls:
+  /api/pipelineruns/v2/result/{jobId}/output/signed-urls:
     parameters:
       - $ref: '#/components/parameters/JobId'
     get:

--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -887,17 +887,6 @@ components:
       type: string
       format: uuid
 
-    InputSize:
-      description: |
-        The detected size of the user's inputs
-      type: integer
-
-    InputSizeUnits:
-      description: |
-        The unit for the detected size of the user's inputs
-      type: string
-      format: string
-
     JobStatus:
       description: |
         The current status of the job.

--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -178,13 +178,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AsyncPipelineRunResponse'
+                $ref: '#/components/schemas/AsyncPipelineRunResponseV2'
         202:
           description: PipelineRun is running
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AsyncPipelineRunResponse'
+                $ref: '#/components/schemas/AsyncPipelineRunResponseV2'
         400:
           $ref: '#/components/responses/BadRequest'
         403:

--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -241,6 +241,88 @@ paths:
         500:
           $ref: '#/components/responses/ServerError'
 
+  /api/pipelineruns/v2/result/{jobId}:
+    parameters:
+      - $ref: '#/components/parameters/JobId'
+    get:
+      summary: Retrieve result for a specified pipeline run
+      operationId: getPipelineRunResultV2
+      tags: [ pipelineRuns ]
+      responses:
+        200:
+          description: PipelineRun is complete (succeeded or failed)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AsyncPipelineRunResponseV2'
+        202:
+          description: PipelineRun is running
+          headers:
+            Retry-After:
+              description: >-
+                optional - estimated seconds to wait before polling again. This allows a server to offer a hint as to when the job might be complete.
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AsyncPipelineRunResponseV2'
+        400:
+          description: Bad request - invalid id, id not for a createPipelineRunRequest job
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        403:
+          description: No permission to see job
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        404:
+          description: Not found - job id does not exist
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        500:
+          $ref: '#/components/responses/ServerError'
+
+  /api/pipelineruns/v1/result/{jobId}/output/signed-urls:
+    parameters:
+      - $ref: '#/components/parameters/JobId'
+    get:
+      summary: Retrieve signed URLs to download available pipeline output files for a specified pipeline run
+      operationId: getPipelineRunOutputSignedUrls
+      tags: [ pipelineRuns ]
+      responses:
+        200:
+          description: PipelineRun results found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PipelineRunOutputSignedUrlsResponse'
+        400:
+          description: Bad request - invalid id, id not for a createPipelineRunRequest job, job state is not SUCCEEDED
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        403:
+          description: No permission to see job
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        404:
+          description: Not found - job id does not exist
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        500:
+          $ref: '#/components/responses/ServerError'
+
   /api/pipelineruns/v1/pipelineruns:
     get:
       tags: [ pipelineRuns ]
@@ -428,27 +510,27 @@ components:
       description: The page number to return. Default 1.
       required: false
       schema:
-          type: integer
-          minimum: 1
-          default: 1
+        type: integer
+        minimum: 1
+        default: 1
 
     SortProperty:
-        name: sortProperty
-        in: query
-        description: The property to sort on. Default id.
-        required: false
-        schema:
-            type: string
+      name: sortProperty
+      in: query
+      description: The property to sort on. Default id.
+      required: false
+      schema:
+        type: string
 
     SortDirection:
-        name: sortDirection
-        in: query
-        description: The direction to sort. Default desc.
-        required: false
-        schema:
-            type: string
-            enum: [ 'ASC', 'DESC' ]
-            default: 'DESC'
+      name: sortDirection
+      in: query
+      description: The direction to sort. Default desc.
+      required: false
+      schema:
+        type: string
+        enum: [ 'ASC', 'DESC' ]
+        default: 'DESC'
 
     PageToken:
       name: pageToken
@@ -720,6 +802,18 @@ components:
         pipelineRunReport:
           $ref: '#/components/schemas/PipelineRunReport'
 
+    AsyncPipelineRunResponseV2:
+      description: Result of an asynchronous pipeline run request.
+      type: object
+      required: [ jobReport, pipelineRunReport ]
+      properties:
+        jobReport:
+          $ref: '#/components/schemas/JobReport'
+        errorReport:
+          $ref: '#/components/schemas/ErrorReport'
+        pipelineRunReport:
+          $ref: '#/components/schemas/PipelineRunReportV2'
+
     DefaultQuota:
       description: |
         Default quota for the pipeline.
@@ -792,6 +886,17 @@ components:
         Required unique identifier (UUID) for a job.
       type: string
       format: uuid
+
+    InputSize:
+      description: |
+        The detected size of the user's inputs
+      type: integer
+
+    InputSizeUnits:
+      description: |
+        The unit for the detected size of the user's inputs
+      type: string
+      format: string
 
     JobStatus:
       description: |
@@ -962,19 +1067,19 @@ components:
       format: string
 
     PipelineQuota:
-        description: |
-            The quota for the pipeline.
-        type: object
-        required: [ pipelineName, defaultQuota, minQuotaConsumed, quotaUnits ]
-        properties:
-          pipelineName:
-            $ref: "#/components/schemas/PipelineName"
-          defaultQuota:
-            $ref: "#/components/schemas/DefaultQuota"
-          minQuotaConsumed:
-            $ref: "#/components/schemas/MinimumQuotaConsumed"
-          quotaUnits:
-            $ref: "#/components/schemas/QuotaUnits"
+      description: |
+        The quota for the pipeline.
+      type: object
+      required: [ pipelineName, defaultQuota, minQuotaConsumed, quotaUnits ]
+      properties:
+        pipelineName:
+          $ref: "#/components/schemas/PipelineName"
+        defaultQuota:
+          $ref: "#/components/schemas/DefaultQuota"
+        minQuotaConsumed:
+          $ref: "#/components/schemas/MinimumQuotaConsumed"
+        quotaUnits:
+          $ref: "#/components/schemas/QuotaUnits"
 
     PipelineRun:
       description: |
@@ -1022,6 +1127,27 @@ components:
         userInputs:
           $ref: "#/components/schemas/PipelineUserProvidedInputs"
         outputs:
+          $ref: "#/components/schemas/PipelineRunOutputSignedUrls"
+        outputExpirationDate:
+          $ref: "#/components/schemas/PipelineOutputExpirationDate"
+        quotaConsumed:
+          $ref: "#/components/schemas/QuotaConsumed"
+
+    PipelineRunReportV2:
+      description: |
+        Object containing metadata about the pipeline that was run, as well as pipeline run outputs if the run has completed successfully.
+      type: object
+      required: [ pipelineName, pipelineVersion, toolVersion, userInputs ]
+      properties:
+        pipelineName:
+          $ref: "#/components/schemas/PipelineName"
+        pipelineVersion:
+          $ref: "#/components/schemas/PipelineVersion"
+        toolVersion:
+          $ref: "#/components/schemas/PipelineToolVersion"
+        userInputs:
+          $ref: "#/components/schemas/PipelineUserProvidedInputs"
+        outputs:
           $ref: "#/components/schemas/PipelineRunOutputs"
         outputExpirationDate:
           $ref: "#/components/schemas/PipelineOutputExpirationDate"
@@ -1041,6 +1167,26 @@ components:
       additionalProperties:
         $ref: "#/components/schemas/AnyTypeMapsToJavaObject"
 
+    PipelineRunOutputSignedUrls:
+      description: |
+        Signed URLs to download pipeline output files.
+      type: object
+      additionalProperties:
+        $ref: "#/components/schemas/AnyTypeMapsToJavaObject"
+
+    PipelineRunOutputSignedUrlsResponse:
+      description: |
+        Signed URLs to download pipeline output files for a specified pipeline run.
+      type: object
+      required: [ jobId, outputExpirationDate ]
+      properties:
+        jobId:
+          $ref: '#/components/schemas/Id'
+        outputSignedUrls:
+          $ref: '#/components/schemas/PipelineRunOutputSignedUrls'
+        outputExpirationDate:
+          $ref: "#/components/schemas/PipelineOutputExpirationDate"
+
     PipelineToolVersion:
       description: |
         An identifier string for the Pipeline Tool Version i.e. github repo tag/branch/release
@@ -1048,7 +1194,7 @@ components:
 
     PipelineType:
       description: |
-          The general type of the Pipeline.
+        The general type of the Pipeline.
       type: string
       format: string
 
@@ -1069,13 +1215,13 @@ components:
         isRequired:
           $ref: "#/components/schemas/PipelineInputIsRequired"
         defaultValue:
-            $ref: "#/components/schemas/PipelineInputDefaultValue"
+          $ref: "#/components/schemas/PipelineInputDefaultValue"
         fileSuffix:
           $ref: "#/components/schemas/PipelineInputFileSuffix"
         minValue:
           $ref: "#/components/schemas/PipelineInputMinimumValue"
         maxValue:
-            $ref: "#/components/schemas/PipelineInputMaximumValue"
+          $ref: "#/components/schemas/PipelineInputMaximumValue"
 
     PipelineUserProvidedInputDefinitions:
       description: |
@@ -1122,7 +1268,7 @@ components:
 
     PipelineWorkspaceStorageContainerName:
       description: |
-          The name of the workspace storage container (e.g. google bucket name, without gs:// prefix).
+        The name of the workspace storage container (e.g. google bucket name, without gs:// prefix).
       type: string
       format: string
 
@@ -1169,18 +1315,18 @@ components:
           $ref: "#/components/schemas/UseResumableUploads"
 
     PreparePipelineRunResponse:
-        description: Result of the preparePipelineRun request, containing signed URLs to upload input files
-        type: object
-        required: [ jobId, fileInputUploadUrls ]
-        properties:
-            jobId:
-              $ref: '#/components/schemas/Id'
-            fileInputUploadUrls:
-              type: object
-              additionalProperties:
-                type: object
-                additionalProperties:
-                  type: string
+      description: Result of the preparePipelineRun request, containing signed URLs to upload input files
+      type: object
+      required: [ jobId, fileInputUploadUrls ]
+      properties:
+        jobId:
+          $ref: '#/components/schemas/Id'
+        fileInputUploadUrls:
+          type: object
+          additionalProperties:
+            type: object
+            additionalProperties:
+              type: string
 
     QuotaConsumed:
       description: |
@@ -1271,5 +1417,5 @@ components:
 
 security:
   - oidc:
-       - openid
+      - openid
   - bearerAuth: [ ]

--- a/service/src/main/java/bio/terra/pipelines/app/controller/PipelineRunsApiController.java
+++ b/service/src/main/java/bio/terra/pipelines/app/controller/PipelineRunsApiController.java
@@ -141,7 +141,7 @@ public class PipelineRunsApiController implements PipelineRunsApi {
    *     and result URL. The response also includes an error report if the job failed.
    */
   @Override
-  public ResponseEntity<ApiAsyncPipelineRunResponse> startPipelineRun(
+  public ResponseEntity<ApiAsyncPipelineRunResponseV2> startPipelineRun(
       @RequestBody ApiStartPipelineRunRequestBody body) {
     final SamUser userRequest = getAuthenticatedInfo();
     String userId = userRequest.getSubjectId();
@@ -170,8 +170,8 @@ public class PipelineRunsApiController implements PipelineRunsApi {
     PipelineRun pipelineRunAfterStart =
         pipelineRunsService.startPipelineRun(pipeline, jobId, userId);
 
-    ApiAsyncPipelineRunResponse createdRunResponse =
-        pipelineRunToApi(pipelineRunAfterStart, pipeline);
+    ApiAsyncPipelineRunResponseV2 createdRunResponse =
+        pipelineRunToApiV2(pipelineRunAfterStart, pipeline);
 
     return new ResponseEntity<>(
         createdRunResponse, getAsyncResponseCode(createdRunResponse.getJobReport()));

--- a/service/src/main/java/bio/terra/pipelines/app/controller/PipelineRunsApiController.java
+++ b/service/src/main/java/bio/terra/pipelines/app/controller/PipelineRunsApiController.java
@@ -54,7 +54,7 @@ public class PipelineRunsApiController implements PipelineRunsApi {
   private final IngressConfiguration ingressConfiguration;
   private final PipelineConfigurations pipelinesConfigurations;
 
-  private final String pipelineRunNotFoundMessage = "Pipeline run %s not found";
+  private static final String pipelineRunNotFoundMessage = "Pipeline run %s not found";
 
   @Autowired
   public PipelineRunsApiController(

--- a/service/src/main/java/bio/terra/pipelines/app/controller/PipelineRunsApiController.java
+++ b/service/src/main/java/bio/terra/pipelines/app/controller/PipelineRunsApiController.java
@@ -54,6 +54,8 @@ public class PipelineRunsApiController implements PipelineRunsApi {
   private final IngressConfiguration ingressConfiguration;
   private final PipelineConfigurations pipelinesConfigurations;
 
+  private final String pipelineRunNotFoundMessage = "Pipeline run %s not found";
+
   @Autowired
   public PipelineRunsApiController(
       SamConfiguration samConfiguration,
@@ -175,6 +177,14 @@ public class PipelineRunsApiController implements PipelineRunsApi {
         createdRunResponse, getAsyncResponseCode(createdRunResponse.getJobReport()));
   }
 
+  /**
+   * Retrieves the result of a pipeline run, including job report, error report (if any), and
+   * pipeline run report, including signed urls for outputs if available.
+   *
+   * @param jobId the ID of the job to retrieve
+   * @return the pipeline run result
+   * @deprecated use getPipelineRunResultV2
+   */
   @Deprecated(since = "2.0.0")
   @Override
   public ResponseEntity<ApiAsyncPipelineRunResponse> getPipelineRunResult(
@@ -184,7 +194,7 @@ public class PipelineRunsApiController implements PipelineRunsApi {
 
     PipelineRun pipelineRun = pipelineRunsService.getPipelineRun(jobId, userId);
     if (pipelineRun == null) {
-      throw new NotFoundException("Pipeline run %s not found".formatted(jobId));
+      throw new NotFoundException(pipelineRunNotFoundMessage.formatted(jobId));
     }
 
     if (pipelineRun.getStatus().equals(CommonPipelineRunStatusEnum.PREPARING)) {
@@ -200,6 +210,13 @@ public class PipelineRunsApiController implements PipelineRunsApi {
     return new ResponseEntity<>(runResponse, getAsyncResponseCode(runResponse.getJobReport()));
   }
 
+  /**
+   * Retrieves the result of a pipeline run, including job report, error report (if any), and
+   * pipeline run report.
+   *
+   * @param jobId the ID of the job to retrieve
+   * @return the pipeline run result
+   */
   @Override
   public ResponseEntity<ApiAsyncPipelineRunResponseV2> getPipelineRunResultV2(
       @PathVariable("jobId") UUID jobId) {
@@ -208,7 +225,7 @@ public class PipelineRunsApiController implements PipelineRunsApi {
 
     PipelineRun pipelineRun = pipelineRunsService.getPipelineRun(jobId, userId);
     if (pipelineRun == null) {
-      throw new NotFoundException("Pipeline run %s not found".formatted(jobId));
+      throw new NotFoundException(pipelineRunNotFoundMessage.formatted(jobId));
     }
 
     if (pipelineRun.getStatus().equals(CommonPipelineRunStatusEnum.PREPARING)) {
@@ -232,7 +249,7 @@ public class PipelineRunsApiController implements PipelineRunsApi {
 
     PipelineRun pipelineRun = pipelineRunsService.getPipelineRun(jobId, userId);
     if (pipelineRun == null) {
-      throw new NotFoundException("Pipeline run %s not found".formatted(jobId));
+      throw new NotFoundException(pipelineRunNotFoundMessage.formatted(jobId));
     }
 
     if (!pipelineRun.getStatus().equals(CommonPipelineRunStatusEnum.SUCCEEDED)) {

--- a/service/src/main/java/bio/terra/pipelines/app/controller/PipelineRunsApiController.java
+++ b/service/src/main/java/bio/terra/pipelines/app/controller/PipelineRunsApiController.java
@@ -237,7 +237,7 @@ public class PipelineRunsApiController implements PipelineRunsApi {
 
     if (!pipelineRun.getStatus().equals(CommonPipelineRunStatusEnum.SUCCEEDED)) {
       throw new BadRequestException(
-          "Pipeline run %s has state %s; signed URLs can only be retrieved for complete and successful runs"
+          "Pipeline run %s has state %s; output signed URLs can only be retrieved for complete and successful runs"
               .formatted(jobId, pipelineRun.getStatus()));
     }
 

--- a/service/src/main/java/bio/terra/pipelines/service/PipelineInputsOutputsService.java
+++ b/service/src/main/java/bio/terra/pipelines/service/PipelineInputsOutputsService.java
@@ -16,6 +16,7 @@ import bio.terra.pipelines.db.entities.PipelineRun;
 import bio.terra.pipelines.db.repositories.PipelineInputsRepository;
 import bio.terra.pipelines.db.repositories.PipelineOutputsRepository;
 import bio.terra.pipelines.dependencies.gcs.GcsService;
+import bio.terra.pipelines.generated.model.ApiPipelineRunOutputSignedUrls;
 import bio.terra.pipelines.generated.model.ApiPipelineRunOutputs;
 import bio.terra.rawls.model.Entity;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -437,13 +438,30 @@ public class PipelineInputsOutputsService {
   }
 
   /**
+   * Retrieve the pipeline outputs from a pipelineRun object and return an ApiPipelineRunOutputs
+   * object containing the outputs.
+   *
+   * @param pipelineRun object from the pipelineRunsRepository
+   * @return ApiPipelineRunOutputs
+   */
+  public ApiPipelineRunOutputs getPipelineRunOutputs(PipelineRun pipelineRun) {
+    Map<String, Object> outputsMap =
+        stringToMap(
+            pipelineOutputsRepository.findPipelineOutputsByJobId(pipelineRun.getId()).getOutputs());
+
+    ApiPipelineRunOutputs apiPipelineRunOutputs = new ApiPipelineRunOutputs();
+    apiPipelineRunOutputs.putAll(outputsMap);
+    return apiPipelineRunOutputs;
+  }
+
+  /**
    * Extract the pipeline outputs from a pipelineRun object, create signed GET (read-only) urls for
    * each file, and return an ApiPipelineRunOutputs object with the outputs.
    *
    * @param pipelineRun object from the pipelineRunsRepository
    * @return ApiPipelineRunOutputs
    */
-  public ApiPipelineRunOutputs formatPipelineRunOutputs(PipelineRun pipelineRun) {
+  public ApiPipelineRunOutputSignedUrls formatPipelineRunOutputSignedUrls(PipelineRun pipelineRun) {
     Map<String, Object> outputsMap =
         stringToMap(
             pipelineOutputsRepository.findPipelineOutputsByJobId(pipelineRun.getId()).getOutputs());
@@ -460,9 +478,10 @@ public class PipelineInputsOutputsService {
                         (String) v, workspaceStorageContainerName))
                 .toString());
 
-    ApiPipelineRunOutputs apiPipelineRunOutputs = new ApiPipelineRunOutputs();
-    apiPipelineRunOutputs.putAll(outputsMap);
-    return apiPipelineRunOutputs;
+    ApiPipelineRunOutputSignedUrls apiPipelineRunOutputSignedUrls =
+        new ApiPipelineRunOutputSignedUrls();
+    apiPipelineRunOutputSignedUrls.putAll(outputsMap);
+    return apiPipelineRunOutputSignedUrls;
   }
 
   /** Convert pipelineOutputs map to string and save to the pipelineOutputs table */

--- a/service/src/main/java/bio/terra/pipelines/service/PipelineInputsOutputsService.java
+++ b/service/src/main/java/bio/terra/pipelines/service/PipelineInputsOutputsService.java
@@ -461,8 +461,8 @@ public class PipelineInputsOutputsService {
 
     outputsMap.replaceAll(
         (key, value) ->
-            fileOutputNames.contains(key) && value instanceof String
-                ? getFileNameFromFullPath((String) value)
+            fileOutputNames.contains(key) && value instanceof String stringValue
+                ? getFileNameFromFullPath(stringValue)
                 : value);
 
     ApiPipelineRunOutputs apiPipelineRunOutputs = new ApiPipelineRunOutputs();

--- a/service/src/main/java/bio/terra/pipelines/service/PipelineInputsOutputsService.java
+++ b/service/src/main/java/bio/terra/pipelines/service/PipelineInputsOutputsService.java
@@ -461,9 +461,7 @@ public class PipelineInputsOutputsService {
 
     outputsMap.replaceAll(
         (key, value) ->
-            fileOutputNames.contains(key) && value instanceof String stringValue
-                ? getFileNameFromFullPath(stringValue)
-                : value);
+            fileOutputNames.contains(key) ? getFileNameFromFullPath((String) value) : value);
 
     ApiPipelineRunOutputs apiPipelineRunOutputs = new ApiPipelineRunOutputs();
     apiPipelineRunOutputs.putAll(outputsMap);

--- a/service/src/test/java/bio/terra/pipelines/controller/PipelineRunsApiControllerTest.java
+++ b/service/src/test/java/bio/terra/pipelines/controller/PipelineRunsApiControllerTest.java
@@ -506,232 +506,240 @@ class PipelineRunsApiControllerTest {
   }
 
   // getPipelineRunResult tests
+  @Nested
+  @Deprecated
+  @DisplayName("getPipelineRunResult V1 tests")
+  class GetPipelineRunResultV1Tests {
+    @Test
+    void getPipelineRunResultDoneSuccess() throws Exception {
+      String pipelineName = PipelinesEnum.ARRAY_IMPUTATION.getValue();
+      String jobIdString = newJobId.toString();
+      PipelineRun pipelineRun =
+          getPipelineRunWithStatusAndQuotaConsumed(
+              CommonPipelineRunStatusEnum.SUCCEEDED, testQuotaConsumed, testRawQuotaConsumed);
+      ApiPipelineRunOutputSignedUrls apiPipelineRunOutputs = new ApiPipelineRunOutputSignedUrls();
+      apiPipelineRunOutputs.putAll(testOutputs);
 
-  @Test
-  void getPipelineRunResultDoneSuccess() throws Exception {
-    String pipelineName = PipelinesEnum.ARRAY_IMPUTATION.getValue();
-    String jobIdString = newJobId.toString();
-    PipelineRun pipelineRun =
-        getPipelineRunWithStatusAndQuotaConsumed(
-            CommonPipelineRunStatusEnum.SUCCEEDED, testQuotaConsumed, testRawQuotaConsumed);
-    ApiPipelineRunOutputs apiPipelineRunOutputs = new ApiPipelineRunOutputs();
-    apiPipelineRunOutputs.putAll(testOutputs);
+      // the mocks - note we don't do anything with Stairway because all our info should be in our
+      // own
+      // db
+      when(pipelineRunsServiceMock.getPipelineRun(newJobId, testUser.getSubjectId()))
+          .thenReturn(pipelineRun);
+      when(pipelineInputsOutputsServiceMock.formatPipelineRunOutputSignedUrls(pipelineRun))
+          .thenReturn(apiPipelineRunOutputs);
 
-    // the mocks - note we don't do anything with Stairway because all our info should be in our own
-    // db
-    when(pipelineRunsServiceMock.getPipelineRun(newJobId, testUser.getSubjectId()))
-        .thenReturn(pipelineRun);
-    when(pipelineInputsOutputsServiceMock.formatPipelineRunOutputs(pipelineRun))
-        .thenReturn(apiPipelineRunOutputs);
+      MvcResult result =
+          mockMvc
+              .perform(get(String.format("/api/pipelineruns/v1/result/%s", jobIdString)))
+              .andExpect(status().isOk())
+              .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+              .andReturn();
 
-    MvcResult result =
-        mockMvc
-            .perform(get(String.format("/api/pipelineruns/v1/result/%s", jobIdString)))
-            .andExpect(status().isOk())
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-            .andReturn();
+      ApiAsyncPipelineRunResponse response =
+          new ObjectMapper()
+              .readValue(
+                  result.getResponse().getContentAsString(), ApiAsyncPipelineRunResponse.class);
+      ApiPipelineRunReport pipelineRunReportResponse = response.getPipelineRunReport();
 
-    ApiAsyncPipelineRunResponse response =
-        new ObjectMapper()
-            .readValue(
-                result.getResponse().getContentAsString(), ApiAsyncPipelineRunResponse.class);
-    ApiPipelineRunReport pipelineRunReportResponse = response.getPipelineRunReport();
+      // response should include the job report and pipeline run report including the outputs object
+      assertEquals(newJobId.toString(), response.getJobReport().getId());
+      assertEquals(ApiJobReport.StatusEnum.SUCCEEDED, response.getJobReport().getStatus());
+      assertEquals(createdTime.toString(), response.getJobReport().getSubmitted());
+      assertEquals(updatedTime.toString(), response.getJobReport().getCompleted());
+      assertEquals(pipelineName, pipelineRunReportResponse.getPipelineName());
+      assertEquals(testPipelineVersion, pipelineRunReportResponse.getPipelineVersion());
+      assertEquals(testPipelineToolVersion, pipelineRunReportResponse.getToolVersion());
+      assertEquals(testOutputs, pipelineRunReportResponse.getOutputs());
+      assertEquals(
+          updatedTime.plus(userDataTtlDays, ChronoUnit.DAYS).toString(),
+          pipelineRunReportResponse.getOutputExpirationDate());
+      assertNull(response.getErrorReport());
+    }
 
-    // response should include the job report and pipeline run report including the outputs object
-    assertEquals(newJobId.toString(), response.getJobReport().getId());
-    assertEquals(ApiJobReport.StatusEnum.SUCCEEDED, response.getJobReport().getStatus());
-    assertEquals(createdTime.toString(), response.getJobReport().getSubmitted());
-    assertEquals(updatedTime.toString(), response.getJobReport().getCompleted());
-    assertEquals(pipelineName, pipelineRunReportResponse.getPipelineName());
-    assertEquals(testPipelineVersion, pipelineRunReportResponse.getPipelineVersion());
-    assertEquals(testPipelineToolVersion, pipelineRunReportResponse.getToolVersion());
-    assertEquals(testOutputs, pipelineRunReportResponse.getOutputs());
-    assertEquals(
-        updatedTime.plus(userDataTtlDays, ChronoUnit.DAYS).toString(),
-        pipelineRunReportResponse.getOutputExpirationDate());
-    assertNull(response.getErrorReport());
-  }
+    @Test
+    void getPipelineRunResultDoneSuccessExpiredOutputs() throws Exception {
+      String jobIdString = newJobId.toString();
+      PipelineRun pipelineRun =
+          getPipelineRunWithStatusAndQuotaConsumed(
+              CommonPipelineRunStatusEnum.SUCCEEDED, testQuotaConsumed, testRawQuotaConsumed);
+      // set the updated time to 1 day ago so that the outputs are expired
+      pipelineRun.setUpdated(updatedTime.minus(userDataTtlDays + 1L, ChronoUnit.DAYS));
+      ApiPipelineRunOutputSignedUrls apiPipelineRunOutputs = new ApiPipelineRunOutputSignedUrls();
+      apiPipelineRunOutputs.putAll(testOutputs);
 
-  @Test
-  void getPipelineRunResultDoneSuccessExpiredOutputs() throws Exception {
-    String jobIdString = newJobId.toString();
-    PipelineRun pipelineRun =
-        getPipelineRunWithStatusAndQuotaConsumed(
-            CommonPipelineRunStatusEnum.SUCCEEDED, testQuotaConsumed, testRawQuotaConsumed);
-    // set the updated time to 1 day ago so that the outputs are expired
-    pipelineRun.setUpdated(updatedTime.minus(userDataTtlDays + 1L, ChronoUnit.DAYS));
-    ApiPipelineRunOutputs apiPipelineRunOutputs = new ApiPipelineRunOutputs();
-    apiPipelineRunOutputs.putAll(testOutputs);
+      // the mocks - note we don't do anything with Stairway because all our info should be in our
+      // db
+      when(pipelineRunsServiceMock.getPipelineRun(newJobId, testUser.getSubjectId()))
+          .thenReturn(pipelineRun);
+      when(pipelineInputsOutputsServiceMock.formatPipelineRunOutputSignedUrls(pipelineRun))
+          .thenReturn(apiPipelineRunOutputs);
 
-    // the mocks - note we don't do anything with Stairway because all our info should be in our db
-    when(pipelineRunsServiceMock.getPipelineRun(newJobId, testUser.getSubjectId()))
-        .thenReturn(pipelineRun);
-    when(pipelineInputsOutputsServiceMock.formatPipelineRunOutputs(pipelineRun))
-        .thenReturn(apiPipelineRunOutputs);
+      MvcResult result =
+          mockMvc
+              .perform(get(String.format("/api/pipelineruns/v1/result/%s", jobIdString)))
+              .andExpect(status().isOk())
+              .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+              .andReturn();
 
-    MvcResult result =
-        mockMvc
-            .perform(get(String.format("/api/pipelineruns/v1/result/%s", jobIdString)))
-            .andExpect(status().isOk())
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-            .andReturn();
+      ApiAsyncPipelineRunResponse response =
+          new ObjectMapper()
+              .readValue(
+                  result.getResponse().getContentAsString(), ApiAsyncPipelineRunResponse.class);
+      ApiPipelineRunReport pipelineRunReportResponse = response.getPipelineRunReport();
 
-    ApiAsyncPipelineRunResponse response =
-        new ObjectMapper()
-            .readValue(
-                result.getResponse().getContentAsString(), ApiAsyncPipelineRunResponse.class);
-    ApiPipelineRunReport pipelineRunReportResponse = response.getPipelineRunReport();
+      // response should not include outputs because it is past the output expiration date
+      assertNull(pipelineRunReportResponse.getOutputs());
+    }
 
-    // response should not include outputs because it is past the output expiration date
-    assertNull(pipelineRunReportResponse.getOutputs());
-  }
+    @Test
+    void getPipelineRunResultDoneFailed() throws Exception {
+      String pipelineName = PipelinesEnum.ARRAY_IMPUTATION.getValue();
+      String jobIdString = newJobId.toString();
+      String errorMessage = "test exception message";
+      Integer statusCode = 500;
+      PipelineRun pipelineRun =
+          getPipelineRunWithStatusAndQuotaConsumed(CommonPipelineRunStatusEnum.FAILED, null, null);
 
-  @Test
-  void getPipelineRunResultDoneFailed() throws Exception {
-    String pipelineName = PipelinesEnum.ARRAY_IMPUTATION.getValue();
-    String jobIdString = newJobId.toString();
-    String errorMessage = "test exception message";
-    Integer statusCode = 500;
-    PipelineRun pipelineRun =
-        getPipelineRunWithStatusAndQuotaConsumed(CommonPipelineRunStatusEnum.FAILED, null, null);
+      ApiErrorReport errorReport =
+          new ApiErrorReport().message(errorMessage).statusCode(statusCode);
 
-    ApiErrorReport errorReport = new ApiErrorReport().message(errorMessage).statusCode(statusCode);
+      JobApiUtils.AsyncJobResult<String> jobResult =
+          new JobApiUtils.AsyncJobResult<String>()
+              .jobReport(
+                  new ApiJobReport()
+                      .id(newJobId.toString())
+                      .status(ApiJobReport.StatusEnum.FAILED)
+                      .statusCode(statusCode))
+              .errorReport(errorReport);
 
-    JobApiUtils.AsyncJobResult<String> jobResult =
-        new JobApiUtils.AsyncJobResult<String>()
-            .jobReport(
-                new ApiJobReport()
-                    .id(newJobId.toString())
-                    .status(ApiJobReport.StatusEnum.FAILED)
-                    .statusCode(statusCode))
-            .errorReport(errorReport);
+      // the mocks
+      when(pipelineRunsServiceMock.getPipelineRun(newJobId, testUser.getSubjectId()))
+          .thenReturn(pipelineRun);
+      when(jobServiceMock.retrieveAsyncJobResult(
+              newJobId, testUser.getSubjectId(), String.class, null))
+          .thenReturn(jobResult);
 
-    // the mocks
-    when(pipelineRunsServiceMock.getPipelineRun(newJobId, testUser.getSubjectId()))
-        .thenReturn(pipelineRun);
-    when(jobServiceMock.retrieveAsyncJobResult(
-            newJobId, testUser.getSubjectId(), String.class, null))
-        .thenReturn(jobResult);
+      MvcResult result =
+          mockMvc
+              .perform(get(String.format("/api/pipelineruns/v1/result/%s", jobIdString)))
+              .andExpect(status().isOk()) // the call itself should return a 200
+              .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+              .andReturn();
 
-    MvcResult result =
-        mockMvc
-            .perform(get(String.format("/api/pipelineruns/v1/result/%s", jobIdString)))
-            .andExpect(status().isOk()) // the call itself should return a 200
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-            .andReturn();
+      ApiAsyncPipelineRunResponse response =
+          new ObjectMapper()
+              .readValue(
+                  result.getResponse().getContentAsString(), ApiAsyncPipelineRunResponse.class);
+      ApiPipelineRunReport pipelineRunReportResponse = response.getPipelineRunReport();
 
-    ApiAsyncPipelineRunResponse response =
-        new ObjectMapper()
-            .readValue(
-                result.getResponse().getContentAsString(), ApiAsyncPipelineRunResponse.class);
-    ApiPipelineRunReport pipelineRunReportResponse = response.getPipelineRunReport();
+      // response should include the error report and pipeline run report without outputs
+      assertEquals(newJobId.toString(), response.getJobReport().getId());
+      assertEquals(pipelineName, pipelineRunReportResponse.getPipelineName());
+      assertEquals(testPipelineVersion, pipelineRunReportResponse.getPipelineVersion());
+      assertEquals(testPipelineToolVersion, pipelineRunReportResponse.getToolVersion());
+      assertNull(pipelineRunReportResponse.getOutputs());
+      assertEquals(statusCode, response.getJobReport().getStatusCode());
+      assertEquals(errorMessage, response.getErrorReport().getMessage());
+      assertNull(response.getPipelineRunReport().getOutputExpirationDate());
+    }
 
-    // response should include the error report and pipeline run report without outputs
-    assertEquals(newJobId.toString(), response.getJobReport().getId());
-    assertEquals(pipelineName, pipelineRunReportResponse.getPipelineName());
-    assertEquals(testPipelineVersion, pipelineRunReportResponse.getPipelineVersion());
-    assertEquals(testPipelineToolVersion, pipelineRunReportResponse.getToolVersion());
-    assertNull(pipelineRunReportResponse.getOutputs());
-    assertEquals(statusCode, response.getJobReport().getStatusCode());
-    assertEquals(errorMessage, response.getErrorReport().getMessage());
-    assertNull(response.getPipelineRunReport().getOutputExpirationDate());
-  }
+    @Test
+    void getPipelineRunResultRunning() throws Exception {
+      String pipelineName = PipelinesEnum.ARRAY_IMPUTATION.getValue();
+      String jobIdString = newJobId.toString();
+      Integer statusCode = 202;
+      PipelineRun pipelineRun = getPipelineRunRunning();
+      JobApiUtils.AsyncJobResult<String> jobResult =
+          new JobApiUtils.AsyncJobResult<String>()
+              .jobReport(
+                  new ApiJobReport()
+                      .id(newJobId.toString())
+                      .status(ApiJobReport.StatusEnum.RUNNING)
+                      .statusCode(statusCode));
 
-  @Test
-  void getPipelineRunResultRunning() throws Exception {
-    String pipelineName = PipelinesEnum.ARRAY_IMPUTATION.getValue();
-    String jobIdString = newJobId.toString();
-    Integer statusCode = 202;
-    PipelineRun pipelineRun = getPipelineRunRunning();
-    JobApiUtils.AsyncJobResult<String> jobResult =
-        new JobApiUtils.AsyncJobResult<String>()
-            .jobReport(
-                new ApiJobReport()
-                    .id(newJobId.toString())
-                    .status(ApiJobReport.StatusEnum.RUNNING)
-                    .statusCode(statusCode));
+      // the mocks
+      when(pipelineRunsServiceMock.getPipelineRun(newJobId, testUser.getSubjectId()))
+          .thenReturn(pipelineRun);
+      when(jobServiceMock.retrieveAsyncJobResult(
+              newJobId, testUser.getSubjectId(), String.class, null))
+          .thenReturn(jobResult);
 
-    // the mocks
-    when(pipelineRunsServiceMock.getPipelineRun(newJobId, testUser.getSubjectId()))
-        .thenReturn(pipelineRun);
-    when(jobServiceMock.retrieveAsyncJobResult(
-            newJobId, testUser.getSubjectId(), String.class, null))
-        .thenReturn(jobResult);
+      MvcResult result =
+          mockMvc
+              .perform(get(String.format("/api/pipelineruns/v1/result/%s", jobIdString)))
+              .andExpect(status().isAccepted())
+              .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+              .andReturn();
 
-    MvcResult result =
-        mockMvc
-            .perform(get(String.format("/api/pipelineruns/v1/result/%s", jobIdString)))
-            .andExpect(status().isAccepted())
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-            .andReturn();
+      ApiAsyncPipelineRunResponse response =
+          new ObjectMapper()
+              .readValue(
+                  result.getResponse().getContentAsString(), ApiAsyncPipelineRunResponse.class);
+      ApiPipelineRunReport pipelineRunReportResponse = response.getPipelineRunReport();
 
-    ApiAsyncPipelineRunResponse response =
-        new ObjectMapper()
-            .readValue(
-                result.getResponse().getContentAsString(), ApiAsyncPipelineRunResponse.class);
-    ApiPipelineRunReport pipelineRunReportResponse = response.getPipelineRunReport();
+      // response should include the job report, no error report, and pipeline run report without an
+      // outputs object
+      assertEquals(newJobId.toString(), response.getJobReport().getId());
+      assertEquals(statusCode, response.getJobReport().getStatusCode());
+      assertEquals(pipelineName, pipelineRunReportResponse.getPipelineName());
+      assertEquals(testPipelineVersion, pipelineRunReportResponse.getPipelineVersion());
+      assertEquals(testPipelineToolVersion, pipelineRunReportResponse.getToolVersion());
+      assertNull(pipelineRunReportResponse.getOutputs());
+      assertNull(response.getErrorReport());
+      assertNull(response.getPipelineRunReport().getOutputExpirationDate());
+    }
 
-    // response should include the job report, no error report, and pipeline run report without an
-    // outputs object
-    assertEquals(newJobId.toString(), response.getJobReport().getId());
-    assertEquals(statusCode, response.getJobReport().getStatusCode());
-    assertEquals(pipelineName, pipelineRunReportResponse.getPipelineName());
-    assertEquals(testPipelineVersion, pipelineRunReportResponse.getPipelineVersion());
-    assertEquals(testPipelineToolVersion, pipelineRunReportResponse.getToolVersion());
-    assertNull(pipelineRunReportResponse.getOutputs());
-    assertNull(response.getErrorReport());
-    assertNull(response.getPipelineRunReport().getOutputExpirationDate());
-  }
+    @Test
+    void getPipelineRunResultPreparing() throws Exception {
+      String jobIdString = newJobId.toString();
+      String description = "description for testGetPipelineRunResultPreparing";
+      PipelineRun pipelineRun = getPipelineRunPreparing(description);
 
-  @Test
-  void getPipelineRunResultPreparing() throws Exception {
-    String jobIdString = newJobId.toString();
-    String description = "description for testGetPipelineRunResultPreparing";
-    PipelineRun pipelineRun = getPipelineRunPreparing(description);
+      // the mocks
+      when(pipelineRunsServiceMock.getPipelineRun(newJobId, testUser.getSubjectId()))
+          .thenReturn(pipelineRun);
 
-    // the mocks
-    when(pipelineRunsServiceMock.getPipelineRun(newJobId, testUser.getSubjectId()))
-        .thenReturn(pipelineRun);
+      MvcResult result =
+          mockMvc
+              .perform(get(String.format("/api/pipelineruns/v1/result/%s", jobIdString)))
+              .andExpect(status().isBadRequest())
+              .andExpect(
+                  res -> assertInstanceOf(BadRequestException.class, res.getResolvedException()))
+              .andReturn();
 
-    MvcResult result =
-        mockMvc
-            .perform(get(String.format("/api/pipelineruns/v1/result/%s", jobIdString)))
-            .andExpect(status().isBadRequest())
-            .andExpect(
-                res -> assertInstanceOf(BadRequestException.class, res.getResolvedException()))
-            .andReturn();
+      ApiErrorReport response =
+          new ObjectMapper()
+              .readValue(result.getResponse().getContentAsString(), ApiErrorReport.class);
 
-    ApiErrorReport response =
-        new ObjectMapper()
-            .readValue(result.getResponse().getContentAsString(), ApiErrorReport.class);
+      assertEquals(
+          "Pipeline run %s is still preparing; it has to be started before you can query the result"
+              .formatted(newJobId),
+          response.getMessage());
+    }
 
-    assertEquals(
-        "Pipeline run %s is still preparing; it has to be started before you can query the result"
-            .formatted(newJobId),
-        response.getMessage());
-  }
+    @Test
+    void getPipelineRunResultNotFound() throws Exception {
+      String jobIdString = newJobId.toString();
 
-  @Test
-  void getPipelineRunResultNotFound() throws Exception {
-    String jobIdString = newJobId.toString();
+      // the mocks
+      when(pipelineRunsServiceMock.getPipelineRun(newJobId, testUser.getSubjectId()))
+          .thenReturn(null);
 
-    // the mocks
-    when(pipelineRunsServiceMock.getPipelineRun(newJobId, testUser.getSubjectId()))
-        .thenReturn(null);
+      // the call should return a 404
+      MvcResult result =
+          mockMvc
+              .perform(get(String.format("/api/pipelineruns/v1/result/%s", jobIdString)))
+              .andExpect(status().isNotFound())
+              .andExpect(
+                  res -> assertInstanceOf(NotFoundException.class, res.getResolvedException()))
+              .andReturn();
 
-    // the call should return a 404
-    MvcResult result =
-        mockMvc
-            .perform(get(String.format("/api/pipelineruns/v1/result/%s", jobIdString)))
-            .andExpect(status().isNotFound())
-            .andExpect(res -> assertInstanceOf(NotFoundException.class, res.getResolvedException()))
-            .andReturn();
+      ApiErrorReport response =
+          new ObjectMapper()
+              .readValue(result.getResponse().getContentAsString(), ApiErrorReport.class);
 
-    ApiErrorReport response =
-        new ObjectMapper()
-            .readValue(result.getResponse().getContentAsString(), ApiErrorReport.class);
-
-    assertEquals("Pipeline run %s not found".formatted(newJobId), response.getMessage());
+      assertEquals("Pipeline run %s not found".formatted(newJobId), response.getMessage());
+    }
   }
 
   @Nested

--- a/service/src/test/java/bio/terra/pipelines/controller/PipelineRunsApiControllerTest.java
+++ b/service/src/test/java/bio/terra/pipelines/controller/PipelineRunsApiControllerTest.java
@@ -979,7 +979,6 @@ class PipelineRunsApiControllerTest {
 
   @Test
   void getPipelineRunOutputSignedUrls() throws Exception {
-    String pipelineName = PipelinesEnum.ARRAY_IMPUTATION.getValue();
     String jobIdString = newJobId.toString();
     PipelineRun pipelineRun =
         getPipelineRunWithStatusAndQuotaConsumed(

--- a/service/src/test/java/bio/terra/pipelines/controller/PipelineRunsApiControllerTest.java
+++ b/service/src/test/java/bio/terra/pipelines/controller/PipelineRunsApiControllerTest.java
@@ -997,7 +997,7 @@ class PipelineRunsApiControllerTest {
             .perform(
                 get(
                     String.format(
-                        "/api/pipelineruns/v1/result/%s/output/signed-urls", jobIdString)))
+                        "/api/pipelineruns/v2/result/%s/output/signed-urls", jobIdString)))
             .andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON))
             .andReturn();
@@ -1030,7 +1030,7 @@ class PipelineRunsApiControllerTest {
             .perform(
                 get(
                     String.format(
-                        "/api/pipelineruns/v1/result/%s/output/signed-urls", jobIdString)))
+                        "/api/pipelineruns/v2/result/%s/output/signed-urls", jobIdString)))
             .andExpect(status().isNotFound())
             .andExpect(res -> assertInstanceOf(NotFoundException.class, res.getResolvedException()))
             .andReturn();
@@ -1057,7 +1057,7 @@ class PipelineRunsApiControllerTest {
             .perform(
                 get(
                     String.format(
-                        "/api/pipelineruns/v1/result/%s/output/signed-urls", jobIdString)))
+                        "/api/pipelineruns/v2/result/%s/output/signed-urls", jobIdString)))
             .andExpect(status().isBadRequest())
             .andExpect(
                 res -> assertInstanceOf(BadRequestException.class, res.getResolvedException()))

--- a/service/src/test/java/bio/terra/pipelines/service/PipelineInputsOutputsServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/PipelineInputsOutputsServiceTest.java
@@ -24,7 +24,7 @@ import bio.terra.pipelines.db.repositories.PipelineInputsRepository;
 import bio.terra.pipelines.db.repositories.PipelineOutputsRepository;
 import bio.terra.pipelines.db.repositories.PipelineRunsRepository;
 import bio.terra.pipelines.dependencies.gcs.GcsService;
-import bio.terra.pipelines.generated.model.ApiPipelineRunOutputs;
+import bio.terra.pipelines.generated.model.ApiPipelineRunOutputSignedUrls;
 import bio.terra.pipelines.testutils.BaseEmbeddedDbTest;
 import bio.terra.pipelines.testutils.TestUtils;
 import bio.terra.rawls.model.Entity;
@@ -237,8 +237,8 @@ class PipelineInputsOutputsServiceTest extends BaseEmbeddedDbTest {
             anyString()))
         .thenReturn(fakeUrl);
 
-    ApiPipelineRunOutputs apiPipelineRunOutputs =
-        pipelineInputsOutputsService.formatPipelineRunOutputs(pipelineRun);
+    ApiPipelineRunOutputSignedUrls apiPipelineRunOutputs =
+        pipelineInputsOutputsService.formatPipelineRunOutputSignedUrls(pipelineRun);
 
     assertEquals(fakeUrl.toString(), apiPipelineRunOutputs.get("testFileOutputKey"));
   }

--- a/service/src/test/java/bio/terra/pipelines/service/PipelineInputsOutputsServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/PipelineInputsOutputsServiceTest.java
@@ -249,7 +249,13 @@ class PipelineInputsOutputsServiceTest extends BaseEmbeddedDbTest {
 
   @Test
   void formatPipelineRunOutputSignedUrls() throws MalformedURLException {
+    // define pipeline with outputs
+    Pipeline testPipeline = createTestPipelineWithId();
+    testPipeline.setPipelineOutputDefinitions(TestUtils.TEST_PIPELINE_OUTPUT_DEFINITIONS_WITH_FILE);
+
     PipelineRun pipelineRun = TestUtils.createNewPipelineRunWithJobId(testJobId);
+    pipelineRun.setStatus(CommonPipelineRunStatusEnum.SUCCEEDED);
+    pipelineRun.setPipeline(testPipeline);
     pipelineRunsRepository.save(pipelineRun);
 
     PipelineOutput pipelineOutput = new PipelineOutput();

--- a/service/src/test/java/bio/terra/pipelines/service/PipelineRunsServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/PipelineRunsServiceTest.java
@@ -545,7 +545,7 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
         pipelineRunsService.markPipelineRunSuccessAndWriteOutputs(
             testJobId,
             testUserId,
-            TestUtils.TEST_PIPELINE_OUTPUTS,
+            TestUtils.TEST_PIPELINE_OUTPUTS_WITH_FILE,
             testQuotaConsumed,
             testRawQuotaConsumed);
     assertTrue(updatedPipelineRun.getStatus().isSuccess());
@@ -558,7 +558,7 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
     Map<String, Object> extractedOutput =
         pipelineInputsOutputsService.stringToMap(pipelineOutput.getOutputs());
 
-    for (Map.Entry<String, String> entry : TestUtils.TEST_PIPELINE_OUTPUTS.entrySet()) {
+    for (Map.Entry<String, String> entry : TestUtils.TEST_PIPELINE_OUTPUTS_WITH_FILE.entrySet()) {
       assertEquals(entry.getValue(), extractedOutput.get(entry.getKey()));
     }
   }

--- a/service/src/test/java/bio/terra/pipelines/stairway/steps/common/CompletePipelineRunStepTest.java
+++ b/service/src/test/java/bio/terra/pipelines/stairway/steps/common/CompletePipelineRunStepTest.java
@@ -42,7 +42,8 @@ class CompletePipelineRunStepTest extends BaseEmbeddedDbTest {
     var inputParameters = new FlightMap();
     var workingMap = new FlightMap();
 
-    workingMap.put(ImputationJobMapKeys.PIPELINE_RUN_OUTPUTS, TestUtils.TEST_PIPELINE_OUTPUTS);
+    workingMap.put(
+        ImputationJobMapKeys.PIPELINE_RUN_OUTPUTS, TestUtils.TEST_PIPELINE_OUTPUTS_WITH_FILE);
     workingMap.put(ImputationJobMapKeys.EFFECTIVE_QUOTA_CONSUMED, effectiveQuotaConsumed);
     workingMap.put(ImputationJobMapKeys.RAW_QUOTA_CONSUMED, rawQuotaConsumed);
 
@@ -99,7 +100,7 @@ class CompletePipelineRunStepTest extends BaseEmbeddedDbTest {
         pipelineOutputsRepository.findById(writtenJob.getId()).orElseThrow();
     ObjectMapper objectMapper = new ObjectMapper();
     assertEquals(
-        objectMapper.writeValueAsString(TestUtils.TEST_PIPELINE_OUTPUTS),
+        objectMapper.writeValueAsString(TestUtils.TEST_PIPELINE_OUTPUTS_WITH_FILE),
         pipelineOutput.getOutputs());
   }
 

--- a/service/src/test/java/bio/terra/pipelines/testutils/TestUtils.java
+++ b/service/src/test/java/bio/terra/pipelines/testutils/TestUtils.java
@@ -44,11 +44,25 @@ public class TestUtils {
       "fc-secure-%s".formatted(CONTROL_WORKSPACE_ID);
   public static final String GCP_STORAGE_PROTOCOL = "gs://";
   public static final String CONTROL_WORKSPACE_GOOGLE_PROJECT = "testGoogleProject";
-  public static final Map<String, String> TEST_PIPELINE_OUTPUTS =
+
+  public static final List<PipelineOutputDefinition> TEST_PIPELINE_OUTPUT_DEFINITIONS_WITH_FILE =
+      new ArrayList<>(
+          List.of(
+              new PipelineOutputDefinition(
+                  1L,
+                  "testFileOutputKey",
+                  "test_file_output_key",
+                  "Test File Output Display Name",
+                  "test output file description",
+                  PipelineVariableTypesEnum.FILE,
+                  true)));
+  public static final Map<String, String> TEST_PIPELINE_OUTPUTS_WITH_FILE =
       new HashMap(
           Map.of(
               "testFileOutputKey",
               "gs://fc-secure-%s/testFileOutputValue".formatted(CONTROL_WORKSPACE_ID)));
+  public static final Map<String, String> TEST_PIPELINE_OUTPUTS_WITH_FILE_FORMATTED =
+      new HashMap(Map.of("testFileOutputKey", "testFileOutputValue"));
 
   public static final List<PipelineInputDefinition> TEST_PIPELINE_INPUTS_DEFINITION_LIST =
       new ArrayList<>(

--- a/service/src/test/java/bio/terra/pipelines/testutils/TestUtils.java
+++ b/service/src/test/java/bio/terra/pipelines/testutils/TestUtils.java
@@ -55,14 +55,29 @@ public class TestUtils {
                   "Test File Output Display Name",
                   "test output file description",
                   PipelineVariableTypesEnum.FILE,
+                  true),
+              new PipelineOutputDefinition(
+                  1L,
+                  "testStringOutputKey",
+                  "test_string_output_key",
+                  "Test String Output Display Name",
+                  "test output string description",
+                  PipelineVariableTypesEnum.STRING,
                   true)));
   public static final Map<String, String> TEST_PIPELINE_OUTPUTS_WITH_FILE =
       new HashMap(
           Map.of(
               "testFileOutputKey",
-              "gs://fc-secure-%s/testFileOutputValue".formatted(CONTROL_WORKSPACE_ID)));
+              "gs://fc-secure-%s/testFileOutputValue".formatted(CONTROL_WORKSPACE_ID),
+              "testStringOutputKey",
+              "testStringOutputValue"));
   public static final Map<String, String> TEST_PIPELINE_OUTPUTS_WITH_FILE_FORMATTED =
-      new HashMap(Map.of("testFileOutputKey", "testFileOutputValue"));
+      new HashMap(
+          Map.of(
+              "testFileOutputKey",
+              "testFileOutputValue",
+              "testStringOutputKey",
+              "testStringOutputValue"));
 
   public static final List<PipelineInputDefinition> TEST_PIPELINE_INPUTS_DEFINITION_LIST =
       new ArrayList<>(


### PR DESCRIPTION
### Description 

Signed URL generation has been removed from the `pipelineruns/result` endpoint to a new `pipelineruns/v2/result/{jobID}/output/signed-urls` endpoint. `pipelineruns/v2/result/{jobID}` instead returns the outputs with file names only.

This will be a major version bump.

`pipelineruns/v1/result/{jobID}` response for a completed, successful job (this response is unchanged from previous):
```
{
  "jobReport": {
    "id": "019269ed-77aa-4e16-92f1-24f78f31f177",
    "description": "local test for new result and output endpoints third try",
    "status": "SUCCEEDED",
    "statusCode": 200,
    "submitted": "2025-12-10T20:34:31.917985Z",
    "completed": "2025-12-10T21:03:45.415890Z",
    "resultURL": "http://localhost:8080/api/pipelineruns/v1/result/019269ed-77aa-4e16-92f1-24f78f31f177"
  },
  "pipelineRunReport": {
    "pipelineName": "array_imputation",
    "pipelineVersion": 1,
    "toolVersion": "1.6.5",
    "userInputs": {
      "multiSampleVcf": "/Users/marymorg/Desktop/gnomad.genomes.v3.1.2.hgdp_tgp.500samples.chr20.vcf.gz",
      "outputBasename": "test"
    },
    "outputs": {
      "imputedMultiSampleVcfIndex": "https://storage.googleapis.com/fc-secure-6970c3a9-dc92-436d-af3d-917bcb4cf05a/submissions/final-outputs/343523d4-fe16-4050-a7a5-dd390e880a59/ImputationBeagle/1720903c-45a4-4af1-9b0b-657be586e7ef/call-WriteEmptyFile/empty_file?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=teaspoons-dev%40broad-dsde-dev.iam.gserviceaccount.com%2F20251210%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20251210T211255Z&X-Goog-Expires=3600&X-Goog-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3D%22empty_file%22&X-Goog-Signature=REDACTED",
      "imputedMultiSampleVcf": "https://storage.googleapis.com/fc-secure-6970c3a9-dc92-436d-af3d-917bcb4cf05a/submissions/final-outputs/343523d4-fe16-4050-a7a5-dd390e880a59/ImputationBeagle/1720903c-45a4-4af1-9b0b-657be586e7ef/call-WriteEmptyFile/empty_file?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=teaspoons-dev%40broad-dsde-dev.iam.gserviceaccount.com%2F20251210%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20251210T211255Z&X-Goog-Expires=3600&X-Goog-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3D%22empty_file%22&X-Goog-Signature=REDACTED",
      "contigsInfo": "https://storage.googleapis.com/fc-secure-6970c3a9-dc92-436d-af3d-917bcb4cf05a/submissions/final-outputs/343523d4-fe16-4050-a7a5-dd390e880a59/ImputationBeagle/1720903c-45a4-4af1-9b0b-657be586e7ef/call-WriteEmptyFile/empty_file?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=teaspoons-dev%40broad-dsde-dev.iam.gserviceaccount.com%2F20251210%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20251210T211255Z&X-Goog-Expires=3600&X-Goog-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3D%22empty_file%22&X-Goog-Signature=REDACTED",
      "chunksInfo": "https://storage.googleapis.com/fc-secure-6970c3a9-dc92-436d-af3d-917bcb4cf05a/submissions/final-outputs/343523d4-fe16-4050-a7a5-dd390e880a59/ImputationBeagle/1720903c-45a4-4af1-9b0b-657be586e7ef/call-WriteEmptyFile/empty_file?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=teaspoons-dev%40broad-dsde-dev.iam.gserviceaccount.com%2F20251210%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20251210T211255Z&X-Goog-Expires=3600&X-Goog-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3D%22empty_file%22&X-Goog-Signature=REDACTED"
    },
    "outputExpirationDate": "2025-12-24T21:03:45.415890Z",
    "quotaConsumed": 500
  }
}
```

`pipelineruns/v2/result/{jobID}` response for a completed, successful job:
```
{
  "jobReport": {
    "id": "019269ed-77aa-4e16-92f1-24f78f31f177",
    "description": "local test for new result and output endpoints third try",
    "status": "SUCCEEDED",
    "statusCode": 200,
    "submitted": "2025-12-10T20:34:31.917985Z",
    "completed": "2025-12-10T21:03:45.415890Z",
    "resultURL": "http://localhost:8080/api/pipelineruns/v1/result/019269ed-77aa-4e16-92f1-24f78f31f177"
  },
  "pipelineRunReport": {
    "pipelineName": "array_imputation",
    "pipelineVersion": 1,
    "toolVersion": "1.6.5",
    "userInputs": {
      "multiSampleVcf": "/Users/marymorg/Desktop/gnomad.genomes.v3.1.2.hgdp_tgp.500samples.chr20.vcf.gz",
      "outputBasename": "test"
    },
    "outputs": {
      "imputedMultiSampleVcfIndex": "empty_file", # note this was run on the empty wdl so these are the file names returned
      "imputedMultiSampleVcf": "empty_file",
      "contigsInfo": "empty_file",
      "chunksInfo": "empty_file"
    },
    "outputExpirationDate": "2025-12-24T21:03:45.415890Z",
    "quotaConsumed": 500
  }
}

```

`pipelineruns/v2/result/{jobId}/outputs/signed-urls` response for a completed, successful job:
```
{
  "jobId": "019269ed-77aa-4e16-92f1-24f78f31f177",
  "outputSignedUrls": {
    "imputedMultiSampleVcfIndex": "https://storage.googleapis.com/fc-secure-6970c3a9-dc92-436d-af3d-917bcb4cf05a/submissions/final-outputs/343523d4-fe16-4050-a7a5-dd390e880a59/ImputationBeagle/1720903c-45a4-4af1-9b0b-657be586e7ef/call-WriteEmptyFile/empty_file?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=teaspoons-dev%40broad-dsde-dev.iam.gserviceaccount.com%2F20251210%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20251210T211604Z&X-Goog-Expires=3600&X-Goog-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3D%22empty_file%22&X-Goog-Signature=REDACTED",
    "imputedMultiSampleVcf": "https://storage.googleapis.com/fc-secure-6970c3a9-dc92-436d-af3d-917bcb4cf05a/submissions/final-outputs/343523d4-fe16-4050-a7a5-dd390e880a59/ImputationBeagle/1720903c-45a4-4af1-9b0b-657be586e7ef/call-WriteEmptyFile/empty_file?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=teaspoons-dev%40broad-dsde-dev.iam.gserviceaccount.com%2F20251210%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20251210T211604Z&X-Goog-Expires=3600&X-Goog-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3D%22empty_file%22&X-Goog-Signature=REDACTED",
    "contigsInfo": "https://storage.googleapis.com/fc-secure-6970c3a9-dc92-436d-af3d-917bcb4cf05a/submissions/final-outputs/343523d4-fe16-4050-a7a5-dd390e880a59/ImputationBeagle/1720903c-45a4-4af1-9b0b-657be586e7ef/call-WriteEmptyFile/empty_file?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=teaspoons-dev%40broad-dsde-dev.iam.gserviceaccount.com%2F20251210%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20251210T211604Z&X-Goog-Expires=3600&X-Goog-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3D%22empty_file%22&X-Goog-Signature=REDACTED",
    "chunksInfo": "https://storage.googleapis.com/fc-secure-6970c3a9-dc92-436d-af3d-917bcb4cf05a/submissions/final-outputs/343523d4-fe16-4050-a7a5-dd390e880a59/ImputationBeagle/1720903c-45a4-4af1-9b0b-657be586e7ef/call-WriteEmptyFile/empty_file?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=teaspoons-dev%40broad-dsde-dev.iam.gserviceaccount.com%2F20251210%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20251210T211604Z&X-Goog-Expires=3600&X-Goog-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3D%22empty_file%22&X-Goog-Signature=REDACTED"
  },
  "outputExpirationDate": "2025-12-24T21:03:45.415890Z"
}
```

`pipelineruns/v2/result/{jobId}/outputs/signed-urls` response for a running job:
```
{
  "message": "Pipeline run f29a03f9-6b62-4aca-b8fa-70fe45bcadc2 has state RUNNING; output signed URLs can only be retrieved for complete and successful runs",
  "statusCode": 400,
  "causes": []
}
```

e2e test changes: TO DO

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-732

### Checklist (provide links to changes)

- [ ] Updated external documentation - TO DO
- [ ] Updated internal documentation (if applicable)
- [x] Planned non patch version bump - MAJOR rev
- [ ] Updated CLI PR (if applicable)
