### PR TITLE
TSPS-840 remove unhelpful SamUser message from log

### DIFF
--- a/service/src/main/java/bio/terra/pipelines/service/PipelineRunsService.java
+++ b/service/src/main/java/bio/terra/pipelines/service/PipelineRunsService.java
@@ -475,8 +475,8 @@ public class PipelineRunsService {
     if (!userHasBucketWriteAccess) {
       String userProxyGroup = samService.getProxyGroupForUser(authedUser);
       throw new ValidationException(
-          "User %s does not have necessary permissions to write to destination bucket %s, or the bucket does not exist. Please ensure the user's proxy group %s has write access to the destination bucket."
-              .formatted(authedUser, destinationBucket, userProxyGroup));
+          "User does not have necessary permissions to write to destination bucket %s, or the bucket does not exist. Please ensure the user's proxy group %s has write access to the destination bucket."
+              .formatted(destinationBucket, userProxyGroup));
     }
 
     boolean serviceHasBucketWriteAccess = gcsService.serviceHasBucketWriteAccess(destinationBucket);

--- a/service/src/test/java/bio/terra/pipelines/service/PipelineRunsServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/PipelineRunsServiceTest.java
@@ -1407,9 +1407,7 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
     assertTrue(
         exception
             .getMessage()
-            .contains(
-                "User %s does not have necessary permissions to write to destination bucket"
-                    .formatted(testUser)));
+            .contains("User does not have necessary permissions to write to destination bucket"));
     assertTrue(exception.getMessage().contains("test-bucket"));
     verify(mockJobBuilder, never()).submit();
   }


### PR DESCRIPTION
### Description 

While writing the e2e delivery tests, came across this error log that looked like
```
{"message":"User bio.terra.common.iam.SamUser@2f49d29b does not have necessary permissions to write to destination bucket teaspoons-testing-delivery-service-permissions, or the bucket does not exist. Please ensure the user's proxy group PROXY_116478835884051553938@dev.test.firecloud.org has write access to the destination bucket.","statusCode":400,"causes":[]}
```
The `bio.terra.common.iam.SamUser@2f49d29b` part seems really unhelpful for users so I am removing it from the log message

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-840

### Checklist (provide links to changes)

- [ ] Updated external documentation (if applicable)
- [ ] Updated internal documentation (if applicable)
- [ ] Planned non patch version bump (if applicable)
- [ ] Made ticket for related CLI PR (if applicable)
- [ ] Made ticket for related UI PR (if applicable)
