### PR TITLE
fix pipeline name filter in filter specification

### DIFF
--- a/service/src/main/java/bio/terra/pipelines/common/utils/PipelineRunFilterSpecification.java
+++ b/service/src/main/java/bio/terra/pipelines/common/utils/PipelineRunFilterSpecification.java
@@ -4,9 +4,10 @@ import bio.terra.pipelines.db.entities.Pipeline;
 import bio.terra.pipelines.db.entities.PipelineRun;
 import bio.terra.pipelines.service.exception.InvalidFilterException;
 import jakarta.persistence.criteria.CriteriaBuilder;
-import jakarta.persistence.criteria.Join;
+import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
+import jakarta.persistence.criteria.Subquery;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -53,7 +54,7 @@ public class PipelineRunFilterSpecification {
                     break;
                   case FILTER_PIPELINE_NAME:
                     predicates.add(
-                        validateAndBuildPipelineNamePredicate(value, root, criteriaBuilder));
+                        validateAndBuildPipelineNamePredicate(value, root, query, criteriaBuilder));
                     break;
                   case FILTER_DESCRIPTION:
                     predicates.add(
@@ -98,10 +99,31 @@ public class PipelineRunFilterSpecification {
   }
 
   private static Predicate validateAndBuildPipelineNamePredicate(
-      String value, Root<PipelineRun> root, CriteriaBuilder criteriaBuilder) {
-    // Join to Pipeline table to filter by name
-    Join<PipelineRun, Pipeline> pipelineJoin = root.join("pipeline");
-    return criteriaBuilder.equal(pipelineJoin.get("name"), value);
+      String value,
+      Root<PipelineRun> root,
+      CriteriaQuery<?> query,
+      CriteriaBuilder criteriaBuilder) {
+    PipelinesEnum pipelineName;
+    try {
+      pipelineName = PipelinesEnum.valueOf(value.toUpperCase());
+    } catch (IllegalArgumentException e) {
+      throw new InvalidFilterException(
+          String.format(
+              "Invalid pipelineName. Valid pipeline names are: %s.",
+              String.join(
+                  ", ",
+                  java.util.Arrays.stream(PipelinesEnum.values())
+                      .map(Enum::name)
+                      .toArray(String[]::new))));
+    }
+    // Use a subquery to find the Pipeline id(s) matching the given name,
+    // since PipelineRun only stores pipelineId (no JPA relationship to Pipeline).
+    Subquery<Long> subquery = query.subquery(Long.class);
+    Root<Pipeline> pipelineRoot = subquery.from(Pipeline.class);
+    subquery
+        .select(pipelineRoot.get("id"))
+        .where(criteriaBuilder.equal(pipelineRoot.get("name"), pipelineName));
+    return root.get("pipelineId").in(subquery);
   }
 
   private static Predicate validateAndBuildDescriptionPredicate(

--- a/service/src/test/java/bio/terra/pipelines/common/utils/PipelineRunFilterSpecificationTest.java
+++ b/service/src/test/java/bio/terra/pipelines/common/utils/PipelineRunFilterSpecificationTest.java
@@ -1,9 +1,10 @@
 package bio.terra.pipelines.common.utils;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
+import bio.terra.pipelines.db.entities.Pipeline;
 import bio.terra.pipelines.db.entities.PipelineRun;
 import bio.terra.pipelines.service.exception.InvalidFilterException;
 import jakarta.persistence.criteria.*;
@@ -24,7 +25,8 @@ class PipelineRunFilterSpecificationTest {
   @Mock private CriteriaBuilder criteriaBuilder;
   @Mock private Path<Object> path;
   @Mock private Predicate predicate;
-  @Mock private Join<Object, Object> pipelineJoin;
+  @Mock private Subquery<Long> pipelineIdSubquery;
+  @Mock private Root<Pipeline> pipelineRoot;
   @Mock private Expression<String> stringExpression;
 
   private static final String TEST_USER_ID = "test-user-123";
@@ -146,8 +148,13 @@ class PipelineRunFilterSpecificationTest {
   @Test
   void testBuildSpecificationWithUserId_pipelineNameFilter_valid() {
     when(criteriaBuilder.and(any(Predicate[].class))).thenReturn(predicate);
-    when(root.join(anyString())).thenReturn(pipelineJoin);
-    when(pipelineJoin.get(anyString())).thenReturn(path);
+    when(query.subquery(Long.class)).thenReturn(pipelineIdSubquery);
+    when(pipelineIdSubquery.from(Pipeline.class)).thenReturn(pipelineRoot);
+    when(pipelineIdSubquery.select(any())).thenReturn(pipelineIdSubquery);
+    // lenient() required because root.get("userId") is always called first in the production code,
+    // which would otherwise trigger PotentialStubbingProblem before the "pipelineId" stub is used.
+    lenient().when(root.get("pipelineId")).thenReturn(path);
+    lenient().when(path.in(pipelineIdSubquery)).thenReturn(predicate);
 
     Map<String, String> filters = new HashMap<>();
     filters.put(PipelineRunFilterSpecification.FILTER_PIPELINE_NAME, "array_imputation");
@@ -159,8 +166,25 @@ class PipelineRunFilterSpecificationTest {
     Predicate result = spec.toPredicate(root, query, criteriaBuilder);
 
     assertNotNull(result);
-    verify(root).join("pipeline");
-    verify(criteriaBuilder).equal(pipelineJoin.get("name"), "array_imputation");
+    verify(query).subquery(Long.class);
+    verify(pipelineIdSubquery).from(Pipeline.class);
+    verify(criteriaBuilder).equal(any(), eq(PipelinesEnum.ARRAY_IMPUTATION));
+    verify(path).in(pipelineIdSubquery);
+  }
+
+  @Test
+  void testBuildSpecificationWithUserId_pipelineNameFilter_invalid() {
+    Map<String, String> filters = new HashMap<>();
+    filters.put(PipelineRunFilterSpecification.FILTER_PIPELINE_NAME, "invalid_pipeline");
+
+    Specification<PipelineRun> spec =
+        PipelineRunFilterSpecification.buildFilterSpecificationWithUserId(filters, TEST_USER_ID);
+
+    InvalidFilterException exception =
+        assertThrows(
+            InvalidFilterException.class, () -> spec.toPredicate(root, query, criteriaBuilder));
+
+    assertTrue(exception.getMessage().contains("Invalid pipelineName. Valid pipeline names are"));
   }
 
   @Test

--- a/service/src/test/java/bio/terra/pipelines/service/PipelineRunsServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/PipelineRunsServiceTest.java
@@ -15,6 +15,7 @@ import bio.terra.pipelines.app.configuration.external.GcsConfiguration;
 import bio.terra.pipelines.common.GcsFile;
 import bio.terra.pipelines.common.utils.CommonPipelineRunStatusEnum;
 import bio.terra.pipelines.common.utils.PipelineVariableTypesEnum;
+import bio.terra.pipelines.common.utils.PipelinesEnum;
 import bio.terra.pipelines.db.entities.Pipeline;
 import bio.terra.pipelines.db.entities.PipelineOutput;
 import bio.terra.pipelines.db.entities.PipelineRun;
@@ -1231,9 +1232,14 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
     Root<PipelineRun> root = mock(Root.class);
     CriteriaQuery<?> query = mock(CriteriaQuery.class);
     CriteriaBuilder cb = mock(CriteriaBuilder.class);
-    Join<Object, Object> pipelineJoin = mock(Join.class);
+    Subquery<Long> pipelineIdSubquery = mock(Subquery.class);
+    Root<Pipeline> pipelineRoot = mock(Root.class);
+    Path<Object> pipelineIdPath = mock(Path.class);
 
-    when(root.join(anyString())).thenReturn(pipelineJoin);
+    when(query.subquery(Long.class)).thenReturn(pipelineIdSubquery);
+    when(pipelineIdSubquery.from(Pipeline.class)).thenReturn(pipelineRoot);
+    when(pipelineIdSubquery.select(any())).thenReturn(pipelineIdSubquery);
+    when(root.get("pipelineId")).thenReturn(pipelineIdPath);
 
     PipelineRunsService mockPipelineRunsService =
         new PipelineRunsService(
@@ -1263,7 +1269,10 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
     verify(cb).equal(root.get("userId"), testUserId);
     verify(cb).equal(root.get("status"), CommonPipelineRunStatusEnum.SUCCEEDED);
     verify(cb).like(root.get("description"), "%bla%");
-    verify(cb).equal(root.get("pipelineName"), "array_imputation");
+    // pipelineName now uses a subquery against the Pipeline table
+    verify(query).subquery(Long.class);
+    verify(pipelineIdSubquery).from(Pipeline.class);
+    verify(cb).equal(any(), eq(PipelinesEnum.ARRAY_IMPUTATION));
   }
 
   @Test


### PR DESCRIPTION
### Description 

we removed that Pipeline relationship in the. PipelineRun entity class which the pipeline name filter specification was relying on.  This changes it to not relly on that relationship.

no pipeline name filter
<img width="1400" height="455" alt="Screenshot 2026-04-10 at 9 58 00 AM" src="https://github.com/user-attachments/assets/7a7d3b1f-52b6-4515-90a4-a565a0eeed4a" />

bad pipeline name filter
<img width="1429" height="439" alt="Screenshot 2026-04-10 at 9 58 16 AM" src="https://github.com/user-attachments/assets/bd29a4ee-5faa-4bc8-af9c-0cee7caf9eb7" />

good pipelien name filter
<img width="1409" height="473" alt="Screenshot 2026-04-10 at 9 58 29 AM" src="https://github.com/user-attachments/assets/d9acb9c4-df77-41e6-ae2a-fc9a3f6ea460" />

### Jira Ticket
N/A

### Checklist (provide links to changes)

- [ ] Updated external documentation (if applicable)
- [ ] Updated internal documentation (if applicable)
- [ ] Planned non patch version bump (if applicable)
- [ ] Made ticket for related CLI PR (if applicable)
- [ ] Made ticket for related UI PR (if applicable)
