### PR TITLE
TSPS-873 add deserializer function so internal step exception

### DIFF
--- a/service/src/main/java/bio/terra/pipelines/stairway/steps/exception/InternalStepException.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/steps/exception/InternalStepException.java
@@ -1,6 +1,7 @@
 package bio.terra.pipelines.stairway.steps.exception;
 
 import bio.terra.common.exception.InternalServerErrorException;
+import java.util.List;
 
 @SuppressWarnings("java:S110") // Disable "Inheritance tree of classes should not be too deep"
 public class InternalStepException extends InternalServerErrorException {
@@ -9,5 +10,14 @@ public class InternalStepException extends InternalServerErrorException {
     super(
         "An error occurred while running the job. %s Please contact support for help."
             .formatted(errorMsg));
+  }
+
+  /**
+   * Deserialization constructor used by {@link
+   * bio.terra.pipelines.dependencies.stairway.StairwayExceptionSerializer}. The message is already
+   * fully formatted, so it is passed through to the superclass without re-wrapping.
+   */
+  public InternalStepException(String message, List<String> causes) {
+    super(message, causes);
   }
 }


### PR DESCRIPTION


### Description 
we had a bug in our code where internal step exceptions would be "double" wrapped when being returned to the user.  So instead of 
```
An error occurred while running the job. Not all workflows succeeded in submission. Please contact support for help.
```
it was returning
```
An error occurred while running the job. An error occurred while running the job. Not all workflows succeeded in submission. Please contact support for help. Please contact support for help.
```
In the stairway database it was the correct string but when being deserialized it was being wrapped.  The bots figured out the rest and which method we needed to add so the stairway exception serializer would do the appropriate thing instead of falling back to the string constructor which would wrap the string again on the way out.

before
<img width="1409" height="575" alt="Screenshot 2026-04-23 at 1 34 48 PM" src="https://github.com/user-attachments/assets/f7dd23c3-f666-43bb-b692-05ff6fad2675" />

after
<img width="1430" height="716" alt="Screenshot 2026-04-23 at 1 33 19 PM" src="https://github.com/user-attachments/assets/8c5ac08e-1e1c-4600-9eb2-2321d99db385" />

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-873


### Checklist (provide links to changes)

- [ ] Updated external documentation (if applicable)
- [ ] Updated internal documentation (if applicable)
- [ ] Planned non patch version bump (if applicable)
- [ ] Made ticket for related CLI PR (if applicable)
- [ ] Made ticket for related UI PR (if applicable)
