### PR TITLE
TSPS-773 Support for left aligned ref panel in array_imputation v2: update pipeline description, specify v2 paths

### DIFF
--- a/service/src/main/resources/db/changelog.xml
+++ b/service/src/main/resources/db/changelog.xml
@@ -31,6 +31,7 @@
   <include file="changesets/20260226_rename_pipeline_inputs_job_id.yaml" relativeToChangelogFile="true"/>
   <include file="changesets/20260309_add_output_file_size.yaml" relativeToChangelogFile="true"/>
   <include file="changesets/20260403_data_delivery_table.yaml" relativeToChangelogFile="true"/>
+  <include file="changesets/20260413_update_array_imputation_v2_description.yaml" relativeToChangelogFile="true"/>
 
   <include file="changesets/testdata.yaml" relativeToChangelogFile="true"/>
 

--- a/service/src/main/resources/db/changesets/20260413_update_array_imputation_v2_description.yaml
+++ b/service/src/main/resources/db/changesets/20260413_update_array_imputation_v2_description.yaml
@@ -1,0 +1,17 @@
+# update the description of the array_imputation v2 pipeline
+
+databaseChangeLog:
+  -  changeSet:
+       id:  update the description of the array_imputation v2 pipeline
+       author:  mma
+       changes:
+         - update:
+             tableName: pipelines
+             columns:
+               - column:
+                  name: description
+                  value: 'Phase and impute genotypes using Beagle with the All of Us + AnVIL reference panel of 515,579 samples.'
+               - column:
+                  name: display_name
+                  value: 'All of Us + AnVIL Array Imputation'
+             where: name='array_imputation' and version=2

--- a/service/src/main/resources/pipelines-config.yml
+++ b/service/src/main/resources/pipelines-config.yml
@@ -6,6 +6,10 @@ env:
         # the default currently points to the GCP dev workspace teaspoons-imputation-dev/teaspoons_imputation_dev_storage_workspace_20240726
         storageWorkspaceContainerUrl: ${IMPUTATION_STORAGE_WORKSPACE_STORAGE_URL:gs://fc-secure-10efd4d7-392a-4e9e-89ea-d6629fbb06cc}
         referencePanelPathPrefixCustomValue: ${IMPUTATION_REFERENCE_PANEL_PATH_PREFIX_CUSTOM_VALUE:/hg38/ref_panels/1000G_HGDP_no_singletons/hgdp.tgp.gwaspy.AN_added.bcf.ac2}
+      "2":
+        # the default currently points to the GCP dev workspace teaspoons-imputation-dev/teaspoons_imputation_dev_storage_workspace_20240726
+        storageWorkspaceContainerUrl: ${IMPUTATION_STORAGE_WORKSPACE_STORAGE_URL:gs://fc-secure-10efd4d7-392a-4e9e-89ea-d6629fbb06cc}
+        referencePanelPathPrefixCustomValue: ${IMPUTATION_REFERENCE_PANEL_PATH_PREFIX_CUSTOM_VALUE_V2:/hg38/ref_panels/1000G_HGDP_no_singletons/hgdp.tgp.gwaspy.AN_added.bcf.ac2}
 
 pipelines:
   configurations:
@@ -29,9 +33,9 @@ pipelines:
       2:
         cromwellSubmissionPollingIntervalInSeconds: 600
         inputKeysToPrependWithStorageWorkspaceContainerUrl: [ "refDict", "referencePanelPathPrefix", "geneticMapsPath" ]
-        storageWorkspaceContainerUrl: ${env.pipelines.imputation.1.storageWorkspaceContainerUrl}
+        storageWorkspaceContainerUrl: ${env.pipelines.imputation.2.storageWorkspaceContainerUrl}
         inputsWithCustomValues:
-          referencePanelPathPrefix: ${env.pipelines.imputation.1.referencePanelPathPrefixCustomValue}
+          referencePanelPathPrefix: ${env.pipelines.imputation.2.referencePanelPathPrefixCustomValue}
         useCallCaching: true
         deleteIntermediateFiles: false
         memoryRetryMultiplier: 2.0


### PR DESCRIPTION
### Description 

In preparation for array_imputation v2 release:
- update pipeline description to omit Beagle version
- add v2 reference panel path prefix value

pipeline details showing new description:
```
{
  "pipelineName": "array_imputation",
  "displayName": "All of Us + AnVIL Array Imputation",
  "pipelineVersion": 2,
  "description": "Phase and impute genotypes using Beagle with the All of Us + AnVIL reference panel of 515,579 samples.",
  ...
```

terra-helmfire PR to define `IMPUTATION_REFERENCE_PANEL_PATH_PREFIX_CUSTOM_VALUE_V2`: https://github.com/broadinstitute/terra-helmfile/pull/6415

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-773

### Checklist (provide links to changes)

- [ ] Updated external documentation (if applicable)
- [ ] Updated internal documentation (if applicable)
- [ ] Planned non patch version bump (if applicable)
- [ ] Made ticket for related CLI PR (if applicable)
- [ ] Made ticket for related UI PR (if applicable)
