### PR TITLE
TSPS-759 add MANIFEST input type

### DIFF
--- a/service/src/main/java/bio/terra/pipelines/common/utils/PipelineVariableTypesEnum.java
+++ b/service/src/main/java/bio/terra/pipelines/common/utils/PipelineVariableTypesEnum.java
@@ -134,6 +134,17 @@ public enum PipelineVariableTypesEnum {
       return null;
     }
   },
+  MANIFEST {
+    @Override
+    public <T> T cast(String fieldName, Object value, TypeReference<T> typeReference) {
+      return (T) FILE.cast(fieldName, value, new TypeReference<>() {});
+    }
+
+    @Override
+    public String validate(PipelineInputDefinition pipelineInputDefinition, Object value) {
+      return FILE.validate(pipelineInputDefinition, value);
+    }
+  },
   STRING_ARRAY {
     @Override
     public <T> T cast(String fieldName, Object value, TypeReference<T> typeReference) {

--- a/service/src/main/java/bio/terra/pipelines/common/utils/PipelineVariableTypesEnum.java
+++ b/service/src/main/java/bio/terra/pipelines/common/utils/PipelineVariableTypesEnum.java
@@ -323,16 +323,8 @@ public enum PipelineVariableTypesEnum {
     }
   }
 
-  /**
-   * Returns true if this type is a subset of the other type. This is used to determine if a
-   * variable of this type can be considered a variable of the other type. The only case where this
-   * is currently true is when this type is MANIFEST and the other type is FILE, since a manifest is
-   * a specific type of file.
-   */
-  public boolean isSubsetOf(PipelineVariableTypesEnum other) {
-    if (this == MANIFEST && other == FILE) {
-      return true;
-    }
-    return this == other;
+  /** Returns true if this type is considered a FILE, i.e. FILE or MANIFEST */
+  public boolean isFile() {
+    return this == MANIFEST || this == FILE;
   }
 }

--- a/service/src/main/java/bio/terra/pipelines/common/utils/PipelineVariableTypesEnum.java
+++ b/service/src/main/java/bio/terra/pipelines/common/utils/PipelineVariableTypesEnum.java
@@ -322,4 +322,17 @@ public enum PipelineVariableTypesEnum {
       return "%s must be at most %s".formatted(fieldName, max);
     }
   }
+
+  /**
+   * Returns true if this type is a subset of the other type. This is used to determine if a
+   * variable of this type can be considered a variable of the other type. The only case where this
+   * is currently true is when this type is MANIFEST and the other type is FILE, since a manifest is
+   * a specific type of file.
+   */
+  public boolean isSubsetOf(PipelineVariableTypesEnum other) {
+    if (this == MANIFEST && other == FILE) {
+      return true;
+    }
+    return this == other;
+  }
 }

--- a/service/src/main/java/bio/terra/pipelines/service/PipelineInputsOutputsService.java
+++ b/service/src/main/java/bio/terra/pipelines/service/PipelineInputsOutputsService.java
@@ -166,7 +166,7 @@ public class PipelineInputsOutputsService {
    * Generate signed PUT/POST urls and curl commands for each user-provided file input in the
    * pipeline, given local file inputs. We expect the userProvidedInputs to have been validated
    * already, so all required inputs should be present, and any optional inputs that are not present
-   * are ok to skip for this validation.
+   * are ok to skip.
    *
    * <p>Each user-provided file input (assumed to be a path to a local file) is translated into a
    * write-only (PUT) signed url in a location in the pipeline workspace storage container, in a

--- a/service/src/main/java/bio/terra/pipelines/service/PipelineInputsOutputsService.java
+++ b/service/src/main/java/bio/terra/pipelines/service/PipelineInputsOutputsService.java
@@ -193,8 +193,7 @@ public class PipelineInputsOutputsService {
         continue; // skip null values; we can assume all required inputs are present
       }
       logger.info(
-          "Preparing signed URL and curl command for user-provided file input %s"
-              .formatted(fileInputName));
+          "Preparing signed URL and curl command for user-provided file input {}", fileInputName);
       String fileInputValue = (String) inputValue;
       String objectName = constructDestinationBlobNameForUserInputFile(jobId, fileInputValue);
       String signedUrl = getSignedUrl(bucketName, objectName, useResumableUploads);

--- a/service/src/main/java/bio/terra/pipelines/service/PipelineInputsOutputsService.java
+++ b/service/src/main/java/bio/terra/pipelines/service/PipelineInputsOutputsService.java
@@ -79,7 +79,7 @@ public class PipelineInputsOutputsService {
   private List<String> getUserProvidedFileInputKeys(Pipeline pipeline) {
     return pipeline.getPipelineInputDefinitions().stream()
         .filter(PipelineInputDefinition::isUserProvided)
-        .filter(p -> p.getType().isSubsetOf(PipelineVariableTypesEnum.FILE))
+        .filter(p -> p.getType().isFile())
         .map(PipelineInputDefinition::getName)
         .toList();
   }
@@ -406,7 +406,7 @@ public class PipelineInputsOutputsService {
     boolean foundLocalFile = false;
     List<String> fileInputNames =
         userProvidedInputDefinitions.stream()
-            .filter(def -> def.getType().isSubsetOf(PipelineVariableTypesEnum.FILE))
+            .filter(def -> def.getType().isFile())
             .map(PipelineInputDefinition::getName)
             .toList();
     for (String fileInputName : fileInputNames) {

--- a/service/src/test/java/bio/terra/pipelines/common/utils/PipelineVariableTypesEnumTest.java
+++ b/service/src/test/java/bio/terra/pipelines/common/utils/PipelineVariableTypesEnumTest.java
@@ -2,7 +2,9 @@ package bio.terra.pipelines.common.utils;
 
 import static bio.terra.pipelines.common.utils.PipelineVariableTypesEnum.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import bio.terra.pipelines.db.entities.PipelineInputDefinition;
@@ -12,6 +14,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -632,5 +635,23 @@ class PipelineVariableTypesEnumTest extends BaseTest {
       assertEquals(
           expectedErrorMessage, inputDefinition.getType().validate(inputDefinition, inputValue));
     }
+  }
+
+  @Test
+  void isSubsetOf() {
+    // MANIFESTs and FILEs are both FILEs
+    assertTrue(PipelineVariableTypesEnum.MANIFEST.isSubsetOf(PipelineVariableTypesEnum.FILE));
+    assertTrue(PipelineVariableTypesEnum.FILE.isSubsetOf(PipelineVariableTypesEnum.FILE));
+
+    // a MANIFEST is a MANIFEST
+    assertTrue(PipelineVariableTypesEnum.MANIFEST.isSubsetOf(PipelineVariableTypesEnum.MANIFEST));
+
+    // a FILE is not a MANIFEST
+    assertFalse(PipelineVariableTypesEnum.FILE.isSubsetOf(PipelineVariableTypesEnum.MANIFEST));
+
+    // other types are not subsets of each other but are subsets of themselves
+    assertFalse(PipelineVariableTypesEnum.STRING.isSubsetOf(PipelineVariableTypesEnum.FILE));
+    assertFalse(PipelineVariableTypesEnum.INTEGER.isSubsetOf(PipelineVariableTypesEnum.STRING));
+    assertTrue(PipelineVariableTypesEnum.STRING.isSubsetOf(PipelineVariableTypesEnum.STRING));
   }
 }

--- a/service/src/test/java/bio/terra/pipelines/common/utils/PipelineVariableTypesEnumTest.java
+++ b/service/src/test/java/bio/terra/pipelines/common/utils/PipelineVariableTypesEnumTest.java
@@ -638,20 +638,18 @@ class PipelineVariableTypesEnumTest extends BaseTest {
   }
 
   @Test
-  void isSubsetOf() {
-    // MANIFESTs and FILEs are both FILEs
-    assertTrue(PipelineVariableTypesEnum.MANIFEST.isSubsetOf(PipelineVariableTypesEnum.FILE));
-    assertTrue(PipelineVariableTypesEnum.FILE.isSubsetOf(PipelineVariableTypesEnum.FILE));
+  void isFile() {
+    // manifests and files are files
+    assertTrue(MANIFEST.isFile());
+    assertTrue(FILE.isFile());
 
-    // a MANIFEST is a MANIFEST
-    assertTrue(PipelineVariableTypesEnum.MANIFEST.isSubsetOf(PipelineVariableTypesEnum.MANIFEST));
-
-    // a FILE is not a MANIFEST
-    assertFalse(PipelineVariableTypesEnum.FILE.isSubsetOf(PipelineVariableTypesEnum.MANIFEST));
-
-    // other types are not subsets of each other but are subsets of themselves
-    assertFalse(PipelineVariableTypesEnum.STRING.isSubsetOf(PipelineVariableTypesEnum.FILE));
-    assertFalse(PipelineVariableTypesEnum.INTEGER.isSubsetOf(PipelineVariableTypesEnum.STRING));
-    assertTrue(PipelineVariableTypesEnum.STRING.isSubsetOf(PipelineVariableTypesEnum.STRING));
+    // other types are not files
+    assertFalse(STRING.isFile());
+    assertFalse(INTEGER.isFile());
+    assertFalse(STRING_ARRAY.isFile());
+    assertFalse(
+        FILE_ARRAY.isFile()); // for isFile purposes we don't yet support FILE_ARRAY processing
+    assertFalse(FLOAT.isFile());
+    assertFalse(BOOLEAN.isFile());
   }
 }

--- a/service/src/test/java/bio/terra/pipelines/common/utils/PipelineVariableTypesEnumTest.java
+++ b/service/src/test/java/bio/terra/pipelines/common/utils/PipelineVariableTypesEnumTest.java
@@ -43,6 +43,8 @@ class PipelineVariableTypesEnumTest extends BaseTest {
     String booleanTypeErrorMessage = "%s must be a boolean".formatted(commonInputName);
     String vcfTypeErrorMessage =
         "%s must be a path to a file ending in .vcf.gz".formatted(commonInputName);
+    String tsvTypeErrorMessage =
+        "%s must be a path to a file ending in .tsv".formatted(commonInputName);
     String stringArrayTypeErrorMessage =
         "%s must be an array of strings".formatted(commonInputName);
     String vcfArrayTypeErrorMessage =
@@ -256,6 +258,21 @@ class PipelineVariableTypesEnumTest extends BaseTest {
             null,
             null,
             null);
+    PipelineInputDefinition manifestTsvInputDefinition =
+        new PipelineInputDefinition(
+            1L,
+            commonInputName,
+            "manifest_input",
+            null,
+            null,
+            MANIFEST,
+            ".tsv",
+            true,
+            true,
+            false,
+            null,
+            null,
+            null);
     PipelineInputDefinition stringArrayInputDefinition =
         new PipelineInputDefinition(
             1L,
@@ -418,6 +435,33 @@ class PipelineVariableTypesEnumTest extends BaseTest {
             fileVcfInputDefinition,
             "path\\to\\valid\\windows\\file.vcf.gz",
             "path\\to\\valid\\windows\\file.vcf.gz",
+            null),
+
+        // MANIFEST
+        arguments(manifestTsvInputDefinition, "path/to/file.tsv", "path/to/file.tsv", null),
+        arguments(manifestTsvInputDefinition, "   path/to/file.tsv   ", "path/to/file.tsv", null),
+        arguments(
+            manifestTsvInputDefinition,
+            "path/to/file.csv",
+            "path/to/file.csv",
+            tsvTypeErrorMessage), // cast is successful but validation fails
+        arguments(manifestTsvInputDefinition, 3, null, tsvTypeErrorMessage),
+        arguments(manifestTsvInputDefinition, null, null, tsvTypeErrorMessage),
+        arguments(manifestTsvInputDefinition, "", null, tsvTypeErrorMessage),
+        arguments(
+            manifestTsvInputDefinition,
+            "path/to/!invalid/file.tsv",
+            "path/to/!invalid/file.tsv",
+            filePatternErrorMessage), // cast is successful but validation fails
+        arguments(
+            manifestTsvInputDefinition,
+            "gs://bucket_name/path/to/file.tsv",
+            "gs://bucket_name/path/to/file.tsv",
+            null),
+        arguments(
+            manifestTsvInputDefinition,
+            "path\\to\\valid\\windows\\file.tsv",
+            "path\\to\\valid\\windows\\file.tsv",
             null),
 
         // STRING_ARRAY

--- a/service/src/test/java/bio/terra/pipelines/service/PipelineInputsOutputsServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/PipelineInputsOutputsServiceTest.java
@@ -65,13 +65,13 @@ class PipelineInputsOutputsServiceTest extends BaseEmbeddedDbTest {
   @MockitoBean private GcsService mockGcsService;
 
   private final UUID testJobId = TestUtils.TEST_NEW_UUID;
-  private final String fileInputKeyName1 = "testRequiredVcfInput";
-  private final String fileInputKeyName2 = "testRequiredVcfInput2";
+  private final String fileInputKeyName = "testRequiredVcfInput";
+  private final String manifestInputKeyName = "testRequiredManifestInput";
   private final List<PipelineInputDefinition> inputDefinitionsWithFileAndManifest =
       List.of(
           new PipelineInputDefinition(
               3L,
-              fileInputKeyName1,
+              fileInputKeyName,
               "test_required_vcf_input",
               null,
               null,
@@ -85,8 +85,8 @@ class PipelineInputsOutputsServiceTest extends BaseEmbeddedDbTest {
               null),
           new PipelineInputDefinition(
               3L,
-              fileInputKeyName2,
-              "test_required_manifest",
+              manifestInputKeyName,
+              "test_required_manifest_input",
               null,
               null,
               PipelineVariableTypesEnum.MANIFEST,
@@ -100,11 +100,11 @@ class PipelineInputsOutputsServiceTest extends BaseEmbeddedDbTest {
 
   @Test
   void validateFileSourcesAreConsistentCloudTrue() {
-    String fileInputValue1 = "gs://some-bucket/some-path/file.vcf.gz";
-    String fileInputValue2 = "gs://some-bucket/some-path/manifest.tsv";
+    String fileInputValue = "gs://some-bucket/some-path/file.vcf.gz";
+    String manifestInputValue = "gs://some-bucket/some-path/manifest.tsv";
     Map<String, Object> userPipelineInputs =
         new HashMap<>(
-            Map.of(fileInputKeyName1, fileInputValue1, fileInputKeyName2, fileInputValue2));
+            Map.of(fileInputKeyName, fileInputValue, manifestInputKeyName, manifestInputValue));
 
     assertEquals(
         List.of(), // no errors
@@ -114,11 +114,11 @@ class PipelineInputsOutputsServiceTest extends BaseEmbeddedDbTest {
 
   @Test
   void validateFileSourcesAreConsistentLocalTrue() {
-    String fileInputValue1 = "some-path/file.vcf.gz";
-    String fileInputValue2 = "some-path/manifest.tsv";
+    String fileInputValue = "some-path/file.vcf.gz";
+    String manifestInputValue = "some-path/manifest.tsv";
     Map<String, Object> userPipelineInputs =
         new HashMap<>(
-            Map.of(fileInputKeyName1, fileInputValue1, fileInputKeyName2, fileInputValue2));
+            Map.of(fileInputKeyName, fileInputValue, manifestInputKeyName, manifestInputValue));
 
     assertEquals(
         List.of(),
@@ -128,11 +128,11 @@ class PipelineInputsOutputsServiceTest extends BaseEmbeddedDbTest {
 
   @Test
   void validateFileSourcesAreConsistentMixError() {
-    String fileInputValue1 = "gs://some-bucket/some-path/file.vcf.gz";
-    String fileInputValue2 = "/some-path/manifest.tsv";
+    String fileInputValue = "gs://some-bucket/some-path/file.vcf.gz";
+    String manifestInputValue = "/some-path/manifest.tsv";
     Map<String, Object> userPipelineInputs =
         new HashMap<>(
-            Map.of(fileInputKeyName1, fileInputValue1, fileInputKeyName2, fileInputValue2));
+            Map.of(fileInputKeyName, fileInputValue, manifestInputKeyName, manifestInputValue));
 
     assertEquals(
         List.of("File inputs must be all local or all GCS cloud based"),
@@ -142,18 +142,18 @@ class PipelineInputsOutputsServiceTest extends BaseEmbeddedDbTest {
 
   @Test
   void validateFileSourcesAreConsistentNonGcsCloudErrors() {
-    String fileInputValue1 = "s3://some-bucket/some-path/file.vcf.gz";
-    String fileInputValue2 = "azure://some-path/manifest.tsv";
+    String fileInputValue = "s3://some-bucket/some-path/file.vcf.gz";
+    String manifestInputValue = "azure://some-path/manifest.tsv";
     Map<String, Object> userPipelineInputs =
         new HashMap<>(
-            Map.of(fileInputKeyName1, fileInputValue1, fileInputKeyName2, fileInputValue2));
+            Map.of(fileInputKeyName, fileInputValue, manifestInputKeyName, manifestInputValue));
 
     assertEquals(
         List.of(
             "Found an unsupported file location type for input %s. Only GCS cloud-based files or local files are supported"
-                .formatted(fileInputKeyName1),
+                .formatted(fileInputKeyName),
             "Found an unsupported file location type for input %s. Only GCS cloud-based files or local files are supported"
-                .formatted(fileInputKeyName2)),
+                .formatted(manifestInputKeyName)),
         pipelineInputsOutputsService.validateFileSourcesAreConsistent(
             inputDefinitionsWithFileAndManifest, userPipelineInputs));
   }

--- a/service/src/test/java/bio/terra/pipelines/service/PipelineInputsOutputsServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/PipelineInputsOutputsServiceTest.java
@@ -323,9 +323,7 @@ class PipelineInputsOutputsServiceTest extends BaseEmbeddedDbTest {
   @Test
   void prepareLocalFileInputs() throws MalformedURLException {
     Pipeline testPipelineWithId = createTestPipelineWithId();
-    String fileInputKeyName = "testRequiredVcfInput";
     String fileInputValue = "fake/file.vcf.gz";
-    String manifestInputKeyName = "testOptionalManifestInput";
     String manifestInputValue = "fake/manifest.tsv";
     Map<String, Object> userPipelineInputs =
         new HashMap<>(

--- a/service/src/test/java/bio/terra/pipelines/service/PipelineInputsOutputsServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/PipelineInputsOutputsServiceTest.java
@@ -66,7 +66,7 @@ class PipelineInputsOutputsServiceTest extends BaseEmbeddedDbTest {
 
   private final UUID testJobId = TestUtils.TEST_NEW_UUID;
   private final String fileInputKeyName = "testRequiredVcfInput";
-  private final String manifestInputKeyName = "testRequiredManifestInput";
+  private final String manifestInputKeyName = "testOptionalManifestInput";
   private final List<PipelineInputDefinition> inputDefinitionsWithFileAndManifest =
       List.of(
           new PipelineInputDefinition(
@@ -86,7 +86,7 @@ class PipelineInputsOutputsServiceTest extends BaseEmbeddedDbTest {
           new PipelineInputDefinition(
               3L,
               manifestInputKeyName,
-              "test_required_manifest_input",
+              "test_optional_manifest_input",
               null,
               null,
               PipelineVariableTypesEnum.MANIFEST,

--- a/service/src/test/java/bio/terra/pipelines/service/PipelineRunsServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/PipelineRunsServiceTest.java
@@ -394,7 +394,7 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
       assertNull(counter);
 
       GcsFile gcsInputFile = new GcsFile(fileInputValue);
-      // todo fix this test
+
       when(mockSamService.getUserPetServiceAccountTokenReadOnly(testUser))
           .thenReturn(testUserBearerToken);
       when(mockGcsService.userHasFileReadAccess(gcsInputFile, testUserBearerToken.getToken()))

--- a/service/src/test/java/bio/terra/pipelines/service/PipelineRunsServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/PipelineRunsServiceTest.java
@@ -394,7 +394,7 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
       assertNull(counter);
 
       GcsFile gcsInputFile = new GcsFile(fileInputValue);
-
+      // todo fix this test
       when(mockSamService.getUserPetServiceAccountTokenReadOnly(testUser))
           .thenReturn(testUserBearerToken);
       when(mockGcsService.userHasFileReadAccess(gcsInputFile, testUserBearerToken.getToken()))

--- a/service/src/test/java/bio/terra/pipelines/service/PipelinesServiceDatabaseTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/PipelinesServiceDatabaseTest.java
@@ -69,16 +69,6 @@ class PipelinesServiceDatabaseTest extends BaseEmbeddedDbTest {
   }
 
   @Test
-  void allOptionalInputsHaveDefaultValues() {
-    // make sure all optional inputs have default values
-    for (PipelineInputDefinition p : pipelineInputDefinitionsRepository.findAll()) {
-      if (!p.isRequired()) {
-        assertNotNull(p.getDefaultValue());
-      }
-    }
-  }
-
-  @Test
   void allServiceProvidedInputsWithoutCustomValuesHaveDefaultValues() {
     // make sure all service-provided inputs that aren't marked as having custom values, have
     // default values

--- a/service/src/test/java/bio/terra/pipelines/testutils/TestUtils.java
+++ b/service/src/test/java/bio/terra/pipelines/testutils/TestUtils.java
@@ -166,6 +166,20 @@ public class TestUtils {
                   false,
                   null,
                   null,
+                  null),
+              new PipelineInputDefinition(
+                  3L,
+                  "testOptionalManifestInput",
+                  "test_optional_manifest_input",
+                  null,
+                  null,
+                  PipelineVariableTypesEnum.MANIFEST,
+                  ".tsv",
+                  false,
+                  true,
+                  false,
+                  null,
+                  null,
                   null)));
 
   public static final List<PipelineOutputDefinition> TEST_PIPELINE_OUTPUTS_DEFINITION_LIST =


### PR DESCRIPTION
### Description 

Here we add a new pipeline input variable type, MANIFEST. It is effectively a FILE but will be treated differently by the service (we will perform validations on the contents of the MANIFEST file).

Anticipating a future where a pipeline can accept either FILE inputs or a MANIFEST input, our previous assumption that all optional user-provided inputs have default values no longer holds. There are several changes in this PR that reflect the new possibility of an optional user input not having a default value.

A MANIFEST type pipeline input would look like this in the db:
```
 id | pipeline_id |           name         |   type   | is_required |  file_suffix  | user_provided | default_value |      wdl_variable_name      | expects_custom_value | min_value | max_value | display_name | description 
----+-------------+------------------------+----------+-------------+---------------+---------------+---------------+-----------------------------+----------------------+-----------+-----------+--------------+-------------
  9 |           3 | cramFilesInputManifest | MANIFEST | f           |  ".tsv"       | t             |               | cram_inputs_manifest        | f                    |           |           |              | 
```

and the service can check whether an input is a MANIFEST type by doing:
```
inputDefinition.type() == PipelineVariableTypesEnum.MANIFEST
```

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-759

### Checklist (provide links to changes)

- [ ] Updated external documentation (if applicable)
- [ ] Updated internal documentation (if applicable)
- [ ] Planned non patch version bump (if applicable)
- [ ] Made ticket for related CLI PR (if applicable)
- [ ] Made ticket for related UI PR (if applicable)
