### PR TITLE
TSPS-780 Access checks on buckets in manifests

### DIFF
--- a/service/src/main/java/bio/terra/pipelines/app/controller/PipelineRunsApiController.java
+++ b/service/src/main/java/bio/terra/pipelines/app/controller/PipelineRunsApiController.java
@@ -218,8 +218,8 @@ public class PipelineRunsApiController implements PipelineRunsApi {
   @Override
   public ResponseEntity<ApiAsyncPipelineRunResponse> startPipelineRun(
       @RequestBody ApiStartPipelineRunRequestBody body) {
-    final SamUser userRequest = getAuthenticatedInfo();
-    String userId = userRequest.getSubjectId();
+    final SamUser authedUser = getAuthenticatedInfo();
+    String userId = authedUser.getSubjectId();
     UUID jobId = body.getJobControl().getId();
 
     PipelineRun pipelineRunBeforeStart = pipelineRunsService.getPipelineRun(jobId, userId);
@@ -243,7 +243,7 @@ public class PipelineRunsApiController implements PipelineRunsApi {
     }
 
     PipelineRun pipelineRunAfterStart =
-        pipelineRunsService.startPipelineRun(pipeline, jobId, userId);
+        pipelineRunsService.startPipelineRun(pipeline, jobId, authedUser);
 
     ApiAsyncPipelineRunResponse createdRunResponse =
         pipelineRunToApi(pipelineRunAfterStart, pipeline);

--- a/service/src/main/java/bio/terra/pipelines/dependencies/gcs/GcsService.java
+++ b/service/src/main/java/bio/terra/pipelines/dependencies/gcs/GcsService.java
@@ -171,6 +171,32 @@ public class GcsService {
     return false;
   }
 
+  public boolean serviceHasBucketReadAccess(String bucketName) {
+    boolean hasAccess = hasBucketReadAccess(bucketName, null);
+    logAccessCheckResult(
+        SERVICE_SUBJECT_FOR_LOGS, "read", "bucket %s".formatted(bucketName), hasAccess);
+    return hasAccess;
+  }
+
+  public boolean userHasBucketReadAccess(String bucketName, @NonNull String accessToken) {
+    boolean hasAccess = hasBucketReadAccess(bucketName, accessToken);
+    logAccessCheckResult(
+        USER_SUBJECT_FOR_LOGS, "read", "bucket %s".formatted(bucketName), hasAccess);
+    return hasAccess;
+  }
+
+  private boolean hasBucketReadAccess(String bucketName, String accessToken) {
+    return executionWithRetryTemplate(
+        listenerResetRetryTemplate,
+        () -> {
+          List<Boolean> accessResult =
+              gcsClient
+                  .getStorageService(accessToken)
+                  .testIamPermissions(bucketName, List.of("storage.objects.get"));
+          return accessResult.size() == 1 && accessResult.get(0);
+        });
+  }
+
   public boolean serviceHasBucketWriteAccess(String bucketName) {
     boolean hasAccess = hasBucketWriteAccess(bucketName, null);
     logAccessCheckResult(

--- a/service/src/main/java/bio/terra/pipelines/dependencies/gcs/GcsService.java
+++ b/service/src/main/java/bio/terra/pipelines/dependencies/gcs/GcsService.java
@@ -43,6 +43,7 @@ public class GcsService {
   private static final String SERVICE_SUBJECT_FOR_LOGS = "Teaspoons service account";
   private static final String USER_SUBJECT_FOR_LOGS = "User";
   private static final String FILE_RESOURCE_FORMAT_FOR_LOGS = "file %s";
+  private static final String BUCKET_RESOURCE_FORMAT_FOR_LOGS = "bucket %s";
 
   /**
    * Helper method to log the result of an access check in a consistent format. Logs at INFO level
@@ -174,14 +175,20 @@ public class GcsService {
   public boolean serviceHasBucketReadAccess(String bucketName) {
     boolean hasAccess = hasBucketReadAccess(bucketName, null);
     logAccessCheckResult(
-        SERVICE_SUBJECT_FOR_LOGS, "read", "bucket %s".formatted(bucketName), hasAccess);
+        SERVICE_SUBJECT_FOR_LOGS,
+        "read",
+        BUCKET_RESOURCE_FORMAT_FOR_LOGS.formatted(bucketName),
+        hasAccess);
     return hasAccess;
   }
 
   public boolean userHasBucketReadAccess(String bucketName, @NonNull String accessToken) {
     boolean hasAccess = hasBucketReadAccess(bucketName, accessToken);
     logAccessCheckResult(
-        USER_SUBJECT_FOR_LOGS, "read", "bucket %s".formatted(bucketName), hasAccess);
+        USER_SUBJECT_FOR_LOGS,
+        "read",
+        BUCKET_RESOURCE_FORMAT_FOR_LOGS.formatted(bucketName),
+        hasAccess);
     return hasAccess;
   }
 
@@ -200,14 +207,20 @@ public class GcsService {
   public boolean serviceHasBucketWriteAccess(String bucketName) {
     boolean hasAccess = hasBucketWriteAccess(bucketName, null);
     logAccessCheckResult(
-        SERVICE_SUBJECT_FOR_LOGS, "write", "bucket %s".formatted(bucketName), hasAccess);
+        SERVICE_SUBJECT_FOR_LOGS,
+        "write",
+        BUCKET_RESOURCE_FORMAT_FOR_LOGS.formatted(bucketName),
+        hasAccess);
     return hasAccess;
   }
 
   public boolean userHasBucketWriteAccess(String bucketName, @NonNull String accessToken) {
     boolean hasAccess = hasBucketWriteAccess(bucketName, accessToken);
     logAccessCheckResult(
-        USER_SUBJECT_FOR_LOGS, "write", "bucket %s".formatted(bucketName), hasAccess);
+        USER_SUBJECT_FOR_LOGS,
+        "write",
+        BUCKET_RESOURCE_FORMAT_FOR_LOGS.formatted(bucketName),
+        hasAccess);
     return hasAccess;
   }
 

--- a/service/src/main/java/bio/terra/pipelines/service/PipelineInputsOutputsService.java
+++ b/service/src/main/java/bio/terra/pipelines/service/PipelineInputsOutputsService.java
@@ -170,6 +170,28 @@ public class PipelineInputsOutputsService {
     }
   }
 
+  public void validateUserAndServiceReadAccessToManifestBuckets(
+      Set<String> gcsBuckets, String userId) {
+    for (String bucketName : gcsBuckets) {
+      boolean userHasAccess =
+          gcsService.userHasBucketReadAccess(
+              bucketName,
+              samService.getUserPetServiceAccountTokenReadOnly(new SamUser(userId)).getToken());
+      if (!userHasAccess) {
+        throw new ValidationException(
+            "User does not have necessary permissions to access the bucket %s containing files referenced in the manifest inputs. Please ensure the user's proxy group has read access to the bucket."
+                .formatted(bucketName));
+      }
+
+      boolean serviceHasAccess = gcsService.serviceHasBucketReadAccess(bucketName);
+      if (!serviceHasAccess) {
+        throw new ValidationException(
+            "Service does not have necessary permissions to access the bucket %s containing files referenced in the manifest inputs. Please ensure that %s has read access to the bucket."
+                .formatted(bucketName, gcsConfiguration.serviceAccountGroupForCloudIntegration()));
+      }
+    }
+  }
+
   /**
    * Generate signed PUT/POST urls and curl commands for each user-provided file input in the
    * pipeline, given local file inputs.
@@ -522,6 +544,17 @@ public class PipelineInputsOutputsService {
       errorMessages.add("File inputs must be all local or all GCS cloud based");
     }
     return errorMessages;
+  }
+
+  /**
+   * Check whether a pipeline has any MANIFEST type inputs.
+   *
+   * @param pipeline to check
+   * @return boolean - true if the pipeline has at least one MANIFEST type input, false otherwise
+   */
+  public boolean pipelineHasManifestInputs(Pipeline pipeline) {
+    return pipeline.getPipelineInputDefinitions().stream()
+        .anyMatch(def -> def.getType() == PipelineVariableTypesEnum.MANIFEST);
   }
 
   /**

--- a/service/src/main/java/bio/terra/pipelines/service/PipelineInputsOutputsService.java
+++ b/service/src/main/java/bio/terra/pipelines/service/PipelineInputsOutputsService.java
@@ -170,23 +170,29 @@ public class PipelineInputsOutputsService {
     }
   }
 
+  /**
+   * Extract all GCS buckets from the manifest inputs and validate that the user and service have
+   * read access to those buckets.
+   */
   public void validateUserAndServiceReadAccessToManifestBuckets(
-      Set<String> gcsBuckets, String userId) {
+      Pipeline pipeline, PipelineRun pipelineRun, SamUser authedUser) {
+    Set<String> gcsBuckets = extractUniqueBucketsFromManifests(pipeline, pipelineRun);
+
     for (String bucketName : gcsBuckets) {
       boolean userHasAccess =
           gcsService.userHasBucketReadAccess(
-              bucketName,
-              samService.getUserPetServiceAccountTokenReadOnly(new SamUser(userId)).getToken());
+              bucketName, samService.getUserPetServiceAccountTokenReadOnly(authedUser).getToken());
       if (!userHasAccess) {
+        String userProxyGroup = samService.getProxyGroupForUser(authedUser);
         throw new ValidationException(
-            "User does not have necessary permissions to access the bucket %s containing files referenced in the manifest inputs. Please ensure the user's proxy group has read access to the bucket."
-                .formatted(bucketName));
+            "User does not have necessary permissions to access the bucket containing files referenced in the manifest inputs (%s). Please ensure the user's proxy group %s has read access to the bucket."
+                .formatted(bucketName, userProxyGroup));
       }
 
       boolean serviceHasAccess = gcsService.serviceHasBucketReadAccess(bucketName);
       if (!serviceHasAccess) {
         throw new ValidationException(
-            "Service does not have necessary permissions to access the bucket %s containing files referenced in the manifest inputs. Please ensure that %s has read access to the bucket."
+            "Service does not have necessary permissions to access the bucket containing files referenced in the manifest inputs (%s). Please ensure that %s has read access to the bucket."
                 .formatted(bucketName, gcsConfiguration.serviceAccountGroupForCloudIntegration()));
       }
     }
@@ -561,17 +567,17 @@ public class PipelineInputsOutputsService {
    * Extract the set of GCS buckets referenced in the user-provided files listed in MANIFEST inputs
    * for a pipeline run.
    *
+   * @param pipeline
    * @param pipelineRun
    * @return Set<String> of unique GCS bucket names referenced in the manifest inputs for the
    *     pipeline run
    */
-  public Set<String> extractUniqueBucketsFromManifests(
-      List<PipelineInputDefinition> pipelineInputDefinitionList,
-      String workspaceStorageContainerName,
-      PipelineRun pipelineRun) {
+  public Set<String> extractUniqueBucketsFromManifests(Pipeline pipeline, PipelineRun pipelineRun) {
     List<GcsFile> inputManifestFiles =
         getInputManifestsForPipelineRun(
-            pipelineInputDefinitionList, workspaceStorageContainerName, pipelineRun);
+            pipeline.getPipelineInputDefinitions(),
+            pipeline.getWorkspaceStorageContainerName(),
+            pipelineRun);
     Set<String> uniqueBuckets = new HashSet<>();
     for (GcsFile manifestGcsFile : inputManifestFiles) {
       Set<String> bucketsFromThisManifest = extractUniqueBucketsFromManifest(manifestGcsFile);
@@ -713,16 +719,21 @@ public class PipelineInputsOutputsService {
    * @throws ValidationException if the number of items in the line is different from the expected
    *     number
    */
-  private void validateLineItemCount(
+  protected void validateLineItemCount(
       String[] items,
       int lineNumber,
       String fileName,
       Integer expectedItemsPerLine,
       boolean isLastLine) {
-    if (hasOnlyEmptyItems(items) && !isLastLine) {
-      throw new ValidationException(
-          "Encountered a non-terminal empty line in manifest file %s at line %d."
-              .formatted(fileName, lineNumber));
+    // only allow empty lines at the end of the file, not in the middle
+    if (hasOnlyEmptyItems(items)) {
+      if (isLastLine) {
+        return;
+      } else {
+        throw new ValidationException(
+            "Encountered a non-terminal empty line in manifest file %s at line %d."
+                .formatted(fileName, lineNumber));
+      }
     }
 
     if (items.length != expectedItemsPerLine) {

--- a/service/src/main/java/bio/terra/pipelines/service/PipelineRunsService.java
+++ b/service/src/main/java/bio/terra/pipelines/service/PipelineRunsService.java
@@ -32,7 +32,6 @@ import bio.terra.stairway.Flight;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.UUID;
 import org.hibernate.exception.ConstraintViolationException;
 import org.slf4j.Logger;
@@ -232,9 +231,10 @@ public class PipelineRunsService {
    */
   @WriteTransaction
   @SuppressWarnings("java:S1301") // allow switch statement with only one case
-  public PipelineRun startPipelineRun(Pipeline pipeline, UUID jobId, String userId) {
+  public PipelineRun startPipelineRun(Pipeline pipeline, UUID jobId, SamUser authedUser) {
 
     PipelinesEnum pipelineName = pipeline.getName();
+    String userId = authedUser.getSubjectId();
 
     validatePipelineWorkspaceSetup(pipeline);
     PipelineRun preparedPipelineRun = getPipelineRun(jobId, userId);
@@ -246,21 +246,9 @@ public class PipelineRunsService {
     validatePipelineRunIsInPreparingState(preparedPipelineRun);
 
     try {
-      // manifest validation
       if (pipelineInputsOutputsService.pipelineHasManifestInputs(pipeline)) {
-        Set<String> gcsBucketsFromManifests =
-            pipelineInputsOutputsService.extractUniqueBucketsFromManifests(
-                pipeline.getPipelineInputDefinitions(),
-                pipeline.getWorkspaceStorageContainerName(),
-                preparedPipelineRun);
-        logger.info(
-            "Extracted {} unique GCS buckets from manifest inputs for jobId {}: {}",
-            gcsBucketsFromManifests.size(),
-            jobId,
-            gcsBucketsFromManifests);
-
         pipelineInputsOutputsService.validateUserAndServiceReadAccessToManifestBuckets(
-            gcsBucketsFromManifests, userId);
+            pipeline, preparedPipelineRun, authedUser);
       }
 
       logger.info("Starting new {} job for user {}", pipelineName, userId);
@@ -415,7 +403,7 @@ public class PipelineRunsService {
                     new InternalServerErrorException(
                         "Pipeline not found for id: " + pipelineRun.getPipelineId()));
 
-    validateUserAndServiceWriteAccessToDestinationPath(
+    validateUserAndServiceWriteAccessToDestinationBucket(
         fullPathWithJobId.getBucketName(), authedUser);
 
     JobBuilder jobBuilder =
@@ -476,7 +464,7 @@ public class PipelineRunsService {
     pipelineRunsRepository.save(pipelineRun);
   }
 
-  public void validateUserAndServiceWriteAccessToDestinationPath(
+  public void validateUserAndServiceWriteAccessToDestinationBucket(
       String destinationBucket, SamUser authedUser) {
 
     boolean userHasBucketWriteAccess =

--- a/service/src/main/java/bio/terra/pipelines/service/PipelineRunsService.java
+++ b/service/src/main/java/bio/terra/pipelines/service/PipelineRunsService.java
@@ -247,16 +247,21 @@ public class PipelineRunsService {
 
     try {
       // manifest validation
-      Set<String> gcsBucketsFromManifests =
-          pipelineInputsOutputsService.extractUniqueBucketsFromManifests(
-              pipeline.getPipelineInputDefinitions(),
-              pipeline.getWorkspaceStorageContainerName(),
-              preparedPipelineRun);
-      logger.info(
-          "Extracted {} unique GCS buckets from manifest inputs for jobId {}: {}",
-          gcsBucketsFromManifests.size(),
-          jobId,
-          gcsBucketsFromManifests);
+      if (pipelineInputsOutputsService.pipelineHasManifestInputs(pipeline)) {
+        Set<String> gcsBucketsFromManifests =
+            pipelineInputsOutputsService.extractUniqueBucketsFromManifests(
+                pipeline.getPipelineInputDefinitions(),
+                pipeline.getWorkspaceStorageContainerName(),
+                preparedPipelineRun);
+        logger.info(
+            "Extracted {} unique GCS buckets from manifest inputs for jobId {}: {}",
+            gcsBucketsFromManifests.size(),
+            jobId,
+            gcsBucketsFromManifests);
+
+        pipelineInputsOutputsService.validateUserAndServiceReadAccessToManifestBuckets(
+            gcsBucketsFromManifests, userId);
+      }
 
       logger.info("Starting new {} job for user {}", pipelineName, userId);
 

--- a/service/src/test/java/bio/terra/pipelines/controller/PipelineRunsApiControllerTest.java
+++ b/service/src/test/java/bio/terra/pipelines/controller/PipelineRunsApiControllerTest.java
@@ -587,8 +587,7 @@ class PipelineRunsApiControllerTest {
     // the mocks
     when(pipelineRunsServiceMock.getPipelineRun(jobId, testUser.getSubjectId()))
         .thenReturn(testPipelinePrepared);
-    when(pipelineRunsServiceMock.startPipelineRun(
-            getTestPipeline(), jobId, testUser.getSubjectId()))
+    when(pipelineRunsServiceMock.startPipelineRun(getTestPipeline(), jobId, testUser))
         .thenReturn(testPipelineRun);
     when(jobServiceMock.retrieveJob(jobId, testUser.getSubjectId(), PipelinesEnum.ARRAY_IMPUTATION))
         .thenReturn(flightState);
@@ -737,8 +736,7 @@ class PipelineRunsApiControllerTest {
     String postBodyAsJson = testStartPipelineRunPostBody(jobId.toString());
 
     // the mocks
-    when(pipelineRunsServiceMock.startPipelineRun(
-            getTestPipeline(), jobId, testUser.getSubjectId()))
+    when(pipelineRunsServiceMock.startPipelineRun(getTestPipeline(), jobId, testUser))
         .thenThrow(new RuntimeException("some message"));
 
     MvcResult result =
@@ -769,8 +767,7 @@ class PipelineRunsApiControllerTest {
     // the mocks - one error that can happen is a MissingRequiredFieldException from Stairway
     when(pipelineRunsServiceMock.getPipelineRun(jobId, testUser.getSubjectId()))
         .thenReturn(getPipelineRunPreparing(description));
-    when(pipelineRunsServiceMock.startPipelineRun(
-            getTestPipeline(), jobId, testUser.getSubjectId()))
+    when(pipelineRunsServiceMock.startPipelineRun(getTestPipeline(), jobId, testUser))
         .thenThrow(new InternalStairwayException("some message"));
 
     MvcResult result =

--- a/service/src/test/java/bio/terra/pipelines/dependencies/gcs/GcsServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/dependencies/gcs/GcsServiceTest.java
@@ -158,7 +158,10 @@ class GcsServiceTest extends BaseEmbeddedDbTest {
   private static Stream<Arguments> bucketReadAccessPermissionsTestArgs() {
     // used for both user and service check tests
     // arguments: list of permission results for "storage.objects.get", expected has access result
-    return Stream.of(Arguments.of(List.of(true), true), Arguments.of(List.of(false), false));
+    return Stream.of(
+        Arguments.of(List.of(true), true),
+        Arguments.of(List.of(false), false),
+        Arguments.of(List.of(), false));
   }
 
   @ParameterizedTest

--- a/service/src/test/java/bio/terra/pipelines/dependencies/gcs/GcsServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/dependencies/gcs/GcsServiceTest.java
@@ -19,8 +19,12 @@ import java.net.SocketTimeoutException;
 import java.net.URL;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.InjectMocks;
@@ -149,6 +153,37 @@ class GcsServiceTest extends BaseEmbeddedDbTest {
   @Test
   void userHasBlobReadAccessFalseNullToken() {
     assertThrows(NullPointerException.class, () -> gcsService.userHasFileReadAccess(gcsFile, null));
+  }
+
+  private static Stream<Arguments> bucketReadAccessPermissionsTestArgs() {
+    // used for both user and service check tests
+    // arguments: list of permission results for "storage.objects.get", expected has access result
+    return Stream.of(Arguments.of(List.of(true), true), Arguments.of(List.of(false), false));
+  }
+
+  @ParameterizedTest
+  @MethodSource("bucketReadAccessPermissionsTestArgs")
+  void serviceHasBucketReadAccess(List<Boolean> permissionResults, boolean expectedHasAccess) {
+    when(mockStorageService.testIamPermissions(bucketName, List.of("storage.objects.get")))
+        .thenReturn(permissionResults);
+
+    assertEquals(expectedHasAccess, gcsService.serviceHasBucketReadAccess(bucketName));
+  }
+
+  @ParameterizedTest
+  @MethodSource("bucketReadAccessPermissionsTestArgs")
+  void userHasBucketReadAccess(List<Boolean> permissionResults, boolean expectedHasAccess) {
+    when(mockStorageService.testIamPermissions(bucketName, List.of("storage.objects.get")))
+        .thenReturn(permissionResults);
+
+    assertEquals(
+        expectedHasAccess, gcsService.userHasBucketReadAccess(bucketName, userBearerToken));
+  }
+
+  @Test
+  void userHasBucketReadAccessFalseNullToken() {
+    assertThrows(
+        NullPointerException.class, () -> gcsService.userHasBucketReadAccess(bucketName, null));
   }
 
   @Test

--- a/service/src/test/java/bio/terra/pipelines/service/PipelineInputsOutputsServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/PipelineInputsOutputsServiceTest.java
@@ -1019,6 +1019,65 @@ class PipelineInputsOutputsServiceTest extends BaseEmbeddedDbTest {
         pipelineInputsOutputsService.validateInputTypes(inputDefinitions, inputs).isEmpty());
   }
 
+  private static Stream<Arguments> lineItemCountValidationTestArgs() {
+    return Stream.of(
+        // arguments: items, expectedItemsPerLine, isLastLine,
+        // shouldPassValidation
+        arguments(new String[] {"item1", "item2", "item3"}, 3, false, true),
+        arguments(new String[] {"item1", "item2", "item3"}, 3, true, true),
+        arguments(new String[] {"item1", "item2"}, 3, false, false), // wrong number of items not ok
+        arguments(
+            new String[] {"item1", "item2"},
+            3,
+            true,
+            false), // wrong number of items even if last line not ok
+        arguments(
+            new String[] {"", "", ""}, 3, false, false), // all empty items not last line not ok
+        arguments(new String[] {"", "", ""}, 3, true, true), // all empty items last line ok
+        arguments(
+            new String[] {"item1", "", ""},
+            3,
+            false,
+            true), // empty items but correct number of items ok
+        arguments(
+            new String[] {"item1", "", ""},
+            3,
+            true,
+            true), // empty items but correct number of items ok even if last line
+        arguments(
+            new String[] {""},
+            3,
+            false,
+            false), // wrong number of items and empty item in not last line not ok
+        arguments(
+            new String[] {""},
+            3,
+            true,
+            true)) // wrong number of items but empty item in last line ok
+    ;
+  }
+
+  @ParameterizedTest
+  @MethodSource("lineItemCountValidationTestArgs")
+  void validateLineItemCount(
+      String[] items, Integer expectedItemsPerLine, boolean isLastLine, boolean expectToPass) {
+    int lineNumber = 5; // only used in error message
+    String fileName = "test_file.tsv"; // only used in error message
+
+    if (expectToPass) {
+      assertDoesNotThrow(
+          () ->
+              pipelineInputsOutputsService.validateLineItemCount(
+                  items, lineNumber, fileName, expectedItemsPerLine, isLastLine));
+    } else {
+      assertThrows(
+          ValidationException.class,
+          () ->
+              pipelineInputsOutputsService.validateLineItemCount(
+                  items, lineNumber, fileName, expectedItemsPerLine, isLastLine));
+    }
+  }
+
   @Test
   void extractUniqueBucketsFromManifests() {
     // test multiple inputs, multiple manifests, don't act on FILE input
@@ -1030,6 +1089,11 @@ class PipelineInputsOutputsServiceTest extends BaseEmbeddedDbTest {
                 "manifest2", "manifest_2", PipelineVariableTypesEnum.MANIFEST, false, true),
             createTestPipelineInputDefWithName(
                 "file1", "file_1", PipelineVariableTypesEnum.FILE, false, true));
+
+    Pipeline pipeline =
+        pipelinesService.getPipeline(
+            TEST_PIPELINE_1_IMPUTATION_ENUM, TEST_PIPELINE_VERSION_1, false);
+    pipeline.setPipelineInputDefinitions(inputDefinitions);
 
     String manifestFile1 = "gs://bucket1/path/to/manifest1.tsv";
     String manifestFile2 = "gs://bucket2/path/to/manifest2.tsv";
@@ -1062,8 +1126,7 @@ class PipelineInputsOutputsServiceTest extends BaseEmbeddedDbTest {
     PipelineRun pipelineRun = createAndSavePipelineRunWithInputs(userInputs);
 
     Set<String> uniqueBucketsResult =
-        pipelineInputsOutputsService.extractUniqueBucketsFromManifests(
-            inputDefinitions, TestUtils.CONTROL_WORKSPACE_CONTAINER_NAME, pipelineRun);
+        pipelineInputsOutputsService.extractUniqueBucketsFromManifests(pipeline, pipelineRun);
 
     assertEquals(expectedBucketSet.size(), uniqueBucketsResult.size());
     assertEquals(expectedBucketSet, uniqueBucketsResult);
@@ -1076,14 +1139,17 @@ class PipelineInputsOutputsServiceTest extends BaseEmbeddedDbTest {
         List.of(
             createTestPipelineInputDefWithName(
                 "file1", "file_1", PipelineVariableTypesEnum.FILE, false, true));
+    Pipeline pipeline =
+        pipelinesService.getPipeline(
+            TEST_PIPELINE_1_IMPUTATION_ENUM, TEST_PIPELINE_VERSION_1, false);
+    pipeline.setPipelineInputDefinitions(inputDefinitions);
 
     Map<String, Object> userInputs = Map.of("file1", "gs://bucket3/path/to/file.vcf.gz");
 
     PipelineRun pipelineRun = createAndSavePipelineRunWithInputs(userInputs);
 
     Set<String> uniqueBucketsResult =
-        pipelineInputsOutputsService.extractUniqueBucketsFromManifests(
-            inputDefinitions, TestUtils.CONTROL_WORKSPACE_CONTAINER_NAME, pipelineRun);
+        pipelineInputsOutputsService.extractUniqueBucketsFromManifests(pipeline, pipelineRun);
 
     assertEquals(0, uniqueBucketsResult.size());
   }
@@ -1096,6 +1162,10 @@ class PipelineInputsOutputsServiceTest extends BaseEmbeddedDbTest {
                 "manifest1", "manifest_1", PipelineVariableTypesEnum.MANIFEST, false, true),
             createTestPipelineInputDefWithName(
                 "manifest2", "manifest_2", PipelineVariableTypesEnum.MANIFEST, false, true));
+    Pipeline pipeline =
+        pipelinesService.getPipeline(
+            TEST_PIPELINE_1_IMPUTATION_ENUM, TEST_PIPELINE_VERSION_1, false);
+    pipeline.setPipelineInputDefinitions(inputDefinitions);
 
     String manifestFile1 = "gs://bucket1/path/to/manifest1.tsv";
 
@@ -1115,8 +1185,7 @@ class PipelineInputsOutputsServiceTest extends BaseEmbeddedDbTest {
     PipelineRun pipelineRun = createAndSavePipelineRunWithInputs(userInputs);
 
     Set<String> uniqueBucketsResult =
-        pipelineInputsOutputsService.extractUniqueBucketsFromManifests(
-            inputDefinitions, TestUtils.CONTROL_WORKSPACE_CONTAINER_NAME, pipelineRun);
+        pipelineInputsOutputsService.extractUniqueBucketsFromManifests(pipeline, pipelineRun);
 
     assertEquals(expectedBucketSet.size(), uniqueBucketsResult.size());
     assertEquals(expectedBucketSet, uniqueBucketsResult);
@@ -1128,6 +1197,10 @@ class PipelineInputsOutputsServiceTest extends BaseEmbeddedDbTest {
         List.of(
             createTestPipelineInputDefWithName(
                 "manifest1", "manifest_1", PipelineVariableTypesEnum.MANIFEST, false, true));
+    Pipeline pipeline =
+        pipelinesService.getPipeline(
+            TEST_PIPELINE_1_IMPUTATION_ENUM, TEST_PIPELINE_VERSION_1, false);
+    pipeline.setPipelineInputDefinitions(inputDefinitions);
 
     String manifestFile1 = "gs://bucket1/path/to/manifest1.tsv";
 
@@ -1146,8 +1219,7 @@ class PipelineInputsOutputsServiceTest extends BaseEmbeddedDbTest {
     assertThrows(
         ValidationException.class,
         () ->
-            pipelineInputsOutputsService.extractUniqueBucketsFromManifests(
-                inputDefinitions, TestUtils.CONTROL_WORKSPACE_CONTAINER_NAME, pipelineRun));
+            pipelineInputsOutputsService.extractUniqueBucketsFromManifests(pipeline, pipelineRun));
   }
 
   @Test
@@ -1156,6 +1228,10 @@ class PipelineInputsOutputsServiceTest extends BaseEmbeddedDbTest {
         List.of(
             createTestPipelineInputDefWithName(
                 "manifest1", "manifest_1", PipelineVariableTypesEnum.MANIFEST, false, true));
+    Pipeline pipeline =
+        pipelinesService.getPipeline(
+            TEST_PIPELINE_1_IMPUTATION_ENUM, TEST_PIPELINE_VERSION_1, false);
+    pipeline.setPipelineInputDefinitions(inputDefinitions);
 
     String manifestFile1 = "gs://bucket1/path/to/manifest1.tsv";
 
@@ -1174,8 +1250,7 @@ class PipelineInputsOutputsServiceTest extends BaseEmbeddedDbTest {
     assertThrows(
         ValidationException.class,
         () ->
-            pipelineInputsOutputsService.extractUniqueBucketsFromManifests(
-                inputDefinitions, TestUtils.CONTROL_WORKSPACE_CONTAINER_NAME, pipelineRun));
+            pipelineInputsOutputsService.extractUniqueBucketsFromManifests(pipeline, pipelineRun));
   }
 
   @Test
@@ -1188,6 +1263,10 @@ class PipelineInputsOutputsServiceTest extends BaseEmbeddedDbTest {
                 "manifest2", "manifest_2", PipelineVariableTypesEnum.MANIFEST, false, true),
             createTestPipelineInputDefWithName(
                 "file1", "file_1", PipelineVariableTypesEnum.FILE, false, true));
+    Pipeline pipeline =
+        pipelinesService.getPipeline(
+            TEST_PIPELINE_1_IMPUTATION_ENUM, TEST_PIPELINE_VERSION_1, false);
+    pipeline.setPipelineInputDefinitions(inputDefinitions);
 
     String manifestFile1 = "path/to/manifest1.tsv";
     String manifestFile2 = "path/to/manifest2.tsv";
@@ -1228,8 +1307,7 @@ class PipelineInputsOutputsServiceTest extends BaseEmbeddedDbTest {
     PipelineRun pipelineRun = createAndSavePipelineRunWithInputs(userInputs);
 
     Set<String> uniqueBucketsResult =
-        pipelineInputsOutputsService.extractUniqueBucketsFromManifests(
-            inputDefinitions, TestUtils.CONTROL_WORKSPACE_CONTAINER_NAME, pipelineRun);
+        pipelineInputsOutputsService.extractUniqueBucketsFromManifests(pipeline, pipelineRun);
 
     assertEquals(expectedBucketSet.size(), uniqueBucketsResult.size());
     assertEquals(expectedBucketSet, uniqueBucketsResult);
@@ -1241,6 +1319,10 @@ class PipelineInputsOutputsServiceTest extends BaseEmbeddedDbTest {
         List.of(
             createTestPipelineInputDefWithName(
                 "manifest1", "manifest_1", PipelineVariableTypesEnum.MANIFEST, false, true));
+    Pipeline pipeline =
+        pipelinesService.getPipeline(
+            TEST_PIPELINE_1_IMPUTATION_ENUM, TEST_PIPELINE_VERSION_1, false);
+    pipeline.setPipelineInputDefinitions(inputDefinitions);
 
     String manifestFile1 = "gs://bucket1/path/to/manifest1.tsv";
 
@@ -1255,8 +1337,7 @@ class PipelineInputsOutputsServiceTest extends BaseEmbeddedDbTest {
     assertThrows(
         InternalServerErrorException.class,
         () ->
-            pipelineInputsOutputsService.extractUniqueBucketsFromManifests(
-                inputDefinitions, TestUtils.CONTROL_WORKSPACE_CONTAINER_NAME, pipelineRun));
+            pipelineInputsOutputsService.extractUniqueBucketsFromManifests(pipeline, pipelineRun));
   }
 
   @Test
@@ -1265,6 +1346,10 @@ class PipelineInputsOutputsServiceTest extends BaseEmbeddedDbTest {
         List.of(
             createTestPipelineInputDefWithName(
                 "manifest1", "manifest_1", PipelineVariableTypesEnum.MANIFEST, false, true));
+    Pipeline pipeline =
+        pipelinesService.getPipeline(
+            TEST_PIPELINE_1_IMPUTATION_ENUM, TEST_PIPELINE_VERSION_1, false);
+    pipeline.setPipelineInputDefinitions(inputDefinitions);
 
     String manifestFile1 = "gs://bucket1/path/to/manifest1.tsv";
     String file1 = "gs://bucket4/path/to/file1.vcf.gz";
@@ -1285,7 +1370,7 @@ class PipelineInputsOutputsServiceTest extends BaseEmbeddedDbTest {
             ValidationException.class,
             () ->
                 pipelineInputsOutputsService.extractUniqueBucketsFromManifests(
-                    inputDefinitions, TestUtils.CONTROL_WORKSPACE_CONTAINER_NAME, pipelineRun));
+                    pipeline, pipelineRun));
     assertTrue(
         e.getMessage()
             .contains(

--- a/service/src/test/java/bio/terra/pipelines/service/PipelineInputsOutputsServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/PipelineInputsOutputsServiceTest.java
@@ -1079,6 +1079,43 @@ class PipelineInputsOutputsServiceTest extends BaseEmbeddedDbTest {
   }
 
   @Test
+  void validateUserAndServiceReadAccessToManifestBucketsOk() {
+    List<PipelineInputDefinition> inputDefinitions =
+        List.of(
+            createTestPipelineInputDefWithName(
+                "manifest1", "manifest_1", PipelineVariableTypesEnum.MANIFEST, false, true));
+    Pipeline pipeline =
+        pipelinesService.getPipeline(
+            TEST_PIPELINE_1_IMPUTATION_ENUM, TEST_PIPELINE_VERSION_1, false);
+    pipeline.setPipelineInputDefinitions(inputDefinitions);
+
+    String manifestFile1 = "gs://bucket1/path/to/manifest1.tsv";
+
+    String file1 = "gs://test-bucket/file1.vcf.gz";
+    String file2 = "gs://test-bucket/file2.vcf.gz";
+    String testBucketName = "test-bucket";
+
+    String manifestFile1Contents = "sample1\t%s%nsample2\t%s%n".formatted(file1, file2);
+
+    SamUser testUser = TestUtils.TEST_SAM_USER_1;
+    BearerToken testUserBearerToken = TEST_USER_1_BEARER_TOKEN;
+    when(mockSamService.getUserPetServiceAccountTokenReadOnly(testUser))
+        .thenReturn(testUserBearerToken);
+    when(mockGcsService.getBufferedReaderForGcsTextFile(new GcsFile(manifestFile1)))
+        .thenReturn(getBufferedReaderForStringTesting(manifestFile1Contents));
+    when(mockGcsService.serviceHasBucketReadAccess(testBucketName)).thenReturn(true);
+    when(mockGcsService.userHasBucketReadAccess(testBucketName, testUserBearerToken.getToken()))
+        .thenReturn(true);
+
+    Map<String, Object> userInputs = Map.of("manifest1", manifestFile1);
+
+    PipelineRun pipelineRun = createAndSavePipelineRunWithInputs(userInputs);
+
+    pipelineInputsOutputsService.validateUserAndServiceReadAccessToManifestBuckets(
+        pipeline, pipelineRun, testUser);
+  }
+
+  @Test
   void extractUniqueBucketsFromManifests() {
     // test multiple inputs, multiple manifests, don't act on FILE input
     List<PipelineInputDefinition> inputDefinitions =
@@ -1378,7 +1415,7 @@ class PipelineInputsOutputsServiceTest extends BaseEmbeddedDbTest {
   }
 
   // helper method to create and save a pipeline run with the given user inputs
-  PipelineRun createAndSavePipelineRunWithInputs(Map<String, Object> userInputs) {
+  private PipelineRun createAndSavePipelineRunWithInputs(Map<String, Object> userInputs) {
     PipelineRun pipelineRun = TestUtils.createNewPipelineRunWithJobId(TEST_JOB_ID);
     pipelineRunsRepository.save(pipelineRun);
 

--- a/service/src/test/java/bio/terra/pipelines/service/PipelineInputsOutputsServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/PipelineInputsOutputsServiceTest.java
@@ -17,6 +17,7 @@ import bio.terra.common.exception.InternalServerErrorException;
 import bio.terra.common.exception.ValidationException;
 import bio.terra.common.iam.BearerToken;
 import bio.terra.common.iam.SamUser;
+import bio.terra.pipelines.app.configuration.external.GcsConfiguration;
 import bio.terra.pipelines.common.GcsFile;
 import bio.terra.pipelines.common.utils.CommonPipelineRunStatusEnum;
 import bio.terra.pipelines.common.utils.PipelineVariableTypesEnum;
@@ -69,6 +70,7 @@ class PipelineInputsOutputsServiceTest extends BaseEmbeddedDbTest {
 
   @MockitoBean private SamService mockSamService;
   @MockitoBean private GcsService mockGcsService;
+  @MockitoBean private GcsConfiguration mockGcsConfiguration;
 
   private static final UUID TEST_JOB_ID = TestUtils.TEST_NEW_UUID;
   private static final String FILE_INPUT_KEY_NAME = "testRequiredVcfInput";
@@ -87,6 +89,8 @@ class PipelineInputsOutputsServiceTest extends BaseEmbeddedDbTest {
               PipelineVariableTypesEnum.MANIFEST,
               true,
               true));
+  private static final String TEST_SA_GROUP_FOR_CLOUD_INTEGRATION =
+      "test-service-account-group@test.com";
 
   @BeforeEach
   void addTestPipelineToDb() {
@@ -386,6 +390,9 @@ class PipelineInputsOutputsServiceTest extends BaseEmbeddedDbTest {
     when(mockSamService.getProxyGroupForUser(testUser)).thenReturn(USER_PROXY_GROUP);
     when(mockSamService.getUserPetServiceAccountTokenReadOnly(testUser)).thenReturn(userPetToken);
 
+    when(mockGcsConfiguration.serviceAccountGroupForCloudIntegration())
+        .thenReturn(TEST_SA_GROUP_FOR_CLOUD_INTEGRATION);
+
     if (shouldPassValidation) {
       assertDoesNotThrow(
           () ->
@@ -398,7 +405,7 @@ class PipelineInputsOutputsServiceTest extends BaseEmbeddedDbTest {
               () ->
                   pipelineInputsOutputsService.validateUserAndServiceReadAccessToCloudInputs(
                       pipeline, userProvidedInputs, testUser));
-      assertTrue(exception.getMessage().contains(expectedErrorMessageString));
+      assertEquals(expectedErrorMessageString, exception.getMessage());
     }
   }
 
@@ -1113,6 +1120,101 @@ class PipelineInputsOutputsServiceTest extends BaseEmbeddedDbTest {
 
     pipelineInputsOutputsService.validateUserAndServiceReadAccessToManifestBuckets(
         pipeline, pipelineRun, testUser);
+  }
+
+  @Test
+  void validateUserAndServiceReadAccessToManifestBucketsFailUserAccess() {
+    List<PipelineInputDefinition> inputDefinitions =
+        List.of(
+            createTestPipelineInputDefWithName(
+                "manifest1", "manifest_1", PipelineVariableTypesEnum.MANIFEST, false, true));
+    Pipeline pipeline =
+        pipelinesService.getPipeline(
+            TEST_PIPELINE_1_IMPUTATION_ENUM, TEST_PIPELINE_VERSION_1, false);
+    pipeline.setPipelineInputDefinitions(inputDefinitions);
+
+    String manifestFile1 = "gs://bucket1/path/to/manifest1.tsv";
+
+    String file1 = "gs://test-bucket/file1.vcf.gz";
+    String file2 = "gs://test-bucket/file2.vcf.gz";
+    String testBucketName = "test-bucket";
+
+    String manifestFile1Contents = "sample1\t%s%nsample2\t%s%n".formatted(file1, file2);
+
+    SamUser testUser = TestUtils.TEST_SAM_USER_1;
+    BearerToken testUserBearerToken = TEST_USER_1_BEARER_TOKEN;
+    String userProxyGroup = "test-user-proxy-group";
+    when(mockSamService.getUserPetServiceAccountTokenReadOnly(testUser))
+        .thenReturn(testUserBearerToken);
+    when(mockSamService.getProxyGroupForUser(testUser)).thenReturn(userProxyGroup);
+    when(mockGcsService.getBufferedReaderForGcsTextFile(new GcsFile(manifestFile1)))
+        .thenReturn(getBufferedReaderForStringTesting(manifestFile1Contents));
+    when(mockGcsService.serviceHasBucketReadAccess(testBucketName)).thenReturn(true);
+    when(mockGcsService.userHasBucketReadAccess(testBucketName, testUserBearerToken.getToken()))
+        .thenReturn(false);
+
+    Map<String, Object> userInputs = Map.of("manifest1", manifestFile1);
+
+    PipelineRun pipelineRun = createAndSavePipelineRunWithInputs(userInputs);
+
+    ValidationException thrownException =
+        assertThrows(
+            ValidationException.class,
+            () ->
+                pipelineInputsOutputsService.validateUserAndServiceReadAccessToManifestBuckets(
+                    pipeline, pipelineRun, testUser));
+    assertEquals(
+        "User does not have necessary permissions to access the bucket containing files referenced in the manifest inputs (%s). Please ensure the user's proxy group %s has read access to the bucket."
+            .formatted(testBucketName, userProxyGroup),
+        thrownException.getMessage());
+  }
+
+  @Test
+  void validateUserAndServiceReadAccessToManifestBucketsFailServiceAccess() {
+    List<PipelineInputDefinition> inputDefinitions =
+        List.of(
+            createTestPipelineInputDefWithName(
+                "manifest1", "manifest_1", PipelineVariableTypesEnum.MANIFEST, false, true));
+    Pipeline pipeline =
+        pipelinesService.getPipeline(
+            TEST_PIPELINE_1_IMPUTATION_ENUM, TEST_PIPELINE_VERSION_1, false);
+    pipeline.setPipelineInputDefinitions(inputDefinitions);
+
+    String manifestFile1 = "gs://bucket1/path/to/manifest1.tsv";
+
+    String file1 = "gs://test-bucket/file1.vcf.gz";
+    String file2 = "gs://test-bucket/file2.vcf.gz";
+    String testBucketName = "test-bucket";
+
+    String manifestFile1Contents = "sample1\t%s%nsample2\t%s%n".formatted(file1, file2);
+
+    SamUser testUser = TestUtils.TEST_SAM_USER_1;
+    BearerToken testUserBearerToken = TEST_USER_1_BEARER_TOKEN;
+
+    when(mockSamService.getUserPetServiceAccountTokenReadOnly(testUser))
+        .thenReturn(testUserBearerToken);
+    when(mockGcsService.getBufferedReaderForGcsTextFile(new GcsFile(manifestFile1)))
+        .thenReturn(getBufferedReaderForStringTesting(manifestFile1Contents));
+    when(mockGcsService.serviceHasBucketReadAccess(testBucketName)).thenReturn(false);
+    when(mockGcsService.userHasBucketReadAccess(testBucketName, testUserBearerToken.getToken()))
+        .thenReturn(true);
+    when(mockGcsConfiguration.serviceAccountGroupForCloudIntegration())
+        .thenReturn(TEST_SA_GROUP_FOR_CLOUD_INTEGRATION);
+
+    Map<String, Object> userInputs = Map.of("manifest1", manifestFile1);
+
+    PipelineRun pipelineRun = createAndSavePipelineRunWithInputs(userInputs);
+
+    ValidationException thrownException =
+        assertThrows(
+            ValidationException.class,
+            () ->
+                pipelineInputsOutputsService.validateUserAndServiceReadAccessToManifestBuckets(
+                    pipeline, pipelineRun, testUser));
+    assertEquals(
+        "Service does not have necessary permissions to access the bucket containing files referenced in the manifest inputs (%s). Please ensure that test-service-account-group@test.com has read access to the bucket."
+            .formatted(testBucketName),
+        thrownException.getMessage());
   }
 
   @Test

--- a/service/src/test/java/bio/terra/pipelines/service/PipelineRunsServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/PipelineRunsServiceTest.java
@@ -66,7 +66,6 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
   @MockitoBean private GcsService mockGcsService;
   @MockitoBean private SamService mockSamService;
   @MockitoBean private GcsConfiguration mockGcsConfiguration;
-  //  @Autowired private DataDeliveryService dataDeliveryService;
 
   private final SamUser testUser = TestUtils.TEST_SAM_USER_1;
   private final String testUserId = TestUtils.TEST_USER_1_ID;

--- a/service/src/test/java/bio/terra/pipelines/service/PipelineRunsServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/PipelineRunsServiceTest.java
@@ -14,6 +14,7 @@ import bio.terra.common.iam.SamUser;
 import bio.terra.pipelines.app.configuration.external.GcsConfiguration;
 import bio.terra.pipelines.common.GcsFile;
 import bio.terra.pipelines.common.utils.CommonPipelineRunStatusEnum;
+import bio.terra.pipelines.common.utils.PipelineVariableTypesEnum;
 import bio.terra.pipelines.db.entities.Pipeline;
 import bio.terra.pipelines.db.entities.PipelineOutput;
 import bio.terra.pipelines.db.entities.PipelineRun;
@@ -64,6 +65,8 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
   @MockitoBean private JobBuilder mockJobBuilder;
   @MockitoBean private GcsService mockGcsService;
   @MockitoBean private SamService mockSamService;
+  @MockitoBean private GcsConfiguration mockGcsConfiguration;
+  //  @Autowired private DataDeliveryService dataDeliveryService;
 
   private final SamUser testUser = TestUtils.TEST_SAM_USER_1;
   private final String testUserId = TestUtils.TEST_USER_1_ID;
@@ -82,10 +85,6 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
   private final Integer testQuotaConsumed = 10;
 
   private SimpleMeterRegistry meterRegistry;
-  @Autowired private SamService samService;
-  @Autowired private GcsConfiguration gcsConfiguration;
-  @Autowired private GcsService gcsService;
-  @Autowired private DataDeliveryService dataDeliveryService;
 
   @BeforeEach
   void initMocks() {
@@ -405,8 +404,6 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
 
       GcsFile gcsInputFile = new GcsFile(fileInputValue);
 
-      when(mockSamService.getUserPetServiceAccountTokenReadOnly(testUser))
-          .thenReturn(testUserBearerToken);
       when(mockGcsService.userHasFileReadAccess(gcsInputFile, testUserBearerToken.getToken()))
           .thenReturn(true);
       when(mockGcsService.serviceHasFileReadAccess(gcsInputFile)).thenReturn(true);
@@ -774,7 +771,7 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
   }
 
   @Test
-  void startPipelineRunImputation() {
+  void startPipelineRunArrayImputation() {
     Pipeline testPipelineWithId = updateTestPipeline1WithTestValues();
 
     // write a prepared pipeline run to the db
@@ -812,6 +809,60 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
     assertEquals(CommonPipelineRunStatusEnum.RUNNING, savedRun.getStatus());
     assertNotNull(savedRun.getCreated());
     assertNotNull(savedRun.getUpdated());
+
+    // verify submit was called
+    verify(mockJobBuilder).submit();
+  }
+
+  @Test
+  void startPipelineRunWithManifestInput() {
+    String manifestInputName = "manifestInput";
+    String manifestInputValue = "gs://fake-manifest-bucket/manifest.tsv";
+    String manifestContentsBucket = "fake-cram-bucket";
+    String manifestInputContents =
+        "sampleId\tfilePath\nsample1\tgs://fake-cram-bucket/sample1.vcf.gz\nsample2\tgs://fake-cram-bucket/sample2.vcf.gz";
+
+    Pipeline testPipeline = addNewTestPipelineWithTestValues();
+    testPipeline.setPipelineInputDefinitions(
+        List.of(
+            createTestPipelineInputDefWithName(
+                manifestInputName,
+                "manifest_input",
+                PipelineVariableTypesEnum.MANIFEST,
+                true,
+                true)));
+    pipelinesRepository.save(testPipeline);
+
+    Map<String, Object> testInputsWithManifest =
+        new HashMap<>(Map.of(manifestInputName, manifestInputValue));
+
+    // write a prepared pipeline run to the db
+    pipelineRunsService.writeNewPipelineRunToDb(
+        testJobId,
+        testUserId,
+        testPipeline.getId(),
+        testToolVersion,
+        testControlWorkspaceProject,
+        testControlWorkspaceName,
+        testControlWorkspaceStorageContainerName,
+        testControlWorkspaceGoogleProject,
+        testInputsWithManifest,
+        testUserDescription);
+
+    // override this mock to ensure the correct flight class is being requested
+    when(mockJobBuilder.flightClass(RunImputationGcpJobFlight.class)).thenReturn(mockJobBuilder);
+
+    when(mockGcsService.getBufferedReaderForGcsTextFile(new GcsFile(manifestInputValue)))
+        .thenReturn(getBufferedReaderForStringTesting(manifestInputContents));
+    when(mockGcsService.serviceHasBucketReadAccess(manifestContentsBucket)).thenReturn(true);
+    when(mockGcsService.userHasBucketReadAccess(
+            manifestContentsBucket, testUserBearerToken.getToken()))
+        .thenReturn(true);
+
+    PipelineRun returnedPipelineRun =
+        pipelineRunsService.startPipelineRun(testPipeline, testJobId, testUser);
+
+    assertEquals(testJobId, returnedPipelineRun.getJobId());
 
     // verify submit was called
     verify(mockJobBuilder).submit();
@@ -990,9 +1041,9 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
               mockPipelineRunsRepository,
               null,
               null,
-              samService,
-              gcsConfiguration,
-              gcsService,
+              mockSamService,
+              mockGcsConfiguration,
+              mockGcsService,
               pipelinesRepository);
 
       // query with null sort params, should default to created DESC
@@ -1020,9 +1071,9 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
               mockPipelineRunsRepository,
               null,
               null,
-              samService,
-              gcsConfiguration,
-              gcsService,
+              mockSamService,
+              mockGcsConfiguration,
+              mockGcsService,
               pipelinesRepository);
 
       // query with null sort property, should default to created
@@ -1154,9 +1205,9 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
             mockPipelineRunsRepository,
             null,
             null,
-            samService,
-            gcsConfiguration,
-            gcsService,
+            mockSamService,
+            mockGcsConfiguration,
+            mockGcsService,
             pipelinesRepository);
 
     mockPipelineRunsService.findPipelineRunsPaginated(
@@ -1192,9 +1243,9 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
             mockPipelineRunsRepository,
             null,
             null,
-            samService,
-            gcsConfiguration,
-            gcsService,
+            mockSamService,
+            mockGcsConfiguration,
+            mockGcsService,
             pipelinesRepository);
 
     Map<String, String> filters = new HashMap<>();
@@ -1280,9 +1331,10 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
 
     String destinationPath = "gs://test-bucket/test-path";
 
-    when(gcsService.userHasBucketWriteAccess("test-bucket", testUser.getBearerToken().getToken()))
+    when(mockGcsService.userHasBucketWriteAccess(
+            "test-bucket", testUser.getBearerToken().getToken()))
         .thenReturn(true);
-    when(gcsService.serviceHasBucketWriteAccess("test-bucket")).thenReturn(true);
+    when(mockGcsService.serviceHasBucketWriteAccess("test-bucket")).thenReturn(true);
 
     UUID returnedJobId =
         pipelineRunsService.submitDataDeliveryFlight(
@@ -1303,9 +1355,10 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
     UUID deliveryJobId = UUID.randomUUID();
     String destinationPath = "gs://test-bucket/test-path";
 
-    when(gcsService.userHasBucketWriteAccess("test-bucket", testUser.getBearerToken().getToken()))
+    when(mockGcsService.userHasBucketWriteAccess(
+            "test-bucket", testUser.getBearerToken().getToken()))
         .thenReturn(true);
-    when(gcsService.serviceHasBucketWriteAccess("test-bucket")).thenReturn(true);
+    when(mockGcsService.serviceHasBucketWriteAccess("test-bucket")).thenReturn(true);
 
     pipelineRunsService.submitDataDeliveryFlight(
         testPipelineRun, deliveryJobId, destinationPath, testUser);
@@ -1331,9 +1384,10 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
     UUID deliveryJobId = UUID.randomUUID();
     String destinationPath = "gs://test-bucket/test-path";
 
-    when(gcsService.userHasBucketWriteAccess("test-bucket", testUser.getBearerToken().getToken()))
+    when(mockGcsService.userHasBucketWriteAccess(
+            "test-bucket", testUser.getBearerToken().getToken()))
         .thenReturn(false);
-    when(gcsService.serviceHasBucketWriteAccess("test-bucket")).thenReturn(true);
+    when(mockGcsService.serviceHasBucketWriteAccess("test-bucket")).thenReturn(true);
     when(mockSamService.getProxyGroupForUser(testUser)).thenReturn("test-proxy-group");
 
     ValidationException exception =
@@ -1364,9 +1418,10 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
     UUID deliveryJobId = UUID.randomUUID();
     String destinationPath = "gs://test-bucket/test-path";
 
-    when(gcsService.userHasBucketWriteAccess("test-bucket", testUser.getBearerToken().getToken()))
+    when(mockGcsService.userHasBucketWriteAccess(
+            "test-bucket", testUser.getBearerToken().getToken()))
         .thenReturn(true);
-    when(gcsService.serviceHasBucketWriteAccess("test-bucket")).thenReturn(false);
+    when(mockGcsService.serviceHasBucketWriteAccess("test-bucket")).thenReturn(false);
 
     ValidationException exception =
         assertThrows(
@@ -1392,9 +1447,9 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
     testPipelineRun.setPipelineId(savedPipeline.getId());
     pipelineRunsRepository.save(testPipelineRun);
 
-    when(gcsService.userHasBucketWriteAccess("bucket", testUser.getBearerToken().getToken()))
+    when(mockGcsService.userHasBucketWriteAccess("bucket", testUser.getBearerToken().getToken()))
         .thenReturn(true);
-    when(gcsService.serviceHasBucketWriteAccess("bucket")).thenReturn(true);
+    when(mockGcsService.serviceHasBucketWriteAccess("bucket")).thenReturn(true);
 
     pipelineRunsService.submitDataDeliveryFlight(
         testPipelineRun, UUID.randomUUID(), "gs://bucket/path", testUser);
@@ -1412,9 +1467,9 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
     testPipelineRun.setPipelineId(savedPipeline.getId());
     pipelineRunsRepository.save(testPipelineRun);
 
-    when(gcsService.userHasBucketWriteAccess("bucket", testUser.getBearerToken().getToken()))
+    when(mockGcsService.userHasBucketWriteAccess("bucket", testUser.getBearerToken().getToken()))
         .thenReturn(true);
-    when(gcsService.serviceHasBucketWriteAccess("bucket")).thenReturn(true);
+    when(mockGcsService.serviceHasBucketWriteAccess("bucket")).thenReturn(true);
 
     pipelineRunsService.submitDataDeliveryFlight(
         testPipelineRun, UUID.randomUUID(), "gs://bucket/path", testUser);

--- a/service/src/test/java/bio/terra/pipelines/service/PipelineRunsServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/PipelineRunsServiceTest.java
@@ -695,7 +695,7 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
         InternalServerErrorException.class,
         () ->
             pipelineRunsService.startPipelineRun(
-                testPipelineWithIdMissingWorkspaceProject, testJobId, testUserId));
+                testPipelineWithIdMissingWorkspaceProject, testJobId, testUser));
 
     // missing workspace name
     Pipeline testPipelineWithIdMissingWorkspaceName = updateTestPipeline1WithTestValues();
@@ -705,7 +705,7 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
         InternalServerErrorException.class,
         () ->
             pipelineRunsService.startPipelineRun(
-                testPipelineWithIdMissingWorkspaceName, testJobId, testUserId));
+                testPipelineWithIdMissingWorkspaceName, testJobId, testUser));
 
     // missing workspace storage container url
     Pipeline testPipelineWithIdMissingWorkspaceStorageContainerUrl =
@@ -716,7 +716,7 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
         InternalServerErrorException.class,
         () ->
             pipelineRunsService.startPipelineRun(
-                testPipelineWithIdMissingWorkspaceStorageContainerUrl, testJobId, testUserId));
+                testPipelineWithIdMissingWorkspaceStorageContainerUrl, testJobId, testUser));
   }
 
   @Test
@@ -725,7 +725,7 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
 
     assertThrows(
         BadRequestException.class,
-        () -> pipelineRunsService.startPipelineRun(testPipelineWithId, testJobId, testUserId));
+        () -> pipelineRunsService.startPipelineRun(testPipelineWithId, testJobId, testUser));
   }
 
   @Test
@@ -748,7 +748,7 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
 
     assertThrows(
         BadRequestException.class,
-        () -> pipelineRunsService.startPipelineRun(testPipelineWithId, testJobId, testUserId));
+        () -> pipelineRunsService.startPipelineRun(testPipelineWithId, testJobId, testUser));
   }
 
   @Test
@@ -770,7 +770,7 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
 
     assertThrows(
         BadRequestException.class,
-        () -> pipelineRunsService.startPipelineRun(testPipelineWithId, testJobId, testUserId));
+        () -> pipelineRunsService.startPipelineRun(testPipelineWithId, testJobId, testUser));
   }
 
   @Test
@@ -794,7 +794,7 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
     when(mockJobBuilder.flightClass(RunImputationGcpJobFlight.class)).thenReturn(mockJobBuilder);
 
     PipelineRun returnedPipelineRun =
-        pipelineRunsService.startPipelineRun(testPipelineWithId, testJobId, testUserId);
+        pipelineRunsService.startPipelineRun(testPipelineWithId, testJobId, testUser);
 
     assertEquals(testJobId, returnedPipelineRun.getJobId());
     assertEquals(testUserId, returnedPipelineRun.getUserId());
@@ -828,7 +828,7 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
 
     assertThrows(
         RuntimeException.class,
-        () -> pipelineRunsService.startPipelineRun(testPipelineWithId, testJobId, testUserId));
+        () -> pipelineRunsService.startPipelineRun(testPipelineWithId, testJobId, testUser));
 
     // check that the pipeline is not persisted to the pipeline_runs table
     assertEquals(


### PR DESCRIPTION
### Description 

When users submit input data files via a manifest, we need to ensure that both the user and the service have access to those files. We do this in the /start step by checking read access on the set of buckets referenced in their manifest file. 

Note that these access checks are separate from the checks done on cloud-hosted manifest files themselves. (Those checks have been implemented and occur in the /prepare step.)

User and service have access to bucket in manifest:
```
✗ terralab submit array_imputation --multiSampleVcf gs://fc-secure-972057b6-fce1-4ec9-be0c-0e5c97fdc3e8/input_data/NA12878.liftedover.vcf.gz --outputBasename test --manifestInput gs://fc-secure-972057b6-fce1-4ec9-be0c-0e5c97fdc3e8/scratch/fakeCramManifestGoodAccess.tsv

Generated job_id 2f0954db-c780-4422-8c0c-4807fbf05ba6
Successfully started array_imputation job 2f0954db-c780-4422-8c0c-4807fbf05ba6
```

Service doesn't have access to bucket in manifest:
```
✗ terralab submit array_imputation --multiSampleVcf gs://fc-secure-972057b6-fce1-4ec9-be0c-0e5c97fdc3e8/input_data/NA12878.liftedover.vcf.gz --outputBasename test --manifestInput gs://fc-secure-972057b6-fce1-4ec9-be0c-0e5c97fdc3e8/scratch/fakeCramManifestNoServiceAccess.tsv

Generated job_id f19e253b-8c53-44cb-86e8-edb9ff1f7f52

API call failed with status code 400: Service does not have necessary permissions to access the bucket containing files referenced in the manifest inputs (fc-431ee27b-67d9-4a5c-b087-226db01368f8). Please ensure that broad-scientific-services@dev.test.firecloud.org has read access to the bucket.
```

User doesn't have access to bucket in manifest:
```
✗ terralab submit array_imputation --multiSampleVcf gs://fc-secure-972057b6-fce1-4ec9-be0c-0e5c97fdc3e8/input_data/NA12878.liftedover.vcf.gz --outputBasename test --manifestInput gs://fc-secure-972057b6-fce1-4ec9-be0c-0e5c97fdc3e8/scratch/fakeCramManifestNoUserAccessAndNoServiceAccess.tsv

Generated job_id 11ea400f-f6ab-47fa-a744-663fcce4ebc7

API call failed with status code 400: User does not have necessary permissions to access the bucket containing files referenced in the manifest inputs (fc-cddd72b5-323c-495c-9557-5057fff0275a). Please ensure the user's proxy group PROXY_25695932148814f590bb4@dev.test.firecloud.org has read access to the bucket.
```

### Jira Ticket

### Checklist (provide links to changes)

- [ ] Updated external documentation (if applicable)
- [ ] Updated internal documentation (if applicable)
- [ ] Planned non patch version bump (if applicable)
- [ ] Made ticket for related CLI PR (if applicable)
- [ ] Made ticket for related UI PR (if applicable)
