### PR TITLE
TSPS-824 Add low_pass_imputation v1 pipeline (infrastructure only - runs empty WDL)

### DIFF
--- a/pipelines/low_pass_imputation/testing/Glimpse2LowPassImputationEmpty.wdl
+++ b/pipelines/low_pass_imputation/testing/Glimpse2LowPassImputationEmpty.wdl
@@ -37,7 +37,7 @@ workflow Glimpse2LowPassImputation {
         File imputed_vcf_md5sum = WriteEmptyFile.empty_file
 
         File imputed_hom_ref_sites_only_vcf = WriteEmptyFile.empty_file
-        File imputed_hom_ref_sites_only_vcf_inex = WriteEmptyFile.empty_file
+        File imputed_hom_ref_sites_only_vcf_index = WriteEmptyFile.empty_file
         File imputed_hom_ref_sites_only_vcf_md5 = WriteEmptyFile.empty_file
 
         File qc_metrics = WriteEmptyFile.empty_file

--- a/pipelines/low_pass_imputation/testing/Glimpse2LowPassImputationEmpty.wdl
+++ b/pipelines/low_pass_imputation/testing/Glimpse2LowPassImputationEmpty.wdl
@@ -36,6 +36,10 @@ workflow Glimpse2LowPassImputation {
         File imputed_vcf_index = WriteEmptyFile.empty_file
         File imputed_vcf_md5sum = WriteEmptyFile.empty_file
 
+        File imputed_hom_ref_sites_only_vcf = WriteEmptyFile.empty_file
+        File imputed_hom_ref_sites_only_vcf_inex = WriteEmptyFile.empty_file
+        File imputed_hom_ref_sites_only_vcf_md5 = WriteEmptyFile.empty_file
+
         File qc_metrics = WriteEmptyFile.empty_file
         File? coverage_metrics = WriteEmptyFile.empty_file
     }

--- a/service/src/main/java/bio/terra/pipelines/app/configuration/internal/PipelineConfigurations.java
+++ b/service/src/main/java/bio/terra/pipelines/app/configuration/internal/PipelineConfigurations.java
@@ -20,8 +20,9 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class PipelineConfigurations {
 
   private PipelinesCommonConfiguration common;
-  // this is a map of array imputation pipeline versions to their configurations
-  private Map<String, ArrayImputationConfig> arrayImputation;
+  // this is a map of pipeline versions to their configurations
+  private Map<String, WdlBasedPipelineConfig> arrayImputation;
+  private Map<String, WdlBasedPipelineConfig> lowPassImputation;
 
   @Getter
   @Setter
@@ -36,7 +37,7 @@ public class PipelineConfigurations {
 
   @Setter
   @Getter
-  public static class ArrayImputationConfig {
+  public static class WdlBasedPipelineConfig {
     private Long cromwellSubmissionPollingIntervalInSeconds;
     private boolean useCallCaching;
     private boolean deleteIntermediateFiles;
@@ -45,7 +46,7 @@ public class PipelineConfigurations {
     private String storageWorkspaceContainerUrl;
     private List<String> inputKeysToPrependWithStorageWorkspaceContainerUrl;
 
-    public ArrayImputationConfig(
+    public WdlBasedPipelineConfig(
         Long cromwellSubmissionPollingIntervalInSeconds,
         List<String> inputKeysToPrependWithStorageWorkspaceContainerUrl,
         String storageWorkspaceContainerUrl,

--- a/service/src/main/java/bio/terra/pipelines/common/utils/PipelinesEnum.java
+++ b/service/src/main/java/bio/terra/pipelines/common/utils/PipelinesEnum.java
@@ -1,7 +1,8 @@
 package bio.terra.pipelines.common.utils;
 
 public enum PipelinesEnum {
-  ARRAY_IMPUTATION("array_imputation");
+  ARRAY_IMPUTATION("array_imputation"),
+  LOW_PASS_IMPUTATION("low_pass_imputation");
 
   private final String value;
 

--- a/service/src/main/java/bio/terra/pipelines/db/repositories/PipelinesRepository.java
+++ b/service/src/main/java/bio/terra/pipelines/db/repositories/PipelinesRepository.java
@@ -16,9 +16,7 @@ public interface PipelinesRepository extends CrudRepository<Pipeline, Long> {
 
   List<Pipeline> findAllByHiddenIsFalseOrderByNameAscVersionDesc();
 
-  Boolean existsByNameAndHiddenIsFalse(PipelinesEnum name);
-
-  Pipeline findByNameAndHiddenIsFalse(PipelinesEnum name);
+  List<Pipeline> findAllByNameOrderByVersionDesc(PipelinesEnum name);
 
   Pipeline findByNameAndVersion(PipelinesEnum name, Integer pipelineVersion);
 

--- a/service/src/main/java/bio/terra/pipelines/service/PipelineInputsOutputsService.java
+++ b/service/src/main/java/bio/terra/pipelines/service/PipelineInputsOutputsService.java
@@ -846,36 +846,44 @@ public class PipelineInputsOutputsService {
 
     for (PipelineInputDefinition inputDefinition : allInputDefinitions) {
       String keyName = inputDefinition.getName();
+      logger.debug("Processing input: {} with raw value {}", keyName, allRawInputs.get(keyName));
       String wdlVariableName = inputDefinition.getWdlVariableName();
       PipelineVariableTypesEnum pipelineInputType = inputDefinition.getType();
 
-      // use custom value if present, otherwise use the value from raw inputs (allRawInputs)
-      String rawOrCustomValue =
-          (inputsWithCustomValues.containsKey(keyName))
-              ? inputsWithCustomValues.get(keyName)
-              : allRawInputs.get(keyName).toString();
-      String processedValue;
-
-      if (keysToPrependWithStorageWorkspaceContainerUrl.contains(keyName)) {
-        // the rawOrCustomValue for this field should start with a / so we don't need to add one
-        // here
-        processedValue = constructFilePath(storageWorkspaceContainerUrl, rawOrCustomValue);
-      } else if (inputDefinition.isUserProvided()
-          && inputDefinition.getType().equals(PipelineVariableTypesEnum.FILE)
-          && getFileLocationType(rawOrCustomValue) == FileLocationTypeEnum.LOCAL) {
-        // user-provided file inputs are formatted with control workspace container url and a custom
-        // path
-        processedValue =
-            constructGcsFilePathForUserLocalInputFile(
-                controlWorkspaceContainerName, jobId, rawOrCustomValue);
+      Object rawValue = allRawInputs.get(keyName);
+      if (rawValue == null && inputDefinition.isUserProvided() && !inputDefinition.isRequired()) {
+        // do nothing; optional user-provided inputs that are missing should not be added as inputs
+        logger.debug("Skipping optional user-provided input {} with no value", keyName);
       } else {
-        processedValue = rawOrCustomValue;
-      }
+        // use custom value if present, otherwise use the value from raw inputs (allRawInputs)
+        String rawOrCustomValue =
+            (inputsWithCustomValues.containsKey(keyName))
+                ? inputsWithCustomValues.get(keyName)
+                : rawValue.toString();
+        String processedValue;
 
-      // we must cast here, otherwise the inputs will not be properly interpreted later by WDS
-      formattedPipelineInputs.put(
-          wdlVariableName,
-          pipelineInputType.cast(keyName, processedValue, new TypeReference<>() {}));
+        if (keysToPrependWithStorageWorkspaceContainerUrl.contains(keyName)) {
+          // the rawOrCustomValue for this field should start with a / so we don't need to add one
+          // here
+          processedValue = constructFilePath(storageWorkspaceContainerUrl, rawOrCustomValue);
+        } else if (inputDefinition.isUserProvided()
+            && inputDefinition.getType().equals(PipelineVariableTypesEnum.FILE)
+            && getFileLocationType(rawOrCustomValue) == FileLocationTypeEnum.LOCAL) {
+          // user-provided file inputs are formatted with control workspace container url and a
+          // custom
+          // path
+          processedValue =
+              constructGcsFilePathForUserLocalInputFile(
+                  controlWorkspaceContainerName, jobId, rawOrCustomValue);
+        } else {
+          processedValue = rawOrCustomValue;
+        }
+
+        // we must cast here, otherwise the inputs will not be properly interpreted later by WDS
+        formattedPipelineInputs.put(
+            wdlVariableName,
+            pipelineInputType.cast(keyName, processedValue, new TypeReference<>() {}));
+      }
     }
 
     logger.info("Formatted pipeline inputs: {}", formattedPipelineInputs);

--- a/service/src/main/java/bio/terra/pipelines/service/PipelineInputsOutputsService.java
+++ b/service/src/main/java/bio/terra/pipelines/service/PipelineInputsOutputsService.java
@@ -94,12 +94,14 @@ public class PipelineInputsOutputsService {
         .toList();
   }
 
+  /** Check whether all user-provided file inputs for a pipeline are GCS cloud paths. */
   public boolean userProvidedInputsAreGcsCloud(
       Pipeline pipeline, Map<String, Object> userProvidedInputs) {
     List<String> fileInputNames = getUserProvidedFileInputKeys(pipeline);
     for (String fileInputName : fileInputNames) {
       String fileInputValue = (String) userProvidedInputs.get(fileInputName);
-      if (getFileLocationType(fileInputValue) != FileLocationTypeEnum.GCS) {
+      if (fileInputValue != null
+          && getFileLocationType(fileInputValue) != FileLocationTypeEnum.GCS) {
         return false;
       }
     }

--- a/service/src/main/java/bio/terra/pipelines/service/PipelineInputsOutputsService.java
+++ b/service/src/main/java/bio/terra/pipelines/service/PipelineInputsOutputsService.java
@@ -100,7 +100,7 @@ public class PipelineInputsOutputsService {
     List<String> fileInputNames = getUserProvidedFileInputKeys(pipeline);
     for (String fileInputName : fileInputNames) {
       String fileInputValue = (String) userProvidedInputs.get(fileInputName);
-      if (fileInputValue != null
+      if (fileInputValue != null // allow null values since some file inputs may be optional
           && getFileLocationType(fileInputValue) != FileLocationTypeEnum.GCS) {
         return false;
       }

--- a/service/src/main/java/bio/terra/pipelines/service/PipelineInputsOutputsService.java
+++ b/service/src/main/java/bio/terra/pipelines/service/PipelineInputsOutputsService.java
@@ -94,7 +94,10 @@ public class PipelineInputsOutputsService {
         .toList();
   }
 
-  /** Check whether all user-provided file inputs for a pipeline are GCS cloud paths. */
+  /**
+   * Check whether all user-provided file inputs for a pipeline are GCS cloud paths. We assume that
+   * all required inputs are present, so null values can be assumed to be optional inputs.
+   */
   public boolean userProvidedInputsAreGcsCloud(
       Pipeline pipeline, Map<String, Object> userProvidedInputs) {
     List<String> fileInputNames = getUserProvidedFileInputKeys(pipeline);
@@ -825,7 +828,10 @@ public class PipelineInputsOutputsService {
   }
 
   /**
-   * Format the pipeline inputs for a pipeline. Apply the following manipulations:
+   * Format the pipeline inputs for a pipeline. We assume that all required inputs are present, so
+   * null values can be assumed to be optional inputs and not problematic.
+   *
+   * <p>Apply the following manipulations:
    *
    * <ul>
    *   <li>use custom (environment-specific) values for certain service-provided inputs

--- a/service/src/main/java/bio/terra/pipelines/service/PipelineInputsOutputsService.java
+++ b/service/src/main/java/bio/terra/pipelines/service/PipelineInputsOutputsService.java
@@ -850,9 +850,9 @@ public class PipelineInputsOutputsService {
       PipelineVariableTypesEnum pipelineInputType = inputDefinition.getType();
 
       Object rawValue = allRawInputs.get(keyName);
-      if (rawValue == null && inputDefinition.isUserProvided() && !inputDefinition.isRequired()) {
-        // do nothing; optional user-provided inputs that are missing should not be added as inputs
-        logger.debug("Skipping optional user-provided input {} with no value", keyName);
+      if (rawValue == null && !inputDefinition.isRequired()) {
+        // do nothing; nothing to do with optional inputs that are missing
+        logger.debug("Skipping optional input {} with no value", keyName);
       } else {
         // use custom value if present, otherwise use the value from raw inputs (allRawInputs)
         String rawOrCustomValue =

--- a/service/src/main/java/bio/terra/pipelines/service/PipelineInputsOutputsService.java
+++ b/service/src/main/java/bio/terra/pipelines/service/PipelineInputsOutputsService.java
@@ -846,7 +846,6 @@ public class PipelineInputsOutputsService {
 
     for (PipelineInputDefinition inputDefinition : allInputDefinitions) {
       String keyName = inputDefinition.getName();
-      logger.debug("Processing input: {} with raw value {}", keyName, allRawInputs.get(keyName));
       String wdlVariableName = inputDefinition.getWdlVariableName();
       PipelineVariableTypesEnum pipelineInputType = inputDefinition.getType();
 

--- a/service/src/main/java/bio/terra/pipelines/service/PipelineRunsService.java
+++ b/service/src/main/java/bio/terra/pipelines/service/PipelineRunsService.java
@@ -26,8 +26,8 @@ import bio.terra.pipelines.dependencies.stairway.JobMapKeys;
 import bio.terra.pipelines.dependencies.stairway.JobService;
 import bio.terra.pipelines.stairway.flights.datadelivery.DataDeliveryJobMapKeys;
 import bio.terra.pipelines.stairway.flights.datadelivery.v20260409.DeliverDataToGcsFlight;
-import bio.terra.pipelines.stairway.flights.imputation.ImputationJobMapKeys;
-import bio.terra.pipelines.stairway.flights.pipelinerun.v20260428.RunWdlBasedPipelineJobFlight;
+import bio.terra.pipelines.stairway.flights.wdlbasedpipelinerun.WdlBasedPipelineJobMapKeys;
+import bio.terra.pipelines.stairway.flights.wdlbasedpipelinerun.v20260428.RunWdlBasedPipelineJobFlight;
 import bio.terra.stairway.Flight;
 import java.util.Collections;
 import java.util.List;
@@ -286,23 +286,24 @@ public class PipelineRunsService {
               .addParameter(JobMapKeys.DO_SET_PIPELINE_RUN_STATUS_FAILED_HOOK, true)
               .addParameter(JobMapKeys.DO_SEND_JOB_FAILURE_NOTIFICATION_HOOK, true)
               .addParameter(JobMapKeys.DO_INCREMENT_METRICS_FAILED_COUNTER_HOOK, true)
-              .addParameter(ImputationJobMapKeys.USER_PROVIDED_PIPELINE_INPUTS, userProvidedInputs)
               .addParameter(
-                  ImputationJobMapKeys.CONTROL_WORKSPACE_BILLING_PROJECT,
+                  WdlBasedPipelineJobMapKeys.USER_PROVIDED_PIPELINE_INPUTS, userProvidedInputs)
+              .addParameter(
+                  WdlBasedPipelineJobMapKeys.CONTROL_WORKSPACE_BILLING_PROJECT,
                   pipeline.getWorkspaceBillingProject())
               .addParameter(
-                  ImputationJobMapKeys.CONTROL_WORKSPACE_NAME, pipeline.getWorkspaceName())
+                  WdlBasedPipelineJobMapKeys.CONTROL_WORKSPACE_NAME, pipeline.getWorkspaceName())
               .addParameter(
-                  ImputationJobMapKeys.CONTROL_WORKSPACE_STORAGE_CONTAINER_NAME,
+                  WdlBasedPipelineJobMapKeys.CONTROL_WORKSPACE_STORAGE_CONTAINER_NAME,
                   startedPipelineRun.getWorkspaceStorageContainerName())
               .addParameter(
-                  ImputationJobMapKeys.PIPELINE_TOOL_CONFIG,
+                  WdlBasedPipelineJobMapKeys.PIPELINE_TOOL_CONFIG,
                   toolConfigService.getPipelineMainToolConfig(pipeline))
               .addParameter(
-                  ImputationJobMapKeys.QUOTA_TOOL_CONFIG,
+                  WdlBasedPipelineJobMapKeys.QUOTA_TOOL_CONFIG,
                   toolConfigService.getQuotaConsumedToolConfig(pipeline))
               .addParameter(
-                  ImputationJobMapKeys.INPUT_QC_TOOL_CONFIG,
+                  WdlBasedPipelineJobMapKeys.INPUT_QC_TOOL_CONFIG,
                   toolConfigService.getInputQcToolConfig(pipeline));
 
       jobBuilder.submit();

--- a/service/src/main/java/bio/terra/pipelines/service/PipelineRunsService.java
+++ b/service/src/main/java/bio/terra/pipelines/service/PipelineRunsService.java
@@ -27,7 +27,6 @@ import bio.terra.pipelines.dependencies.stairway.JobService;
 import bio.terra.pipelines.stairway.flights.datadelivery.DataDeliveryJobMapKeys;
 import bio.terra.pipelines.stairway.flights.datadelivery.v20260409.DeliverDataToGcsFlight;
 import bio.terra.pipelines.stairway.flights.imputation.ImputationJobMapKeys;
-import bio.terra.pipelines.stairway.flights.imputation.v20251002.RunImputationGcpJobFlight;
 import bio.terra.pipelines.stairway.flights.pipelinerun.v20260428.RunWdlBasedPipelineJobFlight;
 import bio.terra.stairway.Flight;
 import java.util.Collections;
@@ -262,7 +261,8 @@ public class PipelineRunsService {
       Class<? extends Flight> flightClass;
       switch (pipelineName) {
         case ARRAY_IMPUTATION:
-          flightClass = RunImputationGcpJobFlight.class; // v20251002
+          //          flightClass = RunImputationGcpJobFlight.class; // v20251002
+          flightClass = RunWdlBasedPipelineJobFlight.class; // v20260428
           break;
         case LOW_PASS_IMPUTATION:
           flightClass = RunWdlBasedPipelineJobFlight.class; // v20260428

--- a/service/src/main/java/bio/terra/pipelines/service/PipelineRunsService.java
+++ b/service/src/main/java/bio/terra/pipelines/service/PipelineRunsService.java
@@ -317,6 +317,16 @@ public class PipelineRunsService {
     if (pipeline.getWorkspaceBillingProject() == null
         || pipeline.getWorkspaceName() == null
         || pipeline.getWorkspaceStorageContainerName() == null) {
+      String defined_string = "defined";
+      String not_defined_string = "not defined";
+      logger.error(
+          "PROGRAMMER ERROR: Pipeline {} is missing workspace configuration. Required values: workspaceBillingProject ({}), workspaceName ({}), workspaceStorageContainerName ({}).",
+          pipeline.getName(),
+          pipeline.getWorkspaceBillingProject() == null ? not_defined_string : defined_string,
+          pipeline.getWorkspaceName() == null ? not_defined_string : defined_string,
+          pipeline.getWorkspaceStorageContainerName() == null
+              ? not_defined_string
+              : defined_string);
       throw new InternalServerErrorException(
           "%s workspace not defined".formatted(pipeline.getName()));
     }

--- a/service/src/main/java/bio/terra/pipelines/service/PipelineRunsService.java
+++ b/service/src/main/java/bio/terra/pipelines/service/PipelineRunsService.java
@@ -28,6 +28,7 @@ import bio.terra.pipelines.stairway.flights.datadelivery.DataDeliveryJobMapKeys;
 import bio.terra.pipelines.stairway.flights.datadelivery.v20260409.DeliverDataToGcsFlight;
 import bio.terra.pipelines.stairway.flights.imputation.ImputationJobMapKeys;
 import bio.terra.pipelines.stairway.flights.imputation.v20251002.RunImputationGcpJobFlight;
+import bio.terra.pipelines.stairway.flights.pipelinerun.v20260428.RunWdlBasedPipelineJobFlight;
 import bio.terra.stairway.Flight;
 import java.util.Collections;
 import java.util.List;
@@ -262,6 +263,9 @@ public class PipelineRunsService {
       switch (pipelineName) {
         case ARRAY_IMPUTATION:
           flightClass = RunImputationGcpJobFlight.class; // v20251002
+          break;
+        case LOW_PASS_IMPUTATION:
+          flightClass = RunWdlBasedPipelineJobFlight.class; // v20260428
           break;
         default:
           throw new InternalServerErrorException(

--- a/service/src/main/java/bio/terra/pipelines/service/PipelineRunsService.java
+++ b/service/src/main/java/bio/terra/pipelines/service/PipelineRunsService.java
@@ -260,11 +260,7 @@ public class PipelineRunsService {
 
       Class<? extends Flight> flightClass;
       switch (pipelineName) {
-        case ARRAY_IMPUTATION:
-          //          flightClass = RunImputationGcpJobFlight.class; // v20251002
-          flightClass = RunWdlBasedPipelineJobFlight.class; // v20260428
-          break;
-        case LOW_PASS_IMPUTATION:
+        case ARRAY_IMPUTATION, LOW_PASS_IMPUTATION:
           flightClass = RunWdlBasedPipelineJobFlight.class; // v20260428
           break;
         default:

--- a/service/src/main/java/bio/terra/pipelines/service/ToolConfigService.java
+++ b/service/src/main/java/bio/terra/pipelines/service/ToolConfigService.java
@@ -26,42 +26,33 @@ public class ToolConfigService {
 
   /** Get the ToolConfig for the main analysis method/workflow for a given pipeline */
   public ToolConfig getPipelineMainToolConfig(Pipeline pipeline) {
-    // for now we're hard coding the imputationConfiguration here since it's the only pipeline
     if (PipelinesEnum.ARRAY_IMPUTATION.equals(pipeline.getName())) {
       PipelineConfigurations.WdlBasedPipelineConfig arrayImputationPipelineConfig =
           pipelineConfigurations.getArrayImputation().get(pipeline.getVersion().toString());
-      String toolNameWithPipelineVersion =
-          appendPipelineVersion(pipeline.getToolName(), pipeline.getVersion());
-      return new ToolConfig(
-          pipeline.getToolName(),
-          pipeline.getToolVersion(),
-          toolNameWithPipelineVersion,
-          getDataTableEntityNameForToolConfig(pipeline),
-          pipeline.getPipelineInputDefinitions(),
-          pipeline.getPipelineOutputDefinitions(),
-          arrayImputationPipelineConfig.isUseCallCaching(),
-          pipelineConfigurations.getCommon().getMonitoringScriptPath(),
-          arrayImputationPipelineConfig.isDeleteIntermediateFiles(),
-          arrayImputationPipelineConfig.getMemoryRetryMultiplier(),
-          arrayImputationPipelineConfig.getCromwellSubmissionPollingIntervalInSeconds());
+      return configureMainToolConfig(pipeline, arrayImputationPipelineConfig);
     } else if (PipelinesEnum.LOW_PASS_IMPUTATION.equals(pipeline.getName())) {
       PipelineConfigurations.WdlBasedPipelineConfig lowPassImputationPipelineConfig =
           pipelineConfigurations.getLowPassImputation().get(pipeline.getVersion().toString());
-      String toolNameWithPipelineVersion =
-          appendPipelineVersion(pipeline.getToolName(), pipeline.getVersion());
-      return new ToolConfig(
-          pipeline.getToolName(),
-          pipeline.getToolVersion(),
-          toolNameWithPipelineVersion,
-          getDataTableEntityNameForToolConfig(pipeline),
-          pipeline.getPipelineInputDefinitions(),
-          pipeline.getPipelineOutputDefinitions(),
-          lowPassImputationPipelineConfig.isUseCallCaching(),
-          pipelineConfigurations.getCommon().getMonitoringScriptPath(),
-          lowPassImputationPipelineConfig.isDeleteIntermediateFiles(),
-          lowPassImputationPipelineConfig.getMemoryRetryMultiplier(),
-          lowPassImputationPipelineConfig.getCromwellSubmissionPollingIntervalInSeconds());
+      return configureMainToolConfig(pipeline, lowPassImputationPipelineConfig);
     } else throw new IllegalArgumentException("Unsupported pipeline type: " + pipeline.getName());
+  }
+
+  private ToolConfig configureMainToolConfig(
+      Pipeline pipeline, PipelineConfigurations.WdlBasedPipelineConfig wdlBasedPipelineConfig) {
+    String toolNameWithPipelineVersion =
+        appendPipelineVersion(pipeline.getToolName(), pipeline.getVersion());
+    return new ToolConfig(
+        pipeline.getToolName(),
+        pipeline.getToolVersion(),
+        toolNameWithPipelineVersion,
+        getDataTableEntityNameForToolConfig(pipeline),
+        pipeline.getPipelineInputDefinitions(),
+        pipeline.getPipelineOutputDefinitions(),
+        wdlBasedPipelineConfig.isUseCallCaching(),
+        pipelineConfigurations.getCommon().getMonitoringScriptPath(),
+        wdlBasedPipelineConfig.isDeleteIntermediateFiles(),
+        wdlBasedPipelineConfig.getMemoryRetryMultiplier(),
+        wdlBasedPipelineConfig.getCromwellSubmissionPollingIntervalInSeconds());
   }
 
   /**

--- a/service/src/main/java/bio/terra/pipelines/service/ToolConfigService.java
+++ b/service/src/main/java/bio/terra/pipelines/service/ToolConfigService.java
@@ -28,7 +28,7 @@ public class ToolConfigService {
   public ToolConfig getPipelineMainToolConfig(Pipeline pipeline) {
     // for now we're hard coding the imputationConfiguration here since it's the only pipeline
     if (PipelinesEnum.ARRAY_IMPUTATION.equals(pipeline.getName())) {
-      PipelineConfigurations.ArrayImputationConfig arrayImputationConfiguration =
+      PipelineConfigurations.WdlBasedPipelineConfig arrayImputationPipelineConfig =
           pipelineConfigurations.getArrayImputation().get(pipeline.getVersion().toString());
       String toolNameWithPipelineVersion =
           appendPipelineVersion(pipeline.getToolName(), pipeline.getVersion());
@@ -39,13 +39,29 @@ public class ToolConfigService {
           getDataTableEntityNameForToolConfig(pipeline),
           pipeline.getPipelineInputDefinitions(),
           pipeline.getPipelineOutputDefinitions(),
-          arrayImputationConfiguration.isUseCallCaching(),
+          arrayImputationPipelineConfig.isUseCallCaching(),
           pipelineConfigurations.getCommon().getMonitoringScriptPath(),
-          arrayImputationConfiguration.isDeleteIntermediateFiles(),
-          arrayImputationConfiguration.getMemoryRetryMultiplier(),
-          arrayImputationConfiguration.getCromwellSubmissionPollingIntervalInSeconds());
-    }
-    throw new IllegalArgumentException("Unsupported pipeline type: " + pipeline.getName());
+          arrayImputationPipelineConfig.isDeleteIntermediateFiles(),
+          arrayImputationPipelineConfig.getMemoryRetryMultiplier(),
+          arrayImputationPipelineConfig.getCromwellSubmissionPollingIntervalInSeconds());
+    } else if (PipelinesEnum.LOW_PASS_IMPUTATION.equals(pipeline.getName())) {
+      PipelineConfigurations.WdlBasedPipelineConfig lowPassImputationPipelineConfig =
+          pipelineConfigurations.getLowPassImputation().get(pipeline.getVersion().toString());
+      String toolNameWithPipelineVersion =
+          appendPipelineVersion(pipeline.getToolName(), pipeline.getVersion());
+      return new ToolConfig(
+          pipeline.getToolName(),
+          pipeline.getToolVersion(),
+          toolNameWithPipelineVersion,
+          getDataTableEntityNameForToolConfig(pipeline),
+          pipeline.getPipelineInputDefinitions(),
+          pipeline.getPipelineOutputDefinitions(),
+          lowPassImputationPipelineConfig.isUseCallCaching(),
+          pipelineConfigurations.getCommon().getMonitoringScriptPath(),
+          lowPassImputationPipelineConfig.isDeleteIntermediateFiles(),
+          lowPassImputationPipelineConfig.getMemoryRetryMultiplier(),
+          lowPassImputationPipelineConfig.getCromwellSubmissionPollingIntervalInSeconds());
+    } else throw new IllegalArgumentException("Unsupported pipeline type: " + pipeline.getName());
   }
 
   /**

--- a/service/src/main/java/bio/terra/pipelines/stairway/flights/imputation/v20251002/RunImputationGcpJobFlight.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/flights/imputation/v20251002/RunImputationGcpJobFlight.java
@@ -5,7 +5,7 @@ import bio.terra.pipelines.common.utils.FlightBeanBag;
 import bio.terra.pipelines.common.utils.FlightUtils;
 import bio.terra.pipelines.common.utils.PipelinesEnum;
 import bio.terra.pipelines.dependencies.stairway.JobMapKeys;
-import bio.terra.pipelines.stairway.flights.imputation.ImputationJobMapKeys;
+import bio.terra.pipelines.stairway.flights.wdlbasedpipelinerun.WdlBasedPipelineJobMapKeys;
 import bio.terra.pipelines.stairway.steps.common.*;
 import bio.terra.pipelines.stairway.steps.common.PrepareInputsStep;
 import bio.terra.stairway.*;
@@ -46,13 +46,13 @@ public class RunImputationGcpJobFlight extends Flight {
         JobMapKeys.DO_SET_PIPELINE_RUN_STATUS_FAILED_HOOK,
         JobMapKeys.DO_SEND_JOB_FAILURE_NOTIFICATION_HOOK,
         JobMapKeys.DO_INCREMENT_METRICS_FAILED_COUNTER_HOOK,
-        ImputationJobMapKeys.USER_PROVIDED_PIPELINE_INPUTS,
-        ImputationJobMapKeys.CONTROL_WORKSPACE_BILLING_PROJECT,
-        ImputationJobMapKeys.CONTROL_WORKSPACE_NAME,
-        ImputationJobMapKeys.CONTROL_WORKSPACE_STORAGE_CONTAINER_NAME,
-        ImputationJobMapKeys.PIPELINE_TOOL_CONFIG,
-        ImputationJobMapKeys.QUOTA_TOOL_CONFIG,
-        ImputationJobMapKeys.INPUT_QC_TOOL_CONFIG);
+        WdlBasedPipelineJobMapKeys.USER_PROVIDED_PIPELINE_INPUTS,
+        WdlBasedPipelineJobMapKeys.CONTROL_WORKSPACE_BILLING_PROJECT,
+        WdlBasedPipelineJobMapKeys.CONTROL_WORKSPACE_NAME,
+        WdlBasedPipelineJobMapKeys.CONTROL_WORKSPACE_STORAGE_CONTAINER_NAME,
+        WdlBasedPipelineJobMapKeys.PIPELINE_TOOL_CONFIG,
+        WdlBasedPipelineJobMapKeys.QUOTA_TOOL_CONFIG,
+        WdlBasedPipelineJobMapKeys.INPUT_QC_TOOL_CONFIG);
 
     PipelinesEnum pipelinesEnum =
         PipelinesEnum.valueOf(inputParameters.get(JobMapKeys.PIPELINE_NAME, String.class));
@@ -73,7 +73,7 @@ public class RunImputationGcpJobFlight extends Flight {
         new AddDataTableRowStep(
             flightBeanBag.getRawlsService(),
             flightBeanBag.getSamService(),
-            ImputationJobMapKeys.PIPELINE_TOOL_CONFIG),
+            WdlBasedPipelineJobMapKeys.PIPELINE_TOOL_CONFIG),
         externalServiceRetryRule);
 
     // Check input for quota to be consumed
@@ -81,16 +81,16 @@ public class RunImputationGcpJobFlight extends Flight {
         new SubmitCromwellSubmissionStep(
             flightBeanBag.getRawlsService(),
             flightBeanBag.getSamService(),
-            ImputationJobMapKeys.QUOTA_TOOL_CONFIG,
-            ImputationJobMapKeys.QUOTA_SUBMISSION_ID),
+            WdlBasedPipelineJobMapKeys.QUOTA_TOOL_CONFIG,
+            WdlBasedPipelineJobMapKeys.QUOTA_SUBMISSION_ID),
         externalServiceRetryRule);
 
     addStep(
         new PollCromwellSubmissionStatusStep(
             flightBeanBag.getRawlsService(),
             flightBeanBag.getSamService(),
-            ImputationJobMapKeys.QUOTA_TOOL_CONFIG,
-            ImputationJobMapKeys.QUOTA_SUBMISSION_ID),
+            WdlBasedPipelineJobMapKeys.QUOTA_TOOL_CONFIG,
+            WdlBasedPipelineJobMapKeys.QUOTA_SUBMISSION_ID),
         externalServiceRetryRule);
 
     addStep(
@@ -98,8 +98,8 @@ public class RunImputationGcpJobFlight extends Flight {
             flightBeanBag.getRawlsService(),
             flightBeanBag.getSamService(),
             flightBeanBag.getPipelineInputsOutputsService(),
-            ImputationJobMapKeys.QUOTA_TOOL_CONFIG,
-            ImputationJobMapKeys.QUOTA_OUTPUTS),
+            WdlBasedPipelineJobMapKeys.QUOTA_TOOL_CONFIG,
+            WdlBasedPipelineJobMapKeys.QUOTA_OUTPUTS),
         externalServiceRetryRule);
 
     addStep(
@@ -112,16 +112,16 @@ public class RunImputationGcpJobFlight extends Flight {
         new SubmitCromwellSubmissionStep(
             flightBeanBag.getRawlsService(),
             flightBeanBag.getSamService(),
-            ImputationJobMapKeys.INPUT_QC_TOOL_CONFIG,
-            ImputationJobMapKeys.INPUT_QC_SUBMISSION_ID),
+            WdlBasedPipelineJobMapKeys.INPUT_QC_TOOL_CONFIG,
+            WdlBasedPipelineJobMapKeys.INPUT_QC_SUBMISSION_ID),
         externalServiceRetryRule);
 
     addStep(
         new PollCromwellSubmissionStatusStep(
             flightBeanBag.getRawlsService(),
             flightBeanBag.getSamService(),
-            ImputationJobMapKeys.INPUT_QC_TOOL_CONFIG,
-            ImputationJobMapKeys.INPUT_QC_SUBMISSION_ID),
+            WdlBasedPipelineJobMapKeys.INPUT_QC_TOOL_CONFIG,
+            WdlBasedPipelineJobMapKeys.INPUT_QC_SUBMISSION_ID),
         externalServiceRetryRule);
 
     addStep(
@@ -129,8 +129,8 @@ public class RunImputationGcpJobFlight extends Flight {
             flightBeanBag.getRawlsService(),
             flightBeanBag.getSamService(),
             flightBeanBag.getPipelineInputsOutputsService(),
-            ImputationJobMapKeys.INPUT_QC_TOOL_CONFIG,
-            ImputationJobMapKeys.INPUT_QC_OUTPUTS),
+            WdlBasedPipelineJobMapKeys.INPUT_QC_TOOL_CONFIG,
+            WdlBasedPipelineJobMapKeys.INPUT_QC_OUTPUTS),
         externalServiceRetryRule);
 
     addStep(new InputQcValidationStep(), dbRetryRule);
@@ -140,16 +140,16 @@ public class RunImputationGcpJobFlight extends Flight {
         new SubmitCromwellSubmissionStep(
             flightBeanBag.getRawlsService(),
             flightBeanBag.getSamService(),
-            ImputationJobMapKeys.PIPELINE_TOOL_CONFIG,
-            ImputationJobMapKeys.PIPELINE_SUBMISSION_ID),
+            WdlBasedPipelineJobMapKeys.PIPELINE_TOOL_CONFIG,
+            WdlBasedPipelineJobMapKeys.PIPELINE_SUBMISSION_ID),
         externalServiceRetryRule);
 
     addStep(
         new PollCromwellSubmissionStatusStep(
             flightBeanBag.getRawlsService(),
             flightBeanBag.getSamService(),
-            ImputationJobMapKeys.PIPELINE_TOOL_CONFIG,
-            ImputationJobMapKeys.PIPELINE_SUBMISSION_ID),
+            WdlBasedPipelineJobMapKeys.PIPELINE_TOOL_CONFIG,
+            WdlBasedPipelineJobMapKeys.PIPELINE_SUBMISSION_ID),
         externalServiceRetryRule);
 
     addStep(
@@ -157,8 +157,8 @@ public class RunImputationGcpJobFlight extends Flight {
             flightBeanBag.getRawlsService(),
             flightBeanBag.getSamService(),
             flightBeanBag.getPipelineInputsOutputsService(),
-            ImputationJobMapKeys.PIPELINE_TOOL_CONFIG,
-            ImputationJobMapKeys.PIPELINE_RUN_OUTPUTS),
+            WdlBasedPipelineJobMapKeys.PIPELINE_TOOL_CONFIG,
+            WdlBasedPipelineJobMapKeys.PIPELINE_RUN_OUTPUTS),
         externalServiceRetryRule);
 
     // populate file sizes for pipeline outputs

--- a/service/src/main/java/bio/terra/pipelines/stairway/flights/pipelinerun/v20260428/RunWdlBasedPipelineJobFlight.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/flights/pipelinerun/v20260428/RunWdlBasedPipelineJobFlight.java
@@ -1,16 +1,30 @@
-package bio.terra.pipelines.stairway.flights.imputation.v20251002;
+package bio.terra.pipelines.stairway.flights.pipelinerun.v20260428;
 
 import bio.terra.pipelines.app.common.MetricsUtils;
+import bio.terra.pipelines.app.configuration.internal.PipelineConfigurations;
 import bio.terra.pipelines.common.utils.FlightBeanBag;
 import bio.terra.pipelines.common.utils.FlightUtils;
 import bio.terra.pipelines.common.utils.PipelinesEnum;
 import bio.terra.pipelines.dependencies.stairway.JobMapKeys;
 import bio.terra.pipelines.stairway.flights.imputation.ImputationJobMapKeys;
-import bio.terra.pipelines.stairway.steps.common.*;
+import bio.terra.pipelines.stairway.steps.common.AddDataTableRowStep;
+import bio.terra.pipelines.stairway.steps.common.CompletePipelineRunStep;
+import bio.terra.pipelines.stairway.steps.common.FetchOutputsFromDataTableStep;
+import bio.terra.pipelines.stairway.steps.common.InputQcValidationStep;
+import bio.terra.pipelines.stairway.steps.common.PollCromwellSubmissionStatusStep;
+import bio.terra.pipelines.stairway.steps.common.PopulateFileOutputSizeStep;
 import bio.terra.pipelines.stairway.steps.common.PrepareInputsStep;
-import bio.terra.stairway.*;
+import bio.terra.pipelines.stairway.steps.common.QuotaConsumedValidationStep;
+import bio.terra.pipelines.stairway.steps.common.SendJobSucceededNotificationStep;
+import bio.terra.pipelines.stairway.steps.common.SubmitCromwellSubmissionStep;
+import bio.terra.stairway.Flight;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.RetryRule;
+import bio.terra.stairway.RetryRuleExponentialBackoff;
+import bio.terra.stairway.RetryRuleFixedInterval;
+import bio.terra.stairway.Step;
 
-public class RunImputationGcpJobFlight extends Flight {
+public class RunWdlBasedPipelineJobFlight extends Flight {
 
   /** Retry for short database operations which may fail due to transaction conflicts. */
   private final RetryRule dbRetryRule =
@@ -32,7 +46,7 @@ public class RunImputationGcpJobFlight extends Flight {
     super.addStep(step, retryRule);
   }
 
-  public RunImputationGcpJobFlight(FlightMap inputParameters, Object beanBag) {
+  public RunWdlBasedPipelineJobFlight(FlightMap inputParameters, Object beanBag) {
     super(inputParameters, beanBag);
     final FlightBeanBag flightBeanBag = FlightBeanBag.getFromObject(beanBag);
 
@@ -60,13 +74,28 @@ public class RunImputationGcpJobFlight extends Flight {
 
     Integer pipelineVersion = inputParameters.get(JobMapKeys.PIPELINE_VERSION, Integer.class);
 
+    // prepare inputs is custom to pipeline
+    PipelineConfigurations.WdlBasedPipelineConfig wdlBasedPipelineConfig;
+    if (pipelinesEnum.equals(PipelinesEnum.ARRAY_IMPUTATION)) {
+      wdlBasedPipelineConfig =
+          flightBeanBag
+              .getPipelineConfigurations()
+              .getArrayImputation()
+              .get(pipelineVersion.toString());
+    } else if (pipelinesEnum.equals(PipelinesEnum.LOW_PASS_IMPUTATION)) {
+      wdlBasedPipelineConfig =
+          flightBeanBag
+              .getPipelineConfigurations()
+              .getLowPassImputation()
+              .get(pipelineVersion.toString());
+    } else {
+      throw new IllegalArgumentException(
+          String.format("Unsupported pipeline %s", pipelinesEnum.name()));
+    }
+
     addStep(
         new PrepareInputsStep(
-            flightBeanBag.getPipelineInputsOutputsService(),
-            flightBeanBag
-                .getPipelineConfigurations()
-                .getArrayImputation()
-                .get(pipelineVersion.toString())),
+            flightBeanBag.getPipelineInputsOutputsService(), wdlBasedPipelineConfig),
         dbRetryRule);
 
     addStep(

--- a/service/src/main/java/bio/terra/pipelines/stairway/flights/wdlbasedpipelinerun/WdlBasedPipelineJobMapKeys.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/flights/wdlbasedpipelinerun/WdlBasedPipelineJobMapKeys.java
@@ -1,6 +1,6 @@
-package bio.terra.pipelines.stairway.flights.imputation;
+package bio.terra.pipelines.stairway.flights.wdlbasedpipelinerun;
 
-public class ImputationJobMapKeys {
+public class WdlBasedPipelineJobMapKeys {
   public static final String PIPELINE_INPUT_DEFINITIONS = "pipeline_input_definitions";
   public static final String USER_PROVIDED_PIPELINE_INPUTS = "user_provided_pipeline_inputs";
   public static final String ALL_PIPELINE_INPUTS = "all_pipeline_inputs";
@@ -28,7 +28,8 @@ public class ImputationJobMapKeys {
   public static final String RAW_QUOTA_CONSUMED = "raw_quota_consumed";
   public static final String EFFECTIVE_QUOTA_CONSUMED = "effective_quota_consumed";
 
-  ImputationJobMapKeys() {
-    throw new IllegalStateException("Attempted to instantiate utility class ImputationJobMapKeys");
+  WdlBasedPipelineJobMapKeys() {
+    throw new IllegalStateException(
+        "Attempted to instantiate utility class WdlBasedPipelineJobMapKeys");
   }
 }

--- a/service/src/main/java/bio/terra/pipelines/stairway/flights/wdlbasedpipelinerun/v20260428/RunWdlBasedPipelineJobFlight.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/flights/wdlbasedpipelinerun/v20260428/RunWdlBasedPipelineJobFlight.java
@@ -1,4 +1,4 @@
-package bio.terra.pipelines.stairway.flights.pipelinerun.v20260428;
+package bio.terra.pipelines.stairway.flights.wdlbasedpipelinerun.v20260428;
 
 import bio.terra.pipelines.app.common.MetricsUtils;
 import bio.terra.pipelines.app.configuration.internal.PipelineConfigurations;
@@ -6,7 +6,7 @@ import bio.terra.pipelines.common.utils.FlightBeanBag;
 import bio.terra.pipelines.common.utils.FlightUtils;
 import bio.terra.pipelines.common.utils.PipelinesEnum;
 import bio.terra.pipelines.dependencies.stairway.JobMapKeys;
-import bio.terra.pipelines.stairway.flights.imputation.ImputationJobMapKeys;
+import bio.terra.pipelines.stairway.flights.wdlbasedpipelinerun.WdlBasedPipelineJobMapKeys;
 import bio.terra.pipelines.stairway.steps.common.AddDataTableRowStep;
 import bio.terra.pipelines.stairway.steps.common.CompletePipelineRunStep;
 import bio.terra.pipelines.stairway.steps.common.FetchOutputsFromDataTableStep;
@@ -60,13 +60,13 @@ public class RunWdlBasedPipelineJobFlight extends Flight {
         JobMapKeys.DO_SET_PIPELINE_RUN_STATUS_FAILED_HOOK,
         JobMapKeys.DO_SEND_JOB_FAILURE_NOTIFICATION_HOOK,
         JobMapKeys.DO_INCREMENT_METRICS_FAILED_COUNTER_HOOK,
-        ImputationJobMapKeys.USER_PROVIDED_PIPELINE_INPUTS,
-        ImputationJobMapKeys.CONTROL_WORKSPACE_BILLING_PROJECT,
-        ImputationJobMapKeys.CONTROL_WORKSPACE_NAME,
-        ImputationJobMapKeys.CONTROL_WORKSPACE_STORAGE_CONTAINER_NAME,
-        ImputationJobMapKeys.PIPELINE_TOOL_CONFIG,
-        ImputationJobMapKeys.QUOTA_TOOL_CONFIG,
-        ImputationJobMapKeys.INPUT_QC_TOOL_CONFIG);
+        WdlBasedPipelineJobMapKeys.USER_PROVIDED_PIPELINE_INPUTS,
+        WdlBasedPipelineJobMapKeys.CONTROL_WORKSPACE_BILLING_PROJECT,
+        WdlBasedPipelineJobMapKeys.CONTROL_WORKSPACE_NAME,
+        WdlBasedPipelineJobMapKeys.CONTROL_WORKSPACE_STORAGE_CONTAINER_NAME,
+        WdlBasedPipelineJobMapKeys.PIPELINE_TOOL_CONFIG,
+        WdlBasedPipelineJobMapKeys.QUOTA_TOOL_CONFIG,
+        WdlBasedPipelineJobMapKeys.INPUT_QC_TOOL_CONFIG);
 
     PipelinesEnum pipelinesEnum =
         PipelinesEnum.valueOf(inputParameters.get(JobMapKeys.PIPELINE_NAME, String.class));
@@ -102,7 +102,7 @@ public class RunWdlBasedPipelineJobFlight extends Flight {
         new AddDataTableRowStep(
             flightBeanBag.getRawlsService(),
             flightBeanBag.getSamService(),
-            ImputationJobMapKeys.PIPELINE_TOOL_CONFIG),
+            WdlBasedPipelineJobMapKeys.PIPELINE_TOOL_CONFIG),
         externalServiceRetryRule);
 
     // Check input for quota to be consumed
@@ -110,16 +110,16 @@ public class RunWdlBasedPipelineJobFlight extends Flight {
         new SubmitCromwellSubmissionStep(
             flightBeanBag.getRawlsService(),
             flightBeanBag.getSamService(),
-            ImputationJobMapKeys.QUOTA_TOOL_CONFIG,
-            ImputationJobMapKeys.QUOTA_SUBMISSION_ID),
+            WdlBasedPipelineJobMapKeys.QUOTA_TOOL_CONFIG,
+            WdlBasedPipelineJobMapKeys.QUOTA_SUBMISSION_ID),
         externalServiceRetryRule);
 
     addStep(
         new PollCromwellSubmissionStatusStep(
             flightBeanBag.getRawlsService(),
             flightBeanBag.getSamService(),
-            ImputationJobMapKeys.QUOTA_TOOL_CONFIG,
-            ImputationJobMapKeys.QUOTA_SUBMISSION_ID),
+            WdlBasedPipelineJobMapKeys.QUOTA_TOOL_CONFIG,
+            WdlBasedPipelineJobMapKeys.QUOTA_SUBMISSION_ID),
         externalServiceRetryRule);
 
     addStep(
@@ -127,8 +127,8 @@ public class RunWdlBasedPipelineJobFlight extends Flight {
             flightBeanBag.getRawlsService(),
             flightBeanBag.getSamService(),
             flightBeanBag.getPipelineInputsOutputsService(),
-            ImputationJobMapKeys.QUOTA_TOOL_CONFIG,
-            ImputationJobMapKeys.QUOTA_OUTPUTS),
+            WdlBasedPipelineJobMapKeys.QUOTA_TOOL_CONFIG,
+            WdlBasedPipelineJobMapKeys.QUOTA_OUTPUTS),
         externalServiceRetryRule);
 
     addStep(
@@ -141,16 +141,16 @@ public class RunWdlBasedPipelineJobFlight extends Flight {
         new SubmitCromwellSubmissionStep(
             flightBeanBag.getRawlsService(),
             flightBeanBag.getSamService(),
-            ImputationJobMapKeys.INPUT_QC_TOOL_CONFIG,
-            ImputationJobMapKeys.INPUT_QC_SUBMISSION_ID),
+            WdlBasedPipelineJobMapKeys.INPUT_QC_TOOL_CONFIG,
+            WdlBasedPipelineJobMapKeys.INPUT_QC_SUBMISSION_ID),
         externalServiceRetryRule);
 
     addStep(
         new PollCromwellSubmissionStatusStep(
             flightBeanBag.getRawlsService(),
             flightBeanBag.getSamService(),
-            ImputationJobMapKeys.INPUT_QC_TOOL_CONFIG,
-            ImputationJobMapKeys.INPUT_QC_SUBMISSION_ID),
+            WdlBasedPipelineJobMapKeys.INPUT_QC_TOOL_CONFIG,
+            WdlBasedPipelineJobMapKeys.INPUT_QC_SUBMISSION_ID),
         externalServiceRetryRule);
 
     addStep(
@@ -158,8 +158,8 @@ public class RunWdlBasedPipelineJobFlight extends Flight {
             flightBeanBag.getRawlsService(),
             flightBeanBag.getSamService(),
             flightBeanBag.getPipelineInputsOutputsService(),
-            ImputationJobMapKeys.INPUT_QC_TOOL_CONFIG,
-            ImputationJobMapKeys.INPUT_QC_OUTPUTS),
+            WdlBasedPipelineJobMapKeys.INPUT_QC_TOOL_CONFIG,
+            WdlBasedPipelineJobMapKeys.INPUT_QC_OUTPUTS),
         externalServiceRetryRule);
 
     addStep(new InputQcValidationStep(), dbRetryRule);
@@ -169,16 +169,16 @@ public class RunWdlBasedPipelineJobFlight extends Flight {
         new SubmitCromwellSubmissionStep(
             flightBeanBag.getRawlsService(),
             flightBeanBag.getSamService(),
-            ImputationJobMapKeys.PIPELINE_TOOL_CONFIG,
-            ImputationJobMapKeys.PIPELINE_SUBMISSION_ID),
+            WdlBasedPipelineJobMapKeys.PIPELINE_TOOL_CONFIG,
+            WdlBasedPipelineJobMapKeys.PIPELINE_SUBMISSION_ID),
         externalServiceRetryRule);
 
     addStep(
         new PollCromwellSubmissionStatusStep(
             flightBeanBag.getRawlsService(),
             flightBeanBag.getSamService(),
-            ImputationJobMapKeys.PIPELINE_TOOL_CONFIG,
-            ImputationJobMapKeys.PIPELINE_SUBMISSION_ID),
+            WdlBasedPipelineJobMapKeys.PIPELINE_TOOL_CONFIG,
+            WdlBasedPipelineJobMapKeys.PIPELINE_SUBMISSION_ID),
         externalServiceRetryRule);
 
     addStep(
@@ -186,8 +186,8 @@ public class RunWdlBasedPipelineJobFlight extends Flight {
             flightBeanBag.getRawlsService(),
             flightBeanBag.getSamService(),
             flightBeanBag.getPipelineInputsOutputsService(),
-            ImputationJobMapKeys.PIPELINE_TOOL_CONFIG,
-            ImputationJobMapKeys.PIPELINE_RUN_OUTPUTS),
+            WdlBasedPipelineJobMapKeys.PIPELINE_TOOL_CONFIG,
+            WdlBasedPipelineJobMapKeys.PIPELINE_RUN_OUTPUTS),
         externalServiceRetryRule);
 
     // populate file sizes for pipeline outputs

--- a/service/src/main/java/bio/terra/pipelines/stairway/steps/common/AddDataTableRowStep.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/steps/common/AddDataTableRowStep.java
@@ -4,7 +4,7 @@ import bio.terra.pipelines.common.utils.FlightUtils;
 import bio.terra.pipelines.dependencies.rawls.RawlsService;
 import bio.terra.pipelines.dependencies.rawls.RawlsServiceApiException;
 import bio.terra.pipelines.dependencies.sam.SamService;
-import bio.terra.pipelines.stairway.flights.imputation.ImputationJobMapKeys;
+import bio.terra.pipelines.stairway.flights.wdlbasedpipelinerun.WdlBasedPipelineJobMapKeys;
 import bio.terra.pipelines.stairway.steps.utils.ToolConfig;
 import bio.terra.rawls.model.Entity;
 import bio.terra.stairway.*;
@@ -42,22 +42,23 @@ public class AddDataTableRowStep implements Step {
     FlightMap inputParameters = flightContext.getInputParameters();
     FlightUtils.validateRequiredEntries(
         inputParameters,
-        ImputationJobMapKeys.CONTROL_WORKSPACE_BILLING_PROJECT,
-        ImputationJobMapKeys.CONTROL_WORKSPACE_NAME,
+        WdlBasedPipelineJobMapKeys.CONTROL_WORKSPACE_BILLING_PROJECT,
+        WdlBasedPipelineJobMapKeys.CONTROL_WORKSPACE_NAME,
         toolConfigKey);
 
     String controlWorkspaceName =
-        inputParameters.get(ImputationJobMapKeys.CONTROL_WORKSPACE_NAME, String.class);
+        inputParameters.get(WdlBasedPipelineJobMapKeys.CONTROL_WORKSPACE_NAME, String.class);
     String controlWorkspaceProject =
-        inputParameters.get(ImputationJobMapKeys.CONTROL_WORKSPACE_BILLING_PROJECT, String.class);
+        inputParameters.get(
+            WdlBasedPipelineJobMapKeys.CONTROL_WORKSPACE_BILLING_PROJECT, String.class);
     ToolConfig toolConfig = inputParameters.get(toolConfigKey, ToolConfig.class);
     String dataTableEntityName = toolConfig.dataTableEntityName();
 
     // validate and extract parameters from working map
     FlightMap workingMap = flightContext.getWorkingMap();
-    FlightUtils.validateRequiredEntries(workingMap, ImputationJobMapKeys.ALL_PIPELINE_INPUTS);
+    FlightUtils.validateRequiredEntries(workingMap, WdlBasedPipelineJobMapKeys.ALL_PIPELINE_INPUTS);
     Map<String, Object> allPipelineInputs =
-        workingMap.get(ImputationJobMapKeys.ALL_PIPELINE_INPUTS, new TypeReference<>() {});
+        workingMap.get(WdlBasedPipelineJobMapKeys.ALL_PIPELINE_INPUTS, new TypeReference<>() {});
 
     Entity entity =
         new Entity()

--- a/service/src/main/java/bio/terra/pipelines/stairway/steps/common/AddDataTableRowStep.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/steps/common/AddDataTableRowStep.java
@@ -1,4 +1,4 @@
-package bio.terra.pipelines.stairway.steps.imputation;
+package bio.terra.pipelines.stairway.steps.common;
 
 import bio.terra.pipelines.common.utils.FlightUtils;
 import bio.terra.pipelines.dependencies.rawls.RawlsService;

--- a/service/src/main/java/bio/terra/pipelines/stairway/steps/common/CompletePipelineRunStep.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/steps/common/CompletePipelineRunStep.java
@@ -3,7 +3,7 @@ package bio.terra.pipelines.stairway.steps.common;
 import bio.terra.pipelines.common.utils.FlightUtils;
 import bio.terra.pipelines.dependencies.stairway.JobMapKeys;
 import bio.terra.pipelines.service.PipelineRunsService;
-import bio.terra.pipelines.stairway.flights.imputation.ImputationJobMapKeys;
+import bio.terra.pipelines.stairway.flights.wdlbasedpipelinerun.WdlBasedPipelineJobMapKeys;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
@@ -18,11 +18,11 @@ import org.slf4j.LoggerFactory;
  * the database
  *
  * <p>This step expects the JobMapKeys.USER_ID in the input parameters and
- * ImputationJobMapKeys.PIPELINE_RUN_OUTPUTS and ImputationJobMapKeys.EFFECTIVE_QUOTA_CONSUMED in
- * the working map.
+ * WdlBasedPipelineJobMapKeys.PIPELINE_RUN_OUTPUTS and
+ * WdlBasedPipelineJobMapKeys.EFFECTIVE_QUOTA_CONSUMED in the working map.
  *
- * <p>ImputationJobMapKeys.PIPELINE_RUN_OUTPUTS_FILE_SIZE is an optional input in the working map.
- * If the output file sizes are present in the working map, it will write the file sizes to the
+ * <p>WdlBasedPipelineJobMapKeys.PIPELINE_RUN_OUTPUTS_FILE_SIZE is an optional input in the working
+ * map. If the output file sizes are present in the working map, it will write the file sizes to the
  * database, but if they are not present, it will continue without writing the file sizes since we
  * don't want to fail the entire step if we can't get the file sizes.
  */
@@ -49,20 +49,20 @@ public class CompletePipelineRunStep implements Step {
     var workingMap = flightContext.getWorkingMap();
     FlightUtils.validateRequiredEntries(
         workingMap,
-        ImputationJobMapKeys.PIPELINE_RUN_OUTPUTS,
-        ImputationJobMapKeys.EFFECTIVE_QUOTA_CONSUMED);
+        WdlBasedPipelineJobMapKeys.PIPELINE_RUN_OUTPUTS,
+        WdlBasedPipelineJobMapKeys.EFFECTIVE_QUOTA_CONSUMED);
     Map<String, String> outputsMap =
-        workingMap.get(ImputationJobMapKeys.PIPELINE_RUN_OUTPUTS, Map.class);
+        workingMap.get(WdlBasedPipelineJobMapKeys.PIPELINE_RUN_OUTPUTS, Map.class);
     int quotaConsumed =
-        workingMap.get(ImputationJobMapKeys.EFFECTIVE_QUOTA_CONSUMED, Integer.class);
+        workingMap.get(WdlBasedPipelineJobMapKeys.EFFECTIVE_QUOTA_CONSUMED, Integer.class);
 
     // fetch output file sizes from working map, but if they are not present, continue
     // with an empty map since we don't want to fail the entire step if we can't get the
     // file sizes
     Map<String, Long> outputFileSizes = Collections.emptyMap();
-    if (workingMap.containsKey(ImputationJobMapKeys.PIPELINE_RUN_OUTPUTS_FILE_SIZE)) {
+    if (workingMap.containsKey(WdlBasedPipelineJobMapKeys.PIPELINE_RUN_OUTPUTS_FILE_SIZE)) {
       outputFileSizes =
-          workingMap.get(ImputationJobMapKeys.PIPELINE_RUN_OUTPUTS_FILE_SIZE, Map.class);
+          workingMap.get(WdlBasedPipelineJobMapKeys.PIPELINE_RUN_OUTPUTS_FILE_SIZE, Map.class);
     }
 
     pipelineRunsService.markPipelineRunSuccessAndWriteOutputs(

--- a/service/src/main/java/bio/terra/pipelines/stairway/steps/common/FetchOutputsFromDataTableStep.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/steps/common/FetchOutputsFromDataTableStep.java
@@ -6,7 +6,7 @@ import bio.terra.pipelines.dependencies.rawls.RawlsService;
 import bio.terra.pipelines.dependencies.rawls.RawlsServiceApiException;
 import bio.terra.pipelines.dependencies.sam.SamService;
 import bio.terra.pipelines.service.PipelineInputsOutputsService;
-import bio.terra.pipelines.stairway.flights.imputation.ImputationJobMapKeys;
+import bio.terra.pipelines.stairway.flights.wdlbasedpipelinerun.WdlBasedPipelineJobMapKeys;
 import bio.terra.pipelines.stairway.steps.utils.ToolConfig;
 import bio.terra.rawls.model.Entity;
 import bio.terra.stairway.FlightContext;
@@ -59,14 +59,15 @@ public class FetchOutputsFromDataTableStep implements Step {
     var inputParameters = flightContext.getInputParameters();
     FlightUtils.validateRequiredEntries(
         inputParameters,
-        ImputationJobMapKeys.CONTROL_WORKSPACE_BILLING_PROJECT,
-        ImputationJobMapKeys.CONTROL_WORKSPACE_NAME,
+        WdlBasedPipelineJobMapKeys.CONTROL_WORKSPACE_BILLING_PROJECT,
+        WdlBasedPipelineJobMapKeys.CONTROL_WORKSPACE_NAME,
         toolConfigKey);
 
     String controlWorkspaceBillingProject =
-        inputParameters.get(ImputationJobMapKeys.CONTROL_WORKSPACE_BILLING_PROJECT, String.class);
+        inputParameters.get(
+            WdlBasedPipelineJobMapKeys.CONTROL_WORKSPACE_BILLING_PROJECT, String.class);
     String controlWorkspaceName =
-        inputParameters.get(ImputationJobMapKeys.CONTROL_WORKSPACE_NAME, String.class);
+        inputParameters.get(WdlBasedPipelineJobMapKeys.CONTROL_WORKSPACE_NAME, String.class);
     ToolConfig toolConfig = inputParameters.get(toolConfigKey, ToolConfig.class);
     List<PipelineOutputDefinition> outputDefinitions = toolConfig.outputDefinitions();
 

--- a/service/src/main/java/bio/terra/pipelines/stairway/steps/common/InputQcValidationStep.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/steps/common/InputQcValidationStep.java
@@ -2,7 +2,7 @@ package bio.terra.pipelines.stairway.steps.common;
 
 import bio.terra.pipelines.common.utils.FlightUtils;
 import bio.terra.pipelines.service.exception.PipelineCheckFailedException;
-import bio.terra.pipelines.stairway.flights.imputation.ImputationJobMapKeys;
+import bio.terra.pipelines.stairway.flights.wdlbasedpipelinerun.WdlBasedPipelineJobMapKeys;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.Step;
@@ -36,10 +36,10 @@ public class InputQcValidationStep implements Step {
 
     // validate and extract parameters from working map
     FlightMap workingMap = flightContext.getWorkingMap();
-    FlightUtils.validateRequiredEntries(workingMap, ImputationJobMapKeys.INPUT_QC_OUTPUTS);
+    FlightUtils.validateRequiredEntries(workingMap, WdlBasedPipelineJobMapKeys.INPUT_QC_OUTPUTS);
 
     Map<String, ?> inputQcOutputs =
-        workingMap.get(ImputationJobMapKeys.INPUT_QC_OUTPUTS, Map.class);
+        workingMap.get(WdlBasedPipelineJobMapKeys.INPUT_QC_OUTPUTS, Map.class);
 
     // extract passes_qc
     boolean passesQc = (boolean) inputQcOutputs.get("passesQc");

--- a/service/src/main/java/bio/terra/pipelines/stairway/steps/common/PollCromwellSubmissionStatusStep.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/steps/common/PollCromwellSubmissionStatusStep.java
@@ -3,7 +3,7 @@ package bio.terra.pipelines.stairway.steps.common;
 import bio.terra.pipelines.common.utils.FlightUtils;
 import bio.terra.pipelines.dependencies.rawls.RawlsService;
 import bio.terra.pipelines.dependencies.sam.SamService;
-import bio.terra.pipelines.stairway.flights.imputation.ImputationJobMapKeys;
+import bio.terra.pipelines.stairway.flights.wdlbasedpipelinerun.WdlBasedPipelineJobMapKeys;
 import bio.terra.pipelines.stairway.steps.utils.RawlsSubmissionStepHelper;
 import bio.terra.pipelines.stairway.steps.utils.ToolConfig;
 import bio.terra.stairway.*;
@@ -47,13 +47,14 @@ public class PollCromwellSubmissionStatusStep implements Step {
     FlightMap inputParameters = flightContext.getInputParameters();
     FlightUtils.validateRequiredEntries(
         inputParameters,
-        ImputationJobMapKeys.CONTROL_WORKSPACE_NAME,
-        ImputationJobMapKeys.CONTROL_WORKSPACE_BILLING_PROJECT,
+        WdlBasedPipelineJobMapKeys.CONTROL_WORKSPACE_NAME,
+        WdlBasedPipelineJobMapKeys.CONTROL_WORKSPACE_BILLING_PROJECT,
         toolConfigKey);
     String controlWorkspaceName =
-        inputParameters.get(ImputationJobMapKeys.CONTROL_WORKSPACE_NAME, String.class);
+        inputParameters.get(WdlBasedPipelineJobMapKeys.CONTROL_WORKSPACE_NAME, String.class);
     String controlWorkspaceProject =
-        inputParameters.get(ImputationJobMapKeys.CONTROL_WORKSPACE_BILLING_PROJECT, String.class);
+        inputParameters.get(
+            WdlBasedPipelineJobMapKeys.CONTROL_WORKSPACE_BILLING_PROJECT, String.class);
     ToolConfig toolConfig = inputParameters.get(toolConfigKey, new TypeReference<>() {});
 
     // validate and extract parameters from working map

--- a/service/src/main/java/bio/terra/pipelines/stairway/steps/common/PopulateFileOutputSizeStep.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/steps/common/PopulateFileOutputSizeStep.java
@@ -5,7 +5,7 @@ import bio.terra.pipelines.db.entities.Pipeline;
 import bio.terra.pipelines.dependencies.stairway.JobMapKeys;
 import bio.terra.pipelines.service.PipelineInputsOutputsService;
 import bio.terra.pipelines.service.PipelinesService;
-import bio.terra.pipelines.stairway.flights.imputation.ImputationJobMapKeys;
+import bio.terra.pipelines.stairway.flights.wdlbasedpipelinerun.WdlBasedPipelineJobMapKeys;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
@@ -19,8 +19,8 @@ import org.slf4j.LoggerFactory;
  * Step to populate the file sizes of pipeline outputs in the working map.
  *
  * <p>This step expects the JobMapKeys.PIPELINE_ID in the input parameters and
- * ImputationJobMapKeys.PIPELINE_RUN_OUTPUTS in the working map. It will write the output file sizes
- * to ImputationJobMapKeys.PIPELINE_RUN_OUTPUTS_FILE_SIZE in the working map.
+ * WdlBasedPipelineJobMapKeys.PIPELINE_RUN_OUTPUTS in the working map. It will write the output file
+ * sizes to WdlBasedPipelineJobMapKeys.PIPELINE_RUN_OUTPUTS_FILE_SIZE in the working map.
  *
  * <p>If there is an error populating the file sizes, this step will log the error and continue
  * without populating the file sizes, since we don't want to fail the entire pipeline run if we
@@ -48,16 +48,17 @@ public class PopulateFileOutputSizeStep implements Step {
 
       // validate and extract parameters from working map
       var workingMap = flightContext.getWorkingMap();
-      FlightUtils.validateRequiredEntries(workingMap, ImputationJobMapKeys.PIPELINE_RUN_OUTPUTS);
+      FlightUtils.validateRequiredEntries(
+          workingMap, WdlBasedPipelineJobMapKeys.PIPELINE_RUN_OUTPUTS);
       Map<String, String> outputsMap =
-          workingMap.get(ImputationJobMapKeys.PIPELINE_RUN_OUTPUTS, Map.class);
+          workingMap.get(WdlBasedPipelineJobMapKeys.PIPELINE_RUN_OUTPUTS, Map.class);
 
       Pipeline pipeline = pipelinesService.getPipelineById(pipelineId);
       Map<String, Long> outputFileSizes =
           pipelineInputsOutputsService.getPipelineOutputsFileSize(pipeline, outputsMap);
 
       logger.info("Retrieved file sizes for pipeline outputs");
-      workingMap.put(ImputationJobMapKeys.PIPELINE_RUN_OUTPUTS_FILE_SIZE, outputFileSizes);
+      workingMap.put(WdlBasedPipelineJobMapKeys.PIPELINE_RUN_OUTPUTS_FILE_SIZE, outputFileSizes);
     } catch (Exception e) {
       // log the error and continue without populating the file sizes as we don't want to fail
       // the entire pipeline run if we can't get the file sizes

--- a/service/src/main/java/bio/terra/pipelines/stairway/steps/common/PrepareInputsStep.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/steps/common/PrepareInputsStep.java
@@ -6,7 +6,7 @@ import bio.terra.pipelines.common.utils.PipelinesEnum;
 import bio.terra.pipelines.db.entities.PipelineInputDefinition;
 import bio.terra.pipelines.dependencies.stairway.JobMapKeys;
 import bio.terra.pipelines.service.PipelineInputsOutputsService;
-import bio.terra.pipelines.stairway.flights.imputation.ImputationJobMapKeys;
+import bio.terra.pipelines.stairway.flights.wdlbasedpipelinerun.WdlBasedPipelineJobMapKeys;
 import bio.terra.pipelines.stairway.steps.utils.ToolConfig;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.Step;
@@ -49,19 +49,19 @@ public class PrepareInputsStep implements Step {
     FlightUtils.validateRequiredEntries(
         inputParameters,
         JobMapKeys.PIPELINE_NAME,
-        ImputationJobMapKeys.PIPELINE_TOOL_CONFIG,
-        ImputationJobMapKeys.CONTROL_WORKSPACE_STORAGE_CONTAINER_NAME);
+        WdlBasedPipelineJobMapKeys.PIPELINE_TOOL_CONFIG,
+        WdlBasedPipelineJobMapKeys.CONTROL_WORKSPACE_STORAGE_CONTAINER_NAME);
 
     PipelinesEnum pipelineEnum =
         PipelinesEnum.valueOf(inputParameters.get(JobMapKeys.PIPELINE_NAME, String.class));
     ToolConfig pipelineToolConfig =
-        inputParameters.get(ImputationJobMapKeys.PIPELINE_TOOL_CONFIG, ToolConfig.class);
+        inputParameters.get(WdlBasedPipelineJobMapKeys.PIPELINE_TOOL_CONFIG, ToolConfig.class);
     Map<String, Object> userProvidedPipelineInputs =
         inputParameters.get(
-            ImputationJobMapKeys.USER_PROVIDED_PIPELINE_INPUTS, new TypeReference<>() {});
+            WdlBasedPipelineJobMapKeys.USER_PROVIDED_PIPELINE_INPUTS, new TypeReference<>() {});
     String controlWorkspaceStorageContainerName =
         inputParameters.get(
-            ImputationJobMapKeys.CONTROL_WORKSPACE_STORAGE_CONTAINER_NAME, String.class);
+            WdlBasedPipelineJobMapKeys.CONTROL_WORKSPACE_STORAGE_CONTAINER_NAME, String.class);
     UUID jobId = UUID.fromString(flightContext.getFlightId());
     List<PipelineInputDefinition> allInputDefinitions = pipelineToolConfig.inputDefinitions();
 
@@ -85,7 +85,7 @@ public class PrepareInputsStep implements Step {
             keysToPrependWithStorageURL,
             storageWorkspaceStorageContainerUrl);
 
-    workingMap.put(ImputationJobMapKeys.ALL_PIPELINE_INPUTS, formattedPipelineInputs);
+    workingMap.put(WdlBasedPipelineJobMapKeys.ALL_PIPELINE_INPUTS, formattedPipelineInputs);
     logger.info("Constructed and formatted {} pipeline inputs", pipelineEnum);
 
     return StepResult.getStepResultSuccess();

--- a/service/src/main/java/bio/terra/pipelines/stairway/steps/common/PrepareInputsStep.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/steps/common/PrepareInputsStep.java
@@ -1,4 +1,4 @@
-package bio.terra.pipelines.stairway.steps.imputation;
+package bio.terra.pipelines.stairway.steps.common;
 
 import bio.terra.pipelines.app.configuration.internal.PipelineConfigurations;
 import bio.terra.pipelines.common.utils.FlightUtils;
@@ -19,26 +19,26 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * This step prepares the inputs for the imputation pipeline by assembling the (already validated)
- * user-provided inputs with the service-provided inputs. It adds the storage workspace URL to the
- * service-provided inputs that need it, and then it casts all the inputs according to the type
- * specified in the pipeline input definitions.
+ * This step prepares the inputs for the array_imputation pipeline by assembling the (already
+ * validated) user-provided inputs with the service-provided inputs. It adds the storage workspace
+ * URL to the service-provided inputs that need it, and then it casts all the inputs according to
+ * the type specified in the pipeline input definitions.
  *
  * <p>This step expects the pipeline name and user provided pipeline inputs to be provided in the
  * input parameter map
  *
  * <p>This step constructs the formatted pipeline inputs and stores them in the working map.
  */
-public class PrepareImputationInputsStep implements Step {
+public class PrepareInputsStep implements Step {
   private final PipelineInputsOutputsService pipelineInputsOutputsService;
-  private final PipelineConfigurations.ArrayImputationConfig arrayImputationConfiguration;
-  private final Logger logger = LoggerFactory.getLogger(PrepareImputationInputsStep.class);
+  private final PipelineConfigurations.WdlBasedPipelineConfig wdlBasedPipelineConfiguration;
+  private final Logger logger = LoggerFactory.getLogger(PrepareInputsStep.class);
 
-  public PrepareImputationInputsStep(
+  public PrepareInputsStep(
       PipelineInputsOutputsService pipelineInputsOutputsService,
-      PipelineConfigurations.ArrayImputationConfig arrayImputationConfiguration) {
+      PipelineConfigurations.WdlBasedPipelineConfig wdlBasedPipelineConfiguration) {
     this.pipelineInputsOutputsService = pipelineInputsOutputsService;
-    this.arrayImputationConfiguration = arrayImputationConfiguration;
+    this.wdlBasedPipelineConfiguration = wdlBasedPipelineConfiguration;
   }
 
   @Override
@@ -67,13 +67,13 @@ public class PrepareImputationInputsStep implements Step {
 
     // define input keys that have custom values to be read from the config
     Map<String, String> inputsWithCustomValues =
-        arrayImputationConfiguration.getInputsWithCustomValues();
+        wdlBasedPipelineConfiguration.getInputsWithCustomValues();
 
     // define input file paths that need to be prepended with the storage workspace storage URL
     List<String> keysToPrependWithStorageURL =
-        arrayImputationConfiguration.getInputKeysToPrependWithStorageWorkspaceContainerUrl();
+        wdlBasedPipelineConfiguration.getInputKeysToPrependWithStorageWorkspaceContainerUrl();
     String storageWorkspaceStorageContainerUrl =
-        arrayImputationConfiguration.getStorageWorkspaceContainerUrl();
+        wdlBasedPipelineConfiguration.getStorageWorkspaceContainerUrl();
 
     Map<String, Object> formattedPipelineInputs =
         pipelineInputsOutputsService.gatherAndFormatPipelineInputs(

--- a/service/src/main/java/bio/terra/pipelines/stairway/steps/common/PrepareInputsStep.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/steps/common/PrepareInputsStep.java
@@ -19,10 +19,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * This step prepares the inputs for the array_imputation pipeline by assembling the (already
- * validated) user-provided inputs with the service-provided inputs. It adds the storage workspace
- * URL to the service-provided inputs that need it, and then it casts all the inputs according to
- * the type specified in the pipeline input definitions.
+ * This step prepares the inputs for a wdl-based pipeline by assembling the (already validated)
+ * user-provided inputs with the service-provided inputs. It adds the storage workspace URL to the
+ * service-provided inputs that need it, and then it casts all the inputs according to the type
+ * specified in the pipeline input definitions.
  *
  * <p>This step expects the pipeline name and user provided pipeline inputs to be provided in the
  * input parameter map

--- a/service/src/main/java/bio/terra/pipelines/stairway/steps/common/QuotaConsumedValidationStep.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/steps/common/QuotaConsumedValidationStep.java
@@ -7,7 +7,7 @@ import bio.terra.pipelines.dependencies.stairway.JobMapKeys;
 import bio.terra.pipelines.service.PipelineRunsService;
 import bio.terra.pipelines.service.QuotasService;
 import bio.terra.pipelines.service.exception.PipelineCheckFailedException;
-import bio.terra.pipelines.stairway.flights.imputation.ImputationJobMapKeys;
+import bio.terra.pipelines.stairway.flights.wdlbasedpipelinerun.WdlBasedPipelineJobMapKeys;
 import bio.terra.pipelines.stairway.steps.exception.InternalStepException;
 import bio.terra.stairway.*;
 import java.util.Map;
@@ -63,9 +63,9 @@ public class QuotaConsumedValidationStep implements Step {
 
     // validate and extract parameters from working map
     FlightMap workingMap = flightContext.getWorkingMap();
-    FlightUtils.validateRequiredEntries(workingMap, ImputationJobMapKeys.QUOTA_OUTPUTS);
+    FlightUtils.validateRequiredEntries(workingMap, WdlBasedPipelineJobMapKeys.QUOTA_OUTPUTS);
 
-    Map<?, ?> quotaOutputsMap = workingMap.get(ImputationJobMapKeys.QUOTA_OUTPUTS, Map.class);
+    Map<?, ?> quotaOutputsMap = workingMap.get(WdlBasedPipelineJobMapKeys.QUOTA_OUTPUTS, Map.class);
     Object quotaConsumedObj = quotaOutputsMap.get("quotaConsumed");
     if (quotaConsumedObj == null) {
       logger.error("Missing 'quotaConsumed' entry in quota outputs map for flight {}.", flightId);
@@ -117,8 +117,8 @@ public class QuotaConsumedValidationStep implements Step {
     quotasService.updateQuotaConsumed(userQuota, totalQuotaConsumed);
 
     // store the raw and effective quota consumed values in the working map
-    workingMap.put(ImputationJobMapKeys.RAW_QUOTA_CONSUMED, rawQuotaConsumed);
-    workingMap.put(ImputationJobMapKeys.EFFECTIVE_QUOTA_CONSUMED, quotaUsedForThisRun);
+    workingMap.put(WdlBasedPipelineJobMapKeys.RAW_QUOTA_CONSUMED, rawQuotaConsumed);
+    workingMap.put(WdlBasedPipelineJobMapKeys.EFFECTIVE_QUOTA_CONSUMED, quotaUsedForThisRun);
 
     return StepResult.getStepResultSuccess();
   }
@@ -138,7 +138,7 @@ public class QuotaConsumedValidationStep implements Step {
 
     // update the user quota to be what it was before this run's quota was added
     Integer quotaUsedForThisRun =
-        workingMap.get(ImputationJobMapKeys.EFFECTIVE_QUOTA_CONSUMED, Integer.class);
+        workingMap.get(WdlBasedPipelineJobMapKeys.EFFECTIVE_QUOTA_CONSUMED, Integer.class);
 
     UserQuota userQuota = quotasService.getOrCreateQuotaForUserAndPipeline(userId, pipelineName);
 

--- a/service/src/main/java/bio/terra/pipelines/stairway/steps/common/SubmitCromwellSubmissionStep.java
+++ b/service/src/main/java/bio/terra/pipelines/stairway/steps/common/SubmitCromwellSubmissionStep.java
@@ -8,7 +8,7 @@ import bio.terra.pipelines.dependencies.rawls.RawlsService;
 import bio.terra.pipelines.dependencies.rawls.RawlsServiceApiException;
 import bio.terra.pipelines.dependencies.sam.SamService;
 import bio.terra.pipelines.dependencies.stairway.JobMapKeys;
-import bio.terra.pipelines.stairway.flights.imputation.ImputationJobMapKeys;
+import bio.terra.pipelines.stairway.flights.wdlbasedpipelinerun.WdlBasedPipelineJobMapKeys;
 import bio.terra.pipelines.stairway.steps.utils.RawlsSubmissionStepHelper;
 import bio.terra.pipelines.stairway.steps.utils.ToolConfig;
 import bio.terra.rawls.model.SubmissionReport;
@@ -58,15 +58,16 @@ public class SubmitCromwellSubmissionStep implements Step {
         inputParameters,
         JobMapKeys.PIPELINE_NAME,
         JobMapKeys.DESCRIPTION,
-        ImputationJobMapKeys.CONTROL_WORKSPACE_BILLING_PROJECT,
-        ImputationJobMapKeys.CONTROL_WORKSPACE_NAME,
+        WdlBasedPipelineJobMapKeys.CONTROL_WORKSPACE_BILLING_PROJECT,
+        WdlBasedPipelineJobMapKeys.CONTROL_WORKSPACE_NAME,
         toolConfigKey);
 
     PipelinesEnum pipelineName = inputParameters.get(JobMapKeys.PIPELINE_NAME, PipelinesEnum.class);
     String controlWorkspaceName =
-        inputParameters.get(ImputationJobMapKeys.CONTROL_WORKSPACE_NAME, String.class);
+        inputParameters.get(WdlBasedPipelineJobMapKeys.CONTROL_WORKSPACE_NAME, String.class);
     String controlWorkspaceProject =
-        inputParameters.get(ImputationJobMapKeys.CONTROL_WORKSPACE_BILLING_PROJECT, String.class);
+        inputParameters.get(
+            WdlBasedPipelineJobMapKeys.CONTROL_WORKSPACE_BILLING_PROJECT, String.class);
     String description = inputParameters.get(JobMapKeys.DESCRIPTION, String.class);
 
     ToolConfig toolConfig = inputParameters.get(toolConfigKey, new TypeReference<>() {});

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -16,7 +16,7 @@ env:
     exportEnabled: ${CLOUD_TRACE_ENABLED:false}
     samplingRate: ${SAMPLING_PROBABILITY:0}
   logging:
-    level: ${LOGGING_LEVEL:INFO}
+    level: ${LOGGING_LEVEL:DEBUG}
   urls:
     sam: ${SAM_ADDRESS:https://sam.dsde-dev.broadinstitute.org}
     rawls: ${RAWLS_ADDRESS:https://rawls.dsde-dev.broadinstitute.org}

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -16,7 +16,7 @@ env:
     exportEnabled: ${CLOUD_TRACE_ENABLED:false}
     samplingRate: ${SAMPLING_PROBABILITY:0}
   logging:
-    level: ${LOGGING_LEVEL:DEBUG}
+    level: ${LOGGING_LEVEL:INFO}
   urls:
     sam: ${SAM_ADDRESS:https://sam.dsde-dev.broadinstitute.org}
     rawls: ${RAWLS_ADDRESS:https://rawls.dsde-dev.broadinstitute.org}

--- a/service/src/main/resources/db/changelog.xml
+++ b/service/src/main/resources/db/changelog.xml
@@ -32,6 +32,7 @@
   <include file="changesets/20260309_add_output_file_size.yaml" relativeToChangelogFile="true"/>
   <include file="changesets/20260403_data_delivery_table.yaml" relativeToChangelogFile="true"/>
   <include file="changesets/20260413_update_array_imputation_v2_description.yaml" relativeToChangelogFile="true"/>
+  <include file="changesets/20260427_add_low_pass_imputation.yaml" relativeToChangelogFile="true"/>
 
   <include file="changesets/testdata.yaml" relativeToChangelogFile="true"/>
 

--- a/service/src/main/resources/db/changesets/20260427_add_low_pass_imputation.yaml
+++ b/service/src/main/resources/db/changesets/20260427_add_low_pass_imputation.yaml
@@ -1,0 +1,446 @@
+# insert all low_pass_imputation pipeline data. insertions into the following tables:
+# - pipelines
+# - pipeline_quotas
+# - pipeline_input_definitions
+# - pipeline_output_definitions
+databaseChangeLog:
+  - changeSet:
+      id: add low_pass_imputation pipeline data
+      author: mma
+      changes:
+        # Insert initial low_pass_imputation pipeline data
+        - insert:
+            tableName: pipelines
+            columns:
+              - column:
+                  name: name
+                  value: 'low_pass_imputation'
+              - column:
+                  name: version
+                  value: '1'
+              - column:
+                  name: display_name
+                  value: 'All of Us + AnVIL Low Pass WGS Imputation'
+              - column:
+                  name: description
+                  value: 'Phase and impute low pass WGS or BGE data using GLIMPSE2 with the All of Us + AnVIL reference panel of 515,579 samples.'
+              - column:
+                  name: pipeline_type
+                  value: 'imputation'
+              - column:
+                  name: wdl_url
+                  value: 'https://github.com/broadinstitute/warp/blob/develop/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.wdl'
+              - column:
+                  name: tool_name
+                  value: 'Glimpse2LowPassImputation'
+
+        # Insert quota for low_pass_imputation
+        - insert:
+            tableName: pipeline_quotas
+            columns:
+              - column:
+                  name: pipeline_name
+                  value: 'low_pass_imputation'
+              - column:
+                  name: default_quota
+                  value: '500'
+              - column:
+                  name: min_quota_consumed
+                  value: '500'
+              - column:
+                  name: quota_units
+                  value: 'samples'
+
+        # Insert pipeline input definitions for low_pass_imputation
+        - insert:
+            tableName: pipeline_input_definitions
+            columns:
+              - column:
+                  name: pipeline_id
+                  valueComputed: (SELECT id FROM pipelines WHERE name='low_pass_imputation' AND version=1)
+              - column:
+                  name: name
+                  value: 'crams'
+              - column:
+                  name: type
+                  value: 'FILE_ARRAY'
+              - column:
+                  name: is_required
+                  value: 'false'
+              - column:
+                  name: file_suffix
+                  value: '.cram'
+              - column:
+                  name: user_provided
+                  value: 'true'
+              - column:
+                  name: wdl_variable_name
+                  value: 'crams'
+              - column:
+                  name: description
+                  value: 'Input CRAM files to be imputed. If submitting CRAMs, CRAM index files and sample IDs must also be submitted.'
+
+        - insert:
+            tableName: pipeline_input_definitions
+            columns:
+              - column:
+                  name: pipeline_id
+                  valueComputed: (SELECT id FROM pipelines WHERE name='low_pass_imputation' AND version=1)
+              - column:
+                  name: name
+                  value: 'cramIndices'
+              - column:
+                  name: type
+                  value: 'FILE_ARRAY'
+              - column:
+                  name: is_required
+                  value: 'false'
+              - column:
+                  name: file_suffix
+                  value: '.crai'
+              - column:
+                  name: user_provided
+                  value: 'true'
+              - column:
+                  name: wdl_variable_name
+                  value: 'cram_indices'
+              - column:
+                  name: description
+                  value: 'CRAM index files corresponding to the input CRAM files.'
+
+        - insert:
+            tableName: pipeline_input_definitions
+            columns:
+              - column:
+                  name: pipeline_id
+                  valueComputed: (SELECT id FROM pipelines WHERE name='low_pass_imputation' AND version=1)
+              - column:
+                  name: name
+                  value: 'sampleIds'
+              - column:
+                  name: type
+                  value: 'STRING_ARRAY'
+              - column:
+                  name: is_required
+                  value: 'false'
+              - column:
+                  name: user_provided
+                  value: 'true'
+              - column:
+                  name: wdl_variable_name
+                  value: 'sample_ids'
+              - column:
+                  name: description
+                  value: 'Sample IDs corresponding to the input CRAM files. These will be the sample identifiers used in the output VCF'
+
+        - insert:
+            tableName: pipeline_input_definitions
+            columns:
+              - column:
+                  name: pipeline_id
+                  valueComputed: (SELECT id FROM pipelines WHERE name='low_pass_imputation' AND version=1)
+              - column:
+                  name: name
+                  value: 'cramManifest'
+              - column:
+                  name: type
+                  value: 'FILE'
+              - column:
+                  name: is_required
+                  value: 'false'
+              - column:
+                  name: file_suffix
+                  value: '.tsv'
+              - column:
+                  name: user_provided
+                  value: 'true'
+              - column:
+                  name: wdl_variable_name
+                  value: 'cram_manifest'
+              - column:
+                  name: description
+                  value: 'Manifest TSV file containing columns sample_id, cram_path, and cram_index_path referring to cloud-hosted input files to be imputed'
+
+        - insert:
+            tableName: pipeline_input_definitions
+            columns:
+              - column:
+                  name: pipeline_id
+                  valueComputed: (SELECT id FROM pipelines WHERE name='low_pass_imputation' AND version=1)
+              - column:
+                  name: name
+                  value: 'outputBasename'
+              - column:
+                  name: type
+                  value: 'STRING'
+              - column:
+                  name: is_required
+                  value: 'true'
+              - column:
+                  name: user_provided
+                  value: 'true'
+              - column:
+                  name: wdl_variable_name
+                  value: 'output_basename'
+              - column:
+                  name: display_name
+                  value: 'output basename'
+              - column:
+                  name: description
+                  value: 'The prefix for all of the outputs'' filenames. May only contain alphanumeric characters, dashes, and underscores'
+
+
+        # Insert non-user-provided input definitions for array_imputation
+        - insert:
+            tableName: pipeline_input_definitions
+            columns:
+              - column:
+                  name: pipeline_id
+                  valueComputed: (SELECT id FROM pipelines WHERE name='low_pass_imputation' AND version=1)
+              - column:
+                  name: name
+                  value: 'contigs'
+              - column:
+                  name: type
+                  value: 'STRING_ARRAY'
+              - column:
+                  name: is_required
+                  value: 'true'
+              - column:
+                  name: user_provided
+                  value: 'false'
+              - column:
+                  name: default_value
+                  value: '["chr1","chr2","chr3","chr4","chr5","chr6","chr7","chr8","chr9","chr10","chr11","chr12","chr13","chr14","chr15","chr16","chr17","chr18","chr19","chr20","chr21","chr22"]'
+              - column:
+                  name: wdl_variable_name
+                  value: 'contigs'
+
+        - insert:
+            tableName: pipeline_input_definitions
+            columns:
+              - column:
+                  name: pipeline_id
+                  valueComputed: (SELECT id FROM pipelines WHERE name='low_pass_imputation' AND version=1)
+              - column:
+                  name: name
+                  value: 'referencePanelPrefix'
+              - column:
+                  name: type
+                  value: 'STRING'
+              - column:
+                  name: expects_custom_value
+                  value: 'true'
+              - column:
+                  name: is_required
+                  value: 'true'
+              - column:
+                  name: user_provided
+                  value: 'false'
+              - column:
+                  name: default_value
+                  value: '/hg38/ref_panels/1000G_HGDP_with_trio_information/auxiliary_files/'
+              - column:
+                  name: wdl_variable_name
+                  value: 'reference_panel_prefix'
+
+        - insert:
+            tableName: pipeline_input_definitions
+            columns:
+              - column:
+                  name: pipeline_id
+                  valueComputed: (SELECT id FROM pipelines WHERE name='low_pass_imputation' AND version=1)
+              - column:
+                  name: name
+                  value: 'fasta'
+              - column:
+                  name: type
+                  value: 'STRING'
+              - column:
+                  name: is_required
+                  value: 'true'
+              - column:
+                  name: user_provided
+                  value: 'false'
+              - column:
+                  name: default_value
+                  value: '/hg38/ref_files/Homo_sapiens_assembly38.fasta'
+              - column:
+                  name: wdl_variable_name
+                  value: 'fasta'
+
+        - insert:
+            tableName: pipeline_input_definitions
+            columns:
+              - column:
+                  name: pipeline_id
+                  valueComputed: (SELECT id FROM pipelines WHERE name='low_pass_imputation' AND version=1)
+              - column:
+                  name: name
+                  value: 'fastaIndex'
+              - column:
+                  name: type
+                  value: 'STRING'
+              - column:
+                  name: is_required
+                  value: 'true'
+              - column:
+                  name: user_provided
+                  value: 'false'
+              - column:
+                  name: default_value
+                  value: '/hg38/ref_files/Homo_sapiens_assembly38.fasta.fai'
+              - column:
+                  name: wdl_variable_name
+                  value: 'fasta_index'
+
+        - insert:
+            tableName: pipeline_input_definitions
+            columns:
+              - column:
+                  name: pipeline_id
+                  valueComputed: (SELECT id FROM pipelines WHERE name='low_pass_imputation' AND version=1)
+              - column:
+                  name: name
+                  value: 'refDict'
+              - column:
+                  name: type
+                  value: 'STRING'
+              - column:
+                  name: is_required
+                  value: 'true'
+              - column:
+                  name: user_provided
+                  value: 'false'
+              - column:
+                  name: default_value
+                  value: '/hg38/ref_files/Homo_sapiens_assembly38.dict'
+              - column:
+                  name: wdl_variable_name
+                  value: 'ref_dict'
+
+        # Insert pipeline output definitions for array_imputation
+        - insert:
+            tableName: pipeline_output_definitions
+            columns:
+              - column:
+                  name: pipeline_id
+                  valueComputed: (SELECT id FROM pipelines WHERE name='low_pass_imputation' AND version=1)
+              - column:
+                  name: name
+                  value: 'imputedVcf'
+              - column:
+                  name: type
+                  value: 'FILE'
+              - column:
+                  name: wdl_variable_name
+                  value: 'imputed_vcf'
+              - column:
+                  name: description
+                  value: 'A multi-sample VCF file containing imputed genotypes for all samples'
+              - column:
+                  name: display_name
+                  value: 'imputed multi-sample VCF'
+              - column:
+                  name: is_required
+                  value: 'true'
+
+        - insert:
+            tableName: pipeline_output_definitions
+            columns:
+              - column:
+                  name: pipeline_id
+                  valueComputed: (SELECT id FROM pipelines WHERE name='low_pass_imputation' AND version=1)
+              - column:
+                  name: name
+                  value: 'imputedVcfIndex'
+              - column:
+                  name: type
+                  value: 'FILE'
+              - column:
+                  name: wdl_variable_name
+                  value: 'imputed_vcf_index'
+              - column:
+                  name: description
+                  value: 'An index file for the imputed multi-sample VCF file'
+              - column:
+                  name: display_name
+                  value: 'imputed multi-sample VCF index'
+              - column:
+                  name: is_required
+                  value: 'true'
+
+        - insert:
+            tableName: pipeline_output_definitions
+            columns:
+              - column:
+                  name: pipeline_id
+                  valueComputed: (SELECT id FROM pipelines WHERE name='low_pass_imputation' AND version=1)
+              - column:
+                  name: name
+                  value: 'imputedHomRefSitesOnlyVcf'
+              - column:
+                  name: type
+                  value: 'FILE'
+              - column:
+                  name: wdl_variable_name
+                  value: 'imputed_hom_ref_sites_only_vcf'
+              - column:
+                  name: description
+                  value: 'A sites only VCF file containing information about homozygous reference sites'
+              - column:
+                  name: display_name
+                  value: 'imputed hom ref sites only VCF'
+              - column:
+                  name: is_required
+                  value: 'true'
+
+        - insert:
+            tableName: pipeline_output_definitions
+            columns:
+              - column:
+                  name: pipeline_id
+                  valueComputed: (SELECT id FROM pipelines WHERE name='low_pass_imputation' AND version=1)
+              - column:
+                  name: name
+                  value: 'imputedHomRefSitesOnlyVcfIndex'
+              - column:
+                  name: type
+                  value: 'FILE'
+              - column:
+                  name: wdl_variable_name
+                  value: 'imputed_hom_ref_sites_only_vcf_index'
+              - column:
+                  name: description
+                  value: 'An index file for the imputed homozygous reference sites only VCF file'
+              - column:
+                  name: display_name
+                  value: 'imputed hom ref sites only VCF index'
+              - column:
+                  name: is_required
+                  value: 'true'
+
+        - insert:
+            tableName: pipeline_output_definitions
+            columns:
+              - column:
+                  name: pipeline_id
+                  valueComputed: (SELECT id FROM pipelines WHERE name='low_pass_imputation' AND version=1)
+              - column:
+                  name: name
+                  value: 'qcMetrics'
+              - column:
+                  name: type
+                  value: 'FILE'
+              - column:
+                  name: wdl_variable_name
+                  value: 'qc_metrics'
+              - column:
+                  name: description
+                  value: 'A TSV file containing metrics about the input data'
+              - column:
+                  name: display_name
+                  value: 'QC metrics TSV file'
+              - column:
+                  name: is_required
+                  value: 'true'

--- a/service/src/main/resources/pipelines-config.yml
+++ b/service/src/main/resources/pipelines-config.yml
@@ -1,7 +1,7 @@
 # This env section is for deployment-specific values
 env:
   pipelines:
-    imputation:
+    arrayImputation:
       "1":
         # the default currently points to the GCP dev workspace teaspoons-imputation-dev/teaspoons_imputation_dev_storage_workspace_20240726
         storageWorkspaceContainerUrl: ${IMPUTATION_STORAGE_WORKSPACE_STORAGE_URL:gs://fc-secure-10efd4d7-392a-4e9e-89ea-d6629fbb06cc}
@@ -10,6 +10,11 @@ env:
         # the default currently points to the GCP dev workspace teaspoons-imputation-dev/teaspoons_imputation_dev_storage_workspace_20240726
         storageWorkspaceContainerUrl: ${IMPUTATION_STORAGE_WORKSPACE_STORAGE_URL:gs://fc-secure-10efd4d7-392a-4e9e-89ea-d6629fbb06cc}
         referencePanelPathPrefixCustomValue: ${IMPUTATION_REFERENCE_PANEL_PATH_PREFIX_CUSTOM_VALUE_V2:/hg38/ref_panels/1000G_HGDP_no_singletons/hgdp.tgp.gwaspy.AN_added.bcf.ac2}
+    lowPassImputation:
+      "1":
+        # the default currently points to the GCP dev workspace teaspoons-imputation-dev/teaspoons_imputation_dev_storage_workspace_20240726
+        storageWorkspaceContainerUrl: ${LOW_PASS_IMPUTATION_STORAGE_WORKSPACE_STORAGE_URL:gs://fc-secure-10efd4d7-392a-4e9e-89ea-d6629fbb06cc}
+        referencePanelPathPrefixCustomValue: ${LOW_PASS_IMPUTATION_REFERENCE_PANEL_PATH_PREFIX_CUSTOM_VALUE:/hg38/ref_panels/1000G_HGDP_no_singletons/hgdp.tgp.gwaspy.AN_added.bcf.ac2}
 
 pipelines:
   configurations:
@@ -24,18 +29,28 @@ pipelines:
       1:
         cromwellSubmissionPollingIntervalInSeconds: 600
         inputKeysToPrependWithStorageWorkspaceContainerUrl: [ "refDict", "referencePanelPathPrefix", "geneticMapsPath" ]
-        storageWorkspaceContainerUrl: ${env.pipelines.imputation.1.storageWorkspaceContainerUrl}
+        storageWorkspaceContainerUrl: ${env.pipelines.arrayImputation.1.storageWorkspaceContainerUrl}
         inputsWithCustomValues:
-          referencePanelPathPrefix: ${env.pipelines.imputation.1.referencePanelPathPrefixCustomValue}
+          referencePanelPathPrefix: ${env.pipelines.arrayImputation.1.referencePanelPathPrefixCustomValue}
         useCallCaching: true
         deleteIntermediateFiles: false
         memoryRetryMultiplier: 2.0
       2:
         cromwellSubmissionPollingIntervalInSeconds: 600
         inputKeysToPrependWithStorageWorkspaceContainerUrl: [ "refDict", "referencePanelPathPrefix", "geneticMapsPath" ]
-        storageWorkspaceContainerUrl: ${env.pipelines.imputation.2.storageWorkspaceContainerUrl}
+        storageWorkspaceContainerUrl: ${env.pipelines.arrayImputation.2.storageWorkspaceContainerUrl}
         inputsWithCustomValues:
-          referencePanelPathPrefix: ${env.pipelines.imputation.2.referencePanelPathPrefixCustomValue}
+          referencePanelPathPrefix: ${env.pipelines.arrayImputation.2.referencePanelPathPrefixCustomValue}
+        useCallCaching: true
+        deleteIntermediateFiles: false
+        memoryRetryMultiplier: 2.0
+    lowPassImputation:
+      1:
+        cromwellSubmissionPollingIntervalInSeconds: 600
+        inputKeysToPrependWithStorageWorkspaceContainerUrl: [ "refDict", "referencePanelPrefix", "fasta", "fastaIndex" ]
+        storageWorkspaceContainerUrl: ${env.pipelines.lowPassImputation.1.storageWorkspaceContainerUrl}
+        inputsWithCustomValues:
+          referencePanelPrefix: ${env.pipelines.lowPassImputation.1.referencePanelPrefixCustomValue}
         useCallCaching: true
         deleteIntermediateFiles: false
         memoryRetryMultiplier: 2.0

--- a/service/src/test/java/bio/terra/pipelines/configuration/internal/PipelineConfigurationsTest.java
+++ b/service/src/test/java/bio/terra/pipelines/configuration/internal/PipelineConfigurationsTest.java
@@ -14,10 +14,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 class PipelineConfigurationsTest extends BaseEmbeddedDbTest {
 
   @Autowired private PipelineConfigurations pipelineConfigurations;
-  private final BigDecimal expectedMemoryRetryMultiplier = BigDecimal.valueOf(2.0);
 
   @Test
-  void testImputationConfiguration() {
+  void testArrayImputationV1Configuration() {
+    // note these are the values in pipelines-config-test.yml and not production values
     PipelineConfigurations.WdlBasedPipelineConfig wdlBasedPipelineConfiguration =
         pipelineConfigurations.getArrayImputation().get("1");
 
@@ -33,12 +33,53 @@ class PipelineConfigurationsTest extends BaseEmbeddedDbTest {
         wdlBasedPipelineConfiguration.getInputsWithCustomValues().get("referencePanelPathPrefix"));
     assertTrue(wdlBasedPipelineConfiguration.isUseCallCaching());
     assertFalse(wdlBasedPipelineConfiguration.isDeleteIntermediateFiles());
-    assertEquals(
-        expectedMemoryRetryMultiplier, wdlBasedPipelineConfiguration.getMemoryRetryMultiplier());
+    assertEquals(BigDecimal.valueOf(0.0), wdlBasedPipelineConfiguration.getMemoryRetryMultiplier());
   }
 
   @Test
-  void imputationConfigurationWithNullCustomValuesThrows() {
+  void testArrayImputationV0Configuration() {
+    // note these are the values in pipelines-config-test.yml and not production values
+    PipelineConfigurations.WdlBasedPipelineConfig wdlBasedPipelineConfiguration =
+        pipelineConfigurations.getArrayImputation().get("0");
+
+    assertEquals(2, wdlBasedPipelineConfiguration.getCromwellSubmissionPollingIntervalInSeconds());
+    assertEquals(
+        List.of("prepend1", "prepend2"),
+        wdlBasedPipelineConfiguration.getInputKeysToPrependWithStorageWorkspaceContainerUrl());
+    assertEquals(
+        "https://test_storage_workspace_url",
+        wdlBasedPipelineConfiguration.getStorageWorkspaceContainerUrl());
+    assertEquals(
+        "/test_reference_panel_path_prefix/file_path",
+        wdlBasedPipelineConfiguration.getInputsWithCustomValues().get("referencePanelPathPrefix"));
+    assertFalse(wdlBasedPipelineConfiguration.isUseCallCaching());
+    assertFalse(wdlBasedPipelineConfiguration.isDeleteIntermediateFiles());
+    assertEquals(BigDecimal.valueOf(1.4), wdlBasedPipelineConfiguration.getMemoryRetryMultiplier());
+  }
+
+  @Test
+  void testLowPassImputationV1Configuration() {
+    // note these are the values in pipelines-config-test.yml and not production values
+    PipelineConfigurations.WdlBasedPipelineConfig wdlBasedPipelineConfiguration =
+        pipelineConfigurations.getLowPassImputation().get("1");
+
+    assertEquals(1, wdlBasedPipelineConfiguration.getCromwellSubmissionPollingIntervalInSeconds());
+    assertEquals(
+        List.of("refDict", "referencePanelPrefix", "fasta", "fastaIndex"),
+        wdlBasedPipelineConfiguration.getInputKeysToPrependWithStorageWorkspaceContainerUrl());
+    assertEquals(
+        "https://test_storage_workspace_url",
+        wdlBasedPipelineConfiguration.getStorageWorkspaceContainerUrl());
+    assertEquals(
+        "/test_reference_panel_path_prefix/file_path",
+        wdlBasedPipelineConfiguration.getInputsWithCustomValues().get("referencePanelPrefix"));
+    assertTrue(wdlBasedPipelineConfiguration.isUseCallCaching());
+    assertFalse(wdlBasedPipelineConfiguration.isDeleteIntermediateFiles());
+    assertEquals(BigDecimal.valueOf(2.0), wdlBasedPipelineConfiguration.getMemoryRetryMultiplier());
+  }
+
+  @Test
+  void arrayImputationConfigurationWithNullCustomValuesThrows() {
     List<String> inputKeysToPrependWithStorageWorkspaceContainerUrl = List.of();
     Map<String, String> inputsWithCustomValuesWithMissingValue =
         Collections.singletonMap("refDict", null);
@@ -53,12 +94,12 @@ class PipelineConfigurationsTest extends BaseEmbeddedDbTest {
               inputsWithCustomValuesWithMissingValue, // this should cause an exception
               true,
               false,
-              expectedMemoryRetryMultiplier);
+              BigDecimal.valueOf(0.0));
         });
   }
 
   @Test
-  void imputationConfigurationWithBlankCustomValuesThrows() {
+  void arrayImputationConfigurationWithBlankCustomValuesThrows() {
     List<String> inputKeysToPrependWithStorageWorkspaceContainerUrl = List.of();
     Map<String, String> inputsWithCustomValuesWithMissingValue =
         Collections.singletonMap("refDict", "");
@@ -73,7 +114,7 @@ class PipelineConfigurationsTest extends BaseEmbeddedDbTest {
               inputsWithCustomValuesWithMissingValue, // this should cause an exception
               true,
               false,
-              expectedMemoryRetryMultiplier);
+              BigDecimal.valueOf(0.0));
         });
   }
 

--- a/service/src/test/java/bio/terra/pipelines/configuration/internal/PipelineConfigurationsTest.java
+++ b/service/src/test/java/bio/terra/pipelines/configuration/internal/PipelineConfigurationsTest.java
@@ -18,23 +18,23 @@ class PipelineConfigurationsTest extends BaseEmbeddedDbTest {
 
   @Test
   void testImputationConfiguration() {
-    PipelineConfigurations.ArrayImputationConfig arrayImputationConfiguration =
+    PipelineConfigurations.WdlBasedPipelineConfig wdlBasedPipelineConfiguration =
         pipelineConfigurations.getArrayImputation().get("1");
 
-    assertEquals(1, arrayImputationConfiguration.getCromwellSubmissionPollingIntervalInSeconds());
+    assertEquals(1, wdlBasedPipelineConfiguration.getCromwellSubmissionPollingIntervalInSeconds());
     assertEquals(
         List.of("refDict", "referencePanelPathPrefix", "geneticMapsPath"),
-        arrayImputationConfiguration.getInputKeysToPrependWithStorageWorkspaceContainerUrl());
+        wdlBasedPipelineConfiguration.getInputKeysToPrependWithStorageWorkspaceContainerUrl());
     assertEquals(
         "https://test_storage_workspace_url",
-        arrayImputationConfiguration.getStorageWorkspaceContainerUrl());
+        wdlBasedPipelineConfiguration.getStorageWorkspaceContainerUrl());
     assertEquals(
         "/test_reference_panel_path_prefix/file_path",
-        arrayImputationConfiguration.getInputsWithCustomValues().get("referencePanelPathPrefix"));
-    assertTrue(arrayImputationConfiguration.isUseCallCaching());
-    assertFalse(arrayImputationConfiguration.isDeleteIntermediateFiles());
+        wdlBasedPipelineConfiguration.getInputsWithCustomValues().get("referencePanelPathPrefix"));
+    assertTrue(wdlBasedPipelineConfiguration.isUseCallCaching());
+    assertFalse(wdlBasedPipelineConfiguration.isDeleteIntermediateFiles());
     assertEquals(
-        expectedMemoryRetryMultiplier, arrayImputationConfiguration.getMemoryRetryMultiplier());
+        expectedMemoryRetryMultiplier, wdlBasedPipelineConfiguration.getMemoryRetryMultiplier());
   }
 
   @Test
@@ -46,7 +46,7 @@ class PipelineConfigurationsTest extends BaseEmbeddedDbTest {
     assertThrows(
         IllegalArgumentException.class,
         () -> {
-          new PipelineConfigurations.ArrayImputationConfig(
+          new PipelineConfigurations.WdlBasedPipelineConfig(
               1L,
               inputKeysToPrependWithStorageWorkspaceContainerUrl,
               "https://test_storage_workspace_url",
@@ -66,7 +66,7 @@ class PipelineConfigurationsTest extends BaseEmbeddedDbTest {
     assertThrows(
         IllegalArgumentException.class,
         () -> {
-          new PipelineConfigurations.ArrayImputationConfig(
+          new PipelineConfigurations.WdlBasedPipelineConfig(
               1L,
               inputKeysToPrependWithStorageWorkspaceContainerUrl,
               "https://test_storage_workspace_url",

--- a/service/src/test/java/bio/terra/pipelines/controller/JobApiUtilsTest.java
+++ b/service/src/test/java/bio/terra/pipelines/controller/JobApiUtilsTest.java
@@ -67,7 +67,7 @@ class JobApiUtilsTest {
         StairwayTestUtils.constructFlightStateWithStatusAndId(
             FlightStatus.SUCCESS,
             TestUtils.TEST_NEW_UUID,
-            StairwayTestUtils.CREATE_JOB_INPUT_PARAMS,
+            StairwayTestUtils.CREATE_ARRAY_IMPUTATION_JOB_INPUT_PARAMS,
             StairwayTestUtils.EMPTY_WORKING_MAP,
             StairwayTestUtils.TIME_SUBMITTED_1,
             null);
@@ -88,7 +88,7 @@ class JobApiUtilsTest {
         StairwayTestUtils.constructFlightStateWithStatusAndId(
             FlightStatus.SUCCESS,
             TestUtils.TEST_NEW_UUID,
-            StairwayTestUtils.CREATE_JOB_INPUT_PARAMS,
+            StairwayTestUtils.CREATE_ARRAY_IMPUTATION_JOB_INPUT_PARAMS,
             flightMapWithStatusCode,
             StairwayTestUtils.TIME_SUBMITTED_1,
             StairwayTestUtils.TIME_COMPLETED_1);
@@ -121,7 +121,7 @@ class JobApiUtilsTest {
         StairwayTestUtils.constructFlightStateWithStatusAndId(
             FlightStatus.ERROR,
             TestUtils.TEST_NEW_UUID,
-            StairwayTestUtils.CREATE_JOB_INPUT_PARAMS,
+            StairwayTestUtils.CREATE_ARRAY_IMPUTATION_JOB_INPUT_PARAMS,
             StairwayTestUtils.EMPTY_WORKING_MAP,
             StairwayTestUtils.TIME_SUBMITTED_1,
             StairwayTestUtils.TIME_COMPLETED_1);

--- a/service/src/test/java/bio/terra/pipelines/controller/JobsApiControllerTest.java
+++ b/service/src/test/java/bio/terra/pipelines/controller/JobsApiControllerTest.java
@@ -89,7 +89,7 @@ class JobsApiControllerTest {
         StairwayTestUtils.constructFlightStateWithStatusAndId(
             FlightStatus.ERROR,
             jobId,
-            StairwayTestUtils.CREATE_JOB_INPUT_PARAMS,
+            StairwayTestUtils.CREATE_ARRAY_IMPUTATION_JOB_INPUT_PARAMS,
             StairwayTestUtils.EMPTY_WORKING_MAP,
             StairwayTestUtils.TIME_SUBMITTED_1,
             StairwayTestUtils.TIME_COMPLETED_1);

--- a/service/src/test/java/bio/terra/pipelines/controller/PipelinesApiControllerTest.java
+++ b/service/src/test/java/bio/terra/pipelines/controller/PipelinesApiControllerTest.java
@@ -53,7 +53,8 @@ class PipelinesApiControllerTest {
   @Autowired private MockMvc mockMvc;
 
   private final List<Pipeline> testPipelineList =
-      List.of(TestUtils.TEST_PIPELINE_1, TestUtils.TEST_PIPELINE_2);
+      List.of(
+          TestUtils.TEST_ARRAY_IMPUTATION_PIPELINE_1, TestUtils.TEST_ARRAY_IMPUTATION_PIPELINE_2);
   private final SamUser testUser = MockMvcUtils.TEST_SAM_USER;
 
   @BeforeEach
@@ -89,11 +90,11 @@ class PipelinesApiControllerTest {
 
   @Test
   void getPipelineDetailsOkNoVersion() throws Exception {
-    PipelinesEnum pipelineNameEnum = TestUtils.TEST_PIPELINE_1.getName();
+    PipelinesEnum pipelineNameEnum = TestUtils.TEST_ARRAY_IMPUTATION_PIPELINE_1.getName();
     String pipelineName = pipelineNameEnum.getValue();
 
     when(pipelinesServiceMock.getPipeline(pipelineNameEnum, null, false))
-        .thenReturn(TestUtils.TEST_PIPELINE_1);
+        .thenReturn(TestUtils.TEST_ARRAY_IMPUTATION_PIPELINE_1);
 
     MvcResult result =
         mockMvc
@@ -111,10 +112,13 @@ class PipelinesApiControllerTest {
 
     assertEquals(pipelineName, response.getPipelineName());
     assertEquals(TestUtils.TEST_PIPELINE_VERSION_1, response.getPipelineVersion());
-    assertEquals(TestUtils.TEST_PIPELINE_1.getDescription(), response.getDescription());
-    assertEquals(TestUtils.TEST_PIPELINE_1.getDisplayName(), response.getDisplayName());
-    assertEquals(TestUtils.TEST_PIPELINE_1.getPipelineType(), response.getType());
-    assertEquals(TestUtils.TEST_PIPELINE_1.getVersion(), response.getPipelineVersion());
+    assertEquals(
+        TestUtils.TEST_ARRAY_IMPUTATION_PIPELINE_1.getDescription(), response.getDescription());
+    assertEquals(
+        TestUtils.TEST_ARRAY_IMPUTATION_PIPELINE_1.getDisplayName(), response.getDisplayName());
+    assertEquals(TestUtils.TEST_ARRAY_IMPUTATION_PIPELINE_1.getPipelineType(), response.getType());
+    assertEquals(
+        TestUtils.TEST_ARRAY_IMPUTATION_PIPELINE_1.getVersion(), response.getPipelineVersion());
 
     // check that the response includes only user-provided inputs, and outputs
     assertEquals(
@@ -143,11 +147,11 @@ class PipelinesApiControllerTest {
 
   @Test
   void getPipelineDetailsOkWithVersion() throws Exception {
-    PipelinesEnum pipelineNameEnum = TestUtils.TEST_PIPELINE_1.getName();
+    PipelinesEnum pipelineNameEnum = TestUtils.TEST_ARRAY_IMPUTATION_PIPELINE_1.getName();
     String pipelineName = pipelineNameEnum.getValue();
 
     when(pipelinesServiceMock.getPipeline(pipelineNameEnum, 3, false))
-        .thenReturn(TestUtils.TEST_PIPELINE_1);
+        .thenReturn(TestUtils.TEST_ARRAY_IMPUTATION_PIPELINE_1);
 
     MvcResult result =
         mockMvc
@@ -164,10 +168,13 @@ class PipelinesApiControllerTest {
             .readValue(result.getResponse().getContentAsString(), ApiPipelineWithDetails.class);
 
     assertEquals(pipelineName, response.getPipelineName());
-    assertEquals(TestUtils.TEST_PIPELINE_1.getDescription(), response.getDescription());
-    assertEquals(TestUtils.TEST_PIPELINE_1.getDisplayName(), response.getDisplayName());
-    assertEquals(TestUtils.TEST_PIPELINE_1.getPipelineType(), response.getType());
-    assertEquals(TestUtils.TEST_PIPELINE_1.getVersion(), response.getPipelineVersion());
+    assertEquals(
+        TestUtils.TEST_ARRAY_IMPUTATION_PIPELINE_1.getDescription(), response.getDescription());
+    assertEquals(
+        TestUtils.TEST_ARRAY_IMPUTATION_PIPELINE_1.getDisplayName(), response.getDisplayName());
+    assertEquals(TestUtils.TEST_ARRAY_IMPUTATION_PIPELINE_1.getPipelineType(), response.getType());
+    assertEquals(
+        TestUtils.TEST_ARRAY_IMPUTATION_PIPELINE_1.getVersion(), response.getPipelineVersion());
 
     // check that the response includes only user-provided inputs, and outputs
     assertEquals(
@@ -196,12 +203,12 @@ class PipelinesApiControllerTest {
 
   @Test
   void getPipelineDetailsIncludesQuota() throws Exception {
-    PipelinesEnum pipelineNameEnum = TestUtils.TEST_PIPELINE_1.getName();
+    PipelinesEnum pipelineNameEnum = TestUtils.TEST_ARRAY_IMPUTATION_PIPELINE_1.getName();
     String pipelineName = pipelineNameEnum.getValue();
 
     // Mocks
     when(pipelinesServiceMock.getPipeline(pipelineNameEnum, null, false))
-        .thenReturn(TestUtils.TEST_PIPELINE_1);
+        .thenReturn(TestUtils.TEST_ARRAY_IMPUTATION_PIPELINE_1);
     PipelineQuota testQuota = new PipelineQuota(pipelineNameEnum, 100, 15, QuotaUnitsEnum.SAMPLES);
     when(quotasServiceMock.getPipelineQuota(pipelineNameEnum)).thenReturn(testQuota);
 
@@ -232,7 +239,7 @@ class PipelinesApiControllerTest {
     PipelinesEnum pipelineNameEnum = PipelinesEnum.ARRAY_IMPUTATION;
 
     when(pipelinesServiceMock.getPipeline(pipelineNameEnum, null, false))
-        .thenReturn(TestUtils.TEST_PIPELINE_1);
+        .thenReturn(TestUtils.TEST_ARRAY_IMPUTATION_PIPELINE_1);
 
     MvcResult result =
         mockMvc

--- a/service/src/test/java/bio/terra/pipelines/dependencies/stairway/JobServiceMockTest.java
+++ b/service/src/test/java/bio/terra/pipelines/dependencies/stairway/JobServiceMockTest.java
@@ -234,7 +234,7 @@ class JobServiceMockTest extends BaseEmbeddedDbTest {
   @Test
   void retrieveAsyncJobResultRunning() throws InterruptedException {
     UUID jobId = TestUtils.TEST_NEW_UUID;
-    FlightMap inputParameters = StairwayTestUtils.CREATE_JOB_INPUT_PARAMS;
+    FlightMap inputParameters = StairwayTestUtils.CREATE_ARRAY_IMPUTATION_JOB_INPUT_PARAMS;
     FlightState flightState =
         StairwayTestUtils.constructFlightStateWithStatusAndId(
             FlightStatus.RUNNING, jobId, inputParameters, new FlightMap());
@@ -253,7 +253,7 @@ class JobServiceMockTest extends BaseEmbeddedDbTest {
   @Test
   void retrieveAsyncJobResultSucceeded() throws InterruptedException {
     UUID jobId = TestUtils.TEST_NEW_UUID;
-    FlightMap inputParameters = StairwayTestUtils.CREATE_JOB_INPUT_PARAMS;
+    FlightMap inputParameters = StairwayTestUtils.CREATE_ARRAY_IMPUTATION_JOB_INPUT_PARAMS;
     FlightMap workingMap = new FlightMap();
     String testResponse = "test response";
     workingMap.put(JobMapKeys.RESPONSE, testResponse);
@@ -275,7 +275,7 @@ class JobServiceMockTest extends BaseEmbeddedDbTest {
   @Test
   void retrieveAsyncJobResultFailed() throws InterruptedException {
     UUID jobId = TestUtils.TEST_NEW_UUID;
-    FlightMap inputParameters = StairwayTestUtils.CREATE_JOB_INPUT_PARAMS;
+    FlightMap inputParameters = StairwayTestUtils.CREATE_ARRAY_IMPUTATION_JOB_INPUT_PARAMS;
     // even on a fatal failure the response might have been written to the working map
     FlightMap workingMap = new FlightMap();
     String testResponse = "test response";

--- a/service/src/test/java/bio/terra/pipelines/service/DataDeliveryServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/DataDeliveryServiceTest.java
@@ -118,7 +118,7 @@ class DataDeliveryServiceTest extends BaseEmbeddedDbTest {
   }
 
   private PipelineRun createTestPipelineRun() {
-    Pipeline testPipeline = TestUtils.addNewTestPipelineWithTestValues();
+    Pipeline testPipeline = TestUtils.addNewArrayImputationTestPipelineWithTestValues();
     Pipeline savedPipeline = pipelinesRepository.save(testPipeline);
     PipelineRun pipelineRun = new PipelineRun();
     pipelineRun.setJobId(UUID.randomUUID());

--- a/service/src/test/java/bio/terra/pipelines/service/PipelineInputsOutputsServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/PipelineInputsOutputsServiceTest.java
@@ -1755,6 +1755,24 @@ class PipelineInputsOutputsServiceTest extends BaseEmbeddedDbTest {
             Map.of(), // no inputs with custom values
             List.of(), // no keys to prepend with storage workspace url
             Map.of("input_name", 42)),
+        arguments( // skip missing values for optional inputs
+            Map.of("requiredInput", "user provided value"),
+            List.of(
+                TestUtils.createTestPipelineInputDefWithName(
+                    "requiredInput",
+                    "required_input",
+                    PipelineVariableTypesEnum.STRING,
+                    true,
+                    true),
+                TestUtils.createTestPipelineInputDefWithName(
+                    "optionalInput",
+                    "optional_input",
+                    PipelineVariableTypesEnum.STRING,
+                    false,
+                    true)),
+            Map.of(), // no inputs with custom values
+            List.of(), // no keys to prepend with storage workspace url
+            Map.of("required_input", "user provided value")),
         arguments( // can handle multiple input definitions
             Map.of(
                 "inputNameUserProvided",

--- a/service/src/test/java/bio/terra/pipelines/service/PipelineInputsOutputsServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/PipelineInputsOutputsServiceTest.java
@@ -2,7 +2,7 @@ package bio.terra.pipelines.service;
 
 import static bio.terra.pipelines.common.utils.FileUtils.constructDestinationBlobNameForUserInputFile;
 import static bio.terra.pipelines.testutils.TestUtils.*;
-import static bio.terra.pipelines.testutils.TestUtils.updateTestPipeline1WithTestValues;
+import static bio.terra.pipelines.testutils.TestUtils.updateArrayImputationTestPipeline1WithTestValues;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -95,9 +95,8 @@ class PipelineInputsOutputsServiceTest extends BaseEmbeddedDbTest {
   @BeforeEach
   void addTestPipelineToDb() {
     // add a test pipeline with one required file input and one required manifest input to the db,
-    // so
-    // we can use it for validation tests
-    Pipeline testPipeline = addNewTestPipelineWithTestValues();
+    // so we can use it for validation tests
+    Pipeline testPipeline = addNewArrayImputationTestPipelineWithTestValues();
     Pipeline savedPipeline = pipelinesRepository.save(testPipeline);
     Long pipelineId = savedPipeline.getId();
 
@@ -191,6 +190,11 @@ class PipelineInputsOutputsServiceTest extends BaseEmbeddedDbTest {
   }
 
   private static Stream<Arguments> userFileInputsAreCloudTestInputs() {
+    // can't use Map.of() with null values, so create this here
+    Map<String, Object> userProvidedInputsWithNulls =
+        new HashMap<>(Map.of(FILE_INPUT_KEY_NAME, "gs://some-bucket/some-path/file.vcf.gz"));
+    userProvidedInputsWithNulls.put(MANIFEST_INPUT_KEY_NAME, null);
+
     return Stream.of(
         // arguments: userProvidedInputs, areCloud
         arguments( // two GCS cloud inputs
@@ -224,13 +228,15 @@ class PipelineInputsOutputsServiceTest extends BaseEmbeddedDbTest {
                     "gs://some-bucket/some-path/file.vcf.gz",
                     MANIFEST_INPUT_KEY_NAME,
                     "s3://some-bucket/some-path/manifest.tsv")),
-            false));
+            false),
+        arguments( // one null input is ignored (simulating a missing optional input)
+            userProvidedInputsWithNulls, true));
   }
 
   @ParameterizedTest
   @MethodSource("userFileInputsAreCloudTestInputs")
   void userProvidedInputsAreGcsCloud(Map<String, Object> userPipelineInputs, boolean areCloud) {
-    Pipeline testPipeline = updateTestPipeline1WithTestValues();
+    Pipeline testPipeline = updateArrayImputationTestPipeline1WithTestValues();
     testPipeline.setPipelineInputDefinitions(INPUT_DEFINITIONS_WITH_FILE_AND_MANIFEST);
 
     if (areCloud) {
@@ -332,7 +338,7 @@ class PipelineInputsOutputsServiceTest extends BaseEmbeddedDbTest {
       Map<String, Object> userProvidedInputs,
       boolean shouldPassValidation,
       String expectedErrorMessageString) {
-    Pipeline pipeline = updateTestPipeline1WithTestValues();
+    Pipeline pipeline = updateArrayImputationTestPipeline1WithTestValues();
     // create inputs with one required file input, one required manifest input, one optional file
     // input, and one service-provided file input
     pipeline.setPipelineInputDefinitions(
@@ -411,7 +417,7 @@ class PipelineInputsOutputsServiceTest extends BaseEmbeddedDbTest {
 
   @Test
   void prepareLocalFileInputs() throws MalformedURLException {
-    Pipeline testPipelineWithId = updateTestPipeline1WithTestValues();
+    Pipeline testPipelineWithId = updateArrayImputationTestPipeline1WithTestValues();
     testPipelineWithId.setPipelineInputDefinitions(INPUT_DEFINITIONS_WITH_FILE_AND_MANIFEST);
     String fileInputValue = "fake/file.vcf.gz";
     String manifestInputValue = "fake/manifest.tsv";
@@ -449,7 +455,7 @@ class PipelineInputsOutputsServiceTest extends BaseEmbeddedDbTest {
 
   @Test
   void prepareLocalFileInputsResumable() throws MalformedURLException {
-    Pipeline testPipelineWithId = updateTestPipeline1WithTestValues();
+    Pipeline testPipelineWithId = updateArrayImputationTestPipeline1WithTestValues();
     String fileInputValue = "fake/file.vcf.gz";
     Map<String, Object> userPipelineInputs =
         new HashMap<>(Map.of(FILE_INPUT_KEY_NAME, fileInputValue));
@@ -1949,7 +1955,7 @@ class PipelineInputsOutputsServiceTest extends BaseEmbeddedDbTest {
 
   @Test
   void getPipelineOutputsFileSizeSuccess() {
-    Pipeline testPipeline = updateTestPipeline1WithTestValues();
+    Pipeline testPipeline = updateArrayImputationTestPipeline1WithTestValues();
     Long pipelineId = testPipeline.getId();
 
     PipelineOutputDefinition fileOutput1 =
@@ -2006,7 +2012,7 @@ class PipelineInputsOutputsServiceTest extends BaseEmbeddedDbTest {
 
   @Test
   void getPipelineOutputsFileSizeMissingOutputThrowsException() {
-    Pipeline testPipeline = updateTestPipeline1WithTestValues();
+    Pipeline testPipeline = updateArrayImputationTestPipeline1WithTestValues();
     testPipeline.setPipelineOutputDefinitions(TestUtils.TEST_PIPELINE_OUTPUT_DEFINITIONS_WITH_FILE);
 
     String fileOutputKey = "testFileOutputKey";

--- a/service/src/test/java/bio/terra/pipelines/service/PipelineRunsServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/PipelineRunsServiceTest.java
@@ -30,7 +30,7 @@ import bio.terra.pipelines.dependencies.stairway.JobMapKeys;
 import bio.terra.pipelines.dependencies.stairway.JobService;
 import bio.terra.pipelines.stairway.flights.datadelivery.DataDeliveryJobMapKeys;
 import bio.terra.pipelines.stairway.flights.datadelivery.v20260409.DeliverDataToGcsFlight;
-import bio.terra.pipelines.stairway.flights.imputation.v20251002.RunImputationGcpJobFlight;
+import bio.terra.pipelines.stairway.flights.pipelinerun.v20260428.RunWdlBasedPipelineJobFlight;
 import bio.terra.pipelines.testutils.BaseEmbeddedDbTest;
 import bio.terra.pipelines.testutils.TestUtils;
 import bio.terra.stairway.Flight;
@@ -787,7 +787,7 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
         testUserDescription);
 
     // override this mock to ensure the correct flight class is being requested
-    when(mockJobBuilder.flightClass(RunImputationGcpJobFlight.class)).thenReturn(mockJobBuilder);
+    when(mockJobBuilder.flightClass(RunWdlBasedPipelineJobFlight.class)).thenReturn(mockJobBuilder);
 
     PipelineRun returnedPipelineRun =
         pipelineRunsService.startPipelineRun(testPipelineWithId, testJobId, testUser);
@@ -849,7 +849,7 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
         testUserDescription);
 
     // override this mock to ensure the correct flight class is being requested
-    when(mockJobBuilder.flightClass(RunImputationGcpJobFlight.class)).thenReturn(mockJobBuilder);
+    when(mockJobBuilder.flightClass(RunWdlBasedPipelineJobFlight.class)).thenReturn(mockJobBuilder);
 
     when(mockGcsService.getBufferedReaderForGcsTextFile(new GcsFile(manifestInputValue)))
         .thenReturn(getBufferedReaderForStringTesting(manifestInputContents));
@@ -873,7 +873,7 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
 
     // test that when we try to create a new run but Stairway fails, we don't write the run
     // to our database (i.e. test the transaction)
-    when(mockJobBuilder.flightClass(RunImputationGcpJobFlight.class))
+    when(mockJobBuilder.flightClass(RunWdlBasedPipelineJobFlight.class))
         .thenThrow(new RuntimeException("Stairway error"));
 
     assertThrows(

--- a/service/src/test/java/bio/terra/pipelines/service/PipelineRunsServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/PipelineRunsServiceTest.java
@@ -30,7 +30,7 @@ import bio.terra.pipelines.dependencies.stairway.JobMapKeys;
 import bio.terra.pipelines.dependencies.stairway.JobService;
 import bio.terra.pipelines.stairway.flights.datadelivery.DataDeliveryJobMapKeys;
 import bio.terra.pipelines.stairway.flights.datadelivery.v20260409.DeliverDataToGcsFlight;
-import bio.terra.pipelines.stairway.flights.pipelinerun.v20260428.RunWdlBasedPipelineJobFlight;
+import bio.terra.pipelines.stairway.flights.wdlbasedpipelinerun.v20260428.RunWdlBasedPipelineJobFlight;
 import bio.terra.pipelines.testutils.BaseEmbeddedDbTest;
 import bio.terra.pipelines.testutils.TestUtils;
 import bio.terra.stairway.Flight;
@@ -213,7 +213,8 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
     @Test
     void preparePipelineRunNoWorkspaceSetUp() {
       // missing workspace project
-      Pipeline testPipelineWithIdMissingWorkspaceProject = updateTestPipeline1WithTestValues();
+      Pipeline testPipelineWithIdMissingWorkspaceProject =
+          updateArrayImputationTestPipeline1WithTestValues();
       testPipelineWithIdMissingWorkspaceProject.setWorkspaceBillingProject(null);
 
       assertThrows(
@@ -228,7 +229,8 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
                   false));
 
       // missing workspace name
-      Pipeline testPipelineWithIdMissingWorkspaceName = updateTestPipeline1WithTestValues();
+      Pipeline testPipelineWithIdMissingWorkspaceName =
+          updateArrayImputationTestPipeline1WithTestValues();
       testPipelineWithIdMissingWorkspaceName.setWorkspaceName(null);
 
       assertThrows(
@@ -244,7 +246,7 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
 
       // missing workspace storage container url
       Pipeline testPipelineWithIdMissingWorkspaceStorageContainerUrl =
-          updateTestPipeline1WithTestValues();
+          updateArrayImputationTestPipeline1WithTestValues();
       testPipelineWithIdMissingWorkspaceStorageContainerUrl.setWorkspaceStorageContainerName(null);
 
       assertThrows(
@@ -261,7 +263,7 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
 
     @Test
     void preparePipelineRunAlreadyExistsSameUser() {
-      Pipeline testPipelineWithId = updateTestPipeline1WithTestValues();
+      Pipeline testPipelineWithId = updateArrayImputationTestPipeline1WithTestValues();
 
       // write a prepared pipeline run to the db
       pipelineRunsService.writeNewPipelineRunToDb(
@@ -290,7 +292,7 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
 
     @Test
     void preparePipelineRunAlreadyExistsOtherUser() {
-      Pipeline testPipelineWithId = updateTestPipeline1WithTestValues();
+      Pipeline testPipelineWithId = updateArrayImputationTestPipeline1WithTestValues();
 
       // write a prepared pipeline run to the db
       pipelineRunsService.writeNewPipelineRunToDb(
@@ -319,7 +321,7 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
 
     @Test
     void preparePipelineRunLocalInputs() throws MalformedURLException {
-      Pipeline testPipelineWithId = updateTestPipeline1WithTestValues();
+      Pipeline testPipelineWithId = updateArrayImputationTestPipeline1WithTestValues();
       String fileInputKeyName = "testRequiredVcfInput";
       String fileInputValue = "fake/file.vcf.gz";
       Map<String, Object> userPipelineInputs =
@@ -385,7 +387,7 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
 
     @Test
     void preparePipelineRunCloudInputs() {
-      Pipeline testPipelineWithId = updateTestPipeline1WithTestValues();
+      Pipeline testPipelineWithId = updateArrayImputationTestPipeline1WithTestValues();
       String fileInputKeyName = "testRequiredVcfInput";
       String fileInputValue = "gs://fake/file.vcf.gz";
       Map<String, Object> userPipelineInputs =
@@ -446,7 +448,7 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
 
     @Test
     void preparePipelineRunAllowNullDescription() throws MalformedURLException {
-      Pipeline testPipelineWithId = updateTestPipeline1WithTestValues();
+      Pipeline testPipelineWithId = updateArrayImputationTestPipeline1WithTestValues();
       String fileInputKeyName = "testRequiredVcfInput";
       String fileInputValue = "fake/file.vcf.gz";
       Map<String, Object> userPipelineInputs =
@@ -481,7 +483,8 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
     @Test
     void preparePipelineRunNoWorkspaceSetUp() {
       // missing workspace project
-      Pipeline testPipelineWithIdMissingWorkspaceProject = updateTestPipeline1WithTestValues();
+      Pipeline testPipelineWithIdMissingWorkspaceProject =
+          updateArrayImputationTestPipeline1WithTestValues();
       testPipelineWithIdMissingWorkspaceProject.setWorkspaceBillingProject(null);
 
       assertThrows(
@@ -496,7 +499,8 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
                   false));
 
       // missing workspace name
-      Pipeline testPipelineWithIdMissingWorkspaceName = updateTestPipeline1WithTestValues();
+      Pipeline testPipelineWithIdMissingWorkspaceName =
+          updateArrayImputationTestPipeline1WithTestValues();
       testPipelineWithIdMissingWorkspaceName.setWorkspaceName(null);
 
       assertThrows(
@@ -512,7 +516,7 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
 
       // missing workspace storage container url
       Pipeline testPipelineWithIdMissingWorkspaceStorageContainerUrl =
-          updateTestPipeline1WithTestValues();
+          updateArrayImputationTestPipeline1WithTestValues();
       testPipelineWithIdMissingWorkspaceStorageContainerUrl.setWorkspaceStorageContainerName(null);
 
       assertThrows(
@@ -529,7 +533,7 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
 
     @Test
     void preparePipelineRunAlreadyExistsSameUser() {
-      Pipeline testPipelineWithId = updateTestPipeline1WithTestValues();
+      Pipeline testPipelineWithId = updateArrayImputationTestPipeline1WithTestValues();
 
       // write a prepared pipeline run to the db
       pipelineRunsService.writeNewPipelineRunToDb(
@@ -558,7 +562,7 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
 
     @Test
     void preparePipelineRunAlreadyExistsOtherUser() {
-      Pipeline testPipelineWithId = updateTestPipeline1WithTestValues();
+      Pipeline testPipelineWithId = updateArrayImputationTestPipeline1WithTestValues();
 
       // write a prepared pipeline run to the db
       pipelineRunsService.writeNewPipelineRunToDb(
@@ -587,7 +591,7 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
 
     @Test
     void preparePipelineRun() throws MalformedURLException {
-      Pipeline testPipelineWithId = updateTestPipeline1WithTestValues();
+      Pipeline testPipelineWithId = updateArrayImputationTestPipeline1WithTestValues();
       String fileInputKeyName = "testRequiredVcfInput";
       String fileInputValue = "fake/file.vcf.gz";
       Map<String, Object> userPipelineInputs =
@@ -653,7 +657,7 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
 
     @Test
     void preparePipelineRunAllowNullDescription() throws MalformedURLException {
-      Pipeline testPipelineWithId = updateTestPipeline1WithTestValues();
+      Pipeline testPipelineWithId = updateArrayImputationTestPipeline1WithTestValues();
       String fileInputKeyName = "testRequiredVcfInput";
       String fileInputValue = "fake/file.vcf.gz";
       Map<String, Object> userPipelineInputs =
@@ -684,7 +688,8 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
   @Test
   void startPipelineRunNoWorkspaceSetUp() {
     // missing workspace project
-    Pipeline testPipelineWithIdMissingWorkspaceProject = updateTestPipeline1WithTestValues();
+    Pipeline testPipelineWithIdMissingWorkspaceProject =
+        updateArrayImputationTestPipeline1WithTestValues();
     testPipelineWithIdMissingWorkspaceProject.setWorkspaceBillingProject(null);
 
     assertThrows(
@@ -694,7 +699,8 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
                 testPipelineWithIdMissingWorkspaceProject, testJobId, testUser));
 
     // missing workspace name
-    Pipeline testPipelineWithIdMissingWorkspaceName = updateTestPipeline1WithTestValues();
+    Pipeline testPipelineWithIdMissingWorkspaceName =
+        updateArrayImputationTestPipeline1WithTestValues();
     testPipelineWithIdMissingWorkspaceName.setWorkspaceName(null);
 
     assertThrows(
@@ -705,7 +711,7 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
 
     // missing workspace storage container url
     Pipeline testPipelineWithIdMissingWorkspaceStorageContainerUrl =
-        updateTestPipeline1WithTestValues();
+        updateArrayImputationTestPipeline1WithTestValues();
     testPipelineWithIdMissingWorkspaceStorageContainerUrl.setWorkspaceStorageContainerName(null);
 
     assertThrows(
@@ -717,7 +723,7 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
 
   @Test
   void startPipelineRunNoPreparedPipelineRun() {
-    Pipeline testPipelineWithId = updateTestPipeline1WithTestValues();
+    Pipeline testPipelineWithId = updateArrayImputationTestPipeline1WithTestValues();
 
     assertThrows(
         BadRequestException.class,
@@ -726,7 +732,7 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
 
   @Test
   void startPipelineRunAlreadyRunning() {
-    Pipeline testPipelineWithId = updateTestPipeline1WithTestValues();
+    Pipeline testPipelineWithId = updateArrayImputationTestPipeline1WithTestValues();
 
     // write a RUNNING pipelineRun to the db
     pipelineRunsRepository.save(
@@ -749,7 +755,7 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
 
   @Test
   void startPipelineRunWrongUser() {
-    Pipeline testPipelineWithId = updateTestPipeline1WithTestValues();
+    Pipeline testPipelineWithId = updateArrayImputationTestPipeline1WithTestValues();
 
     // write a prepared pipeline run to the db
     pipelineRunsService.writeNewPipelineRunToDb(
@@ -771,8 +777,8 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
 
   @Test
   void startPipelineRunArrayImputation() {
-    Pipeline testPipelineWithId = updateTestPipeline1WithTestValues();
-
+    Pipeline testPipelineWithId = updateArrayImputationTestPipeline1WithTestValues();
+    ;
     // write a prepared pipeline run to the db
     pipelineRunsService.writeNewPipelineRunToDb(
         testJobId,
@@ -814,6 +820,50 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
   }
 
   @Test
+  void startPipelineRunLowPassImputation() {
+    Pipeline testPipeline = updateLowPassImputationTestPipelineWithTestValues();
+
+    // write a prepared pipeline run to the db
+    pipelineRunsService.writeNewPipelineRunToDb(
+        testJobId,
+        testUserId,
+        testPipeline.getId(),
+        testToolVersion,
+        testControlWorkspaceProject,
+        testControlWorkspaceName,
+        testControlWorkspaceStorageContainerName,
+        testControlWorkspaceGoogleProject,
+        testPipelineInputs,
+        testUserDescription);
+
+    // override this mock to ensure the correct flight class is being requested
+    when(mockJobBuilder.flightClass(RunWdlBasedPipelineJobFlight.class)).thenReturn(mockJobBuilder);
+
+    PipelineRun returnedPipelineRun =
+        pipelineRunsService.startPipelineRun(testPipeline, testJobId, testUser);
+
+    assertEquals(testJobId, returnedPipelineRun.getJobId());
+    assertEquals(testUserId, returnedPipelineRun.getUserId());
+    assertEquals(testUserDescription, returnedPipelineRun.getDescription());
+    assertEquals(testPipeline.getId(), returnedPipelineRun.getPipelineId());
+    assertNotNull(returnedPipelineRun.getCreated());
+    assertNotNull(returnedPipelineRun.getUpdated());
+
+    // verify info written to pipeline_runs table
+    PipelineRun savedRun =
+        pipelineRunsRepository
+            .findByJobIdAndUserId(returnedPipelineRun.getJobId(), testUserId)
+            .orElseThrow();
+    assertEquals(testJobId, savedRun.getJobId());
+    assertEquals(CommonPipelineRunStatusEnum.RUNNING, savedRun.getStatus());
+    assertNotNull(savedRun.getCreated());
+    assertNotNull(savedRun.getUpdated());
+
+    // verify submit was called
+    verify(mockJobBuilder).submit();
+  }
+
+  @Test
   void startPipelineRunWithManifestInput() {
     String manifestInputName = "manifestInput";
     String manifestInputValue = "gs://fake-manifest-bucket/manifest.tsv";
@@ -821,7 +871,7 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
     String manifestInputContents =
         "sampleId\tfilePath\nsample1\tgs://fake-cram-bucket/sample1.vcf.gz\nsample2\tgs://fake-cram-bucket/sample2.vcf.gz";
 
-    Pipeline testPipeline = addNewTestPipelineWithTestValues();
+    Pipeline testPipeline = addNewArrayImputationTestPipelineWithTestValues();
     testPipeline.setPipelineInputDefinitions(
         List.of(
             createTestPipelineInputDefWithName(
@@ -869,7 +919,7 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
 
   @Test
   void createImputationRunStairwayError() {
-    Pipeline testPipelineWithId = updateTestPipeline1WithTestValues();
+    Pipeline testPipelineWithId = updateArrayImputationTestPipeline1WithTestValues();
 
     // test that when we try to create a new run but Stairway fails, we don't write the run
     // to our database (i.e. test the transaction)
@@ -1330,7 +1380,7 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
 
   @Test
   void submitDataDeliveryFlightSuccess() {
-    Pipeline testPipeline = addNewTestPipelineWithTestValues();
+    Pipeline testPipeline = addNewArrayImputationTestPipelineWithTestValues();
     Pipeline savedPipeline = pipelinesRepository.save(testPipeline);
     PipelineRun testPipelineRun = createNewPipelineRunWithJobId(testJobId);
     testPipelineRun.setPipelineId(savedPipeline.getId());
@@ -1353,7 +1403,7 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
 
   @Test
   void submitDataDeliveryFlightAppendsPipelineRunIdToPath() {
-    Pipeline testPipeline = addNewTestPipelineWithTestValues();
+    Pipeline testPipeline = addNewArrayImputationTestPipelineWithTestValues();
     Pipeline savedPipeline = pipelinesRepository.save(testPipeline);
     PipelineRun testPipelineRun = createNewPipelineRunWithJobId(testJobId);
     testPipelineRun.setPipelineId(savedPipeline.getId());
@@ -1382,7 +1432,7 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
 
   @Test
   void submitDataDeliveryUserNoWriteAccess() {
-    Pipeline testPipeline = addNewTestPipelineWithTestValues();
+    Pipeline testPipeline = addNewArrayImputationTestPipelineWithTestValues();
     Pipeline savedPipeline = pipelinesRepository.save(testPipeline);
     PipelineRun testPipelineRun = createNewPipelineRunWithJobId(testJobId);
     testPipelineRun.setPipelineId(savedPipeline.getId());
@@ -1414,7 +1464,7 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
 
   @Test
   void submitDataDeliveryServiceNoWriteAccess() {
-    Pipeline testPipeline = addNewTestPipelineWithTestValues();
+    Pipeline testPipeline = addNewArrayImputationTestPipelineWithTestValues();
     Pipeline savedPipeline = pipelinesRepository.save(testPipeline);
     PipelineRun testPipelineRun = createNewPipelineRunWithJobId(testJobId);
     testPipelineRun.setPipelineId(savedPipeline.getId());
@@ -1446,7 +1496,7 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
 
   @Test
   void submitDataDeliveryFlightUsesCorrectFlightClass() {
-    Pipeline testPipeline = addNewTestPipelineWithTestValues();
+    Pipeline testPipeline = addNewArrayImputationTestPipelineWithTestValues();
     Pipeline savedPipeline = pipelinesRepository.save(testPipeline);
     PipelineRun testPipelineRun = createNewPipelineRunWithJobId(testJobId);
     testPipelineRun.setPipelineId(savedPipeline.getId());
@@ -1464,7 +1514,7 @@ class PipelineRunsServiceTest extends BaseEmbeddedDbTest {
 
   @Test
   void submitDataDeliveryFlightDisablesFailureHooks() {
-    Pipeline testPipeline = addNewTestPipelineWithTestValues();
+    Pipeline testPipeline = addNewArrayImputationTestPipelineWithTestValues();
     Pipeline savedPipeline = pipelinesRepository.save(testPipeline);
     PipelineRun testPipelineRun = createNewPipelineRunWithJobId(testJobId);
     testPipelineRun.setPipelineId(savedPipeline.getId());

--- a/service/src/test/java/bio/terra/pipelines/service/PipelinesServiceDatabaseTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/PipelinesServiceDatabaseTest.java
@@ -82,6 +82,19 @@ class PipelinesServiceDatabaseTest extends BaseEmbeddedDbTest {
   }
 
   @Test
+  void allServiceProvidedInputsWithCustomValuesAreRequired() {
+    // make sure all service-provided inputs that are marked as having custom values, are required.
+    // otherwise if they are marked as not required and have no default value, the logic in
+    // PipelineInputsOutputsService.formatPipelineInputs() will skip the input and not do the proper
+    // substitution.
+    for (PipelineInputDefinition p : pipelineInputDefinitionsRepository.findAll()) {
+      if (!p.isUserProvided() && p.isExpectsCustomValue()) {
+        assertTrue(p.isRequired());
+      }
+    }
+  }
+
+  @Test
   void allFileInputsHaveDefinedFileSuffixes() {
     // make sure each user-provided FILE input has a defined value for file_suffix
     for (PipelineInputDefinition p : pipelineInputDefinitionsRepository.findAll()) {

--- a/service/src/test/java/bio/terra/pipelines/service/PipelinesServiceDatabaseTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/PipelinesServiceDatabaseTest.java
@@ -33,9 +33,9 @@ class PipelinesServiceDatabaseTest extends BaseEmbeddedDbTest {
 
   @Test
   void allPipelineEnumsExist() {
-    // make sure all the pipelines in the enum exist in the table
+    // make sure all the pipelines in the enum exist in the database with at least one version
     for (PipelinesEnum p : PipelinesEnum.values()) {
-      assertTrue(pipelinesRepository.existsByNameAndHiddenIsFalse(p));
+      assertNotNull(pipelinesRepository.findAllByNameOrderByVersionDesc(p));
     }
   }
 
@@ -43,8 +43,10 @@ class PipelinesServiceDatabaseTest extends BaseEmbeddedDbTest {
   void allPipelinesHaveDefinedInputs() {
     // make sure all the pipelines in the enum have defined inputs
     for (PipelinesEnum p : PipelinesEnum.values()) {
-      Pipeline pipeline = pipelinesRepository.findByNameAndHiddenIsFalse(p);
-      assertNotNull(pipeline.getPipelineInputDefinitions());
+      List<Pipeline> pipelines = pipelinesRepository.findAllByNameOrderByVersionDesc(p);
+      for (Pipeline pipeline : pipelines) {
+        assertNotNull(pipeline.getPipelineInputDefinitions());
+      }
     }
   }
 
@@ -69,16 +71,6 @@ class PipelinesServiceDatabaseTest extends BaseEmbeddedDbTest {
   }
 
   @Test
-  void allOptionalInputsHaveDefaultValues() {
-    // make sure all optional inputs have default values
-    for (PipelineInputDefinition p : pipelineInputDefinitionsRepository.findAll()) {
-      if (!p.isRequired()) {
-        assertNotNull(p.getDefaultValue());
-      }
-    }
-  }
-
-  @Test
   void allServiceProvidedInputsWithoutCustomValuesHaveDefaultValues() {
     // make sure all service-provided inputs that aren't marked as having custom values, have
     // default values
@@ -91,17 +83,16 @@ class PipelinesServiceDatabaseTest extends BaseEmbeddedDbTest {
 
   @Test
   void allFileInputsHaveDefinedFileSuffixes() {
-    // make sure each FILE input has a defined value for file_suffix
+    // make sure each user-provided FILE input has a defined value for file_suffix
     for (PipelineInputDefinition p : pipelineInputDefinitionsRepository.findAll()) {
-      if (p.getType() == PipelineVariableTypesEnum.FILE
-          || p.getType() == PipelineVariableTypesEnum.FILE_ARRAY) {
+      if (p.isUserProvided() && p.getType().isFileLike()) {
         assertNotNull(p.getFileSuffix());
       }
     }
   }
 
   @Test
-  void imputationPipelineV1HasCorrectInputsAndOutputs() {
+  void arrayImputationPipelineV1HasCorrectInputsAndOutputs() {
     // make sure the imputation pipeline has the correct inputs
     Pipeline pipeline = pipelinesRepository.findByNameAndVersion(PipelinesEnum.ARRAY_IMPUTATION, 1);
 
@@ -188,7 +179,7 @@ class PipelinesServiceDatabaseTest extends BaseEmbeddedDbTest {
   }
 
   @Test
-  void imputationPipelineV2HasCorrectInputsAndOutputs() {
+  void arrayImputationPipelineV2HasCorrectInputsAndOutputs() {
     // make sure the imputation pipeline has the correct inputs
     Pipeline pipeline = pipelinesRepository.findByNameAndVersion(PipelinesEnum.ARRAY_IMPUTATION, 2);
 
@@ -281,9 +272,115 @@ class PipelinesServiceDatabaseTest extends BaseEmbeddedDbTest {
   }
 
   @Test
-  void addDuplicatePipelineInputThrows() {
+  void lowPassImputationPipelineV1HasCorrectInputsAndOutputs() {
     Pipeline pipeline =
-        pipelinesRepository.findByNameAndHiddenIsFalse(PipelinesEnum.ARRAY_IMPUTATION);
+        pipelinesRepository.findByNameAndVersion(PipelinesEnum.LOW_PASS_IMPUTATION, 1);
+
+    List<PipelineInputDefinition> allPipelineInputDefinitions =
+        pipeline.getPipelineInputDefinitions();
+
+    // there should be 5 user-provided inputs and 5 service-provided inputs
+    assertEquals(
+        5,
+        allPipelineInputDefinitions.stream()
+            .filter(PipelineInputDefinition::isUserProvided)
+            .count());
+    assertEquals(
+        5,
+        allPipelineInputDefinitions.stream()
+            .filter(Predicate.not(PipelineInputDefinition::isUserProvided))
+            .count());
+
+    // check user-provided inputs
+    assertTrue(
+        allPipelineInputDefinitions.stream()
+            .filter(PipelineInputDefinition::isUserProvided)
+            .toList()
+            .stream()
+            .map(PipelineInputDefinition::getWdlVariableName)
+            .collect(Collectors.toSet())
+            .containsAll(
+                Set.of("crams", "cram_indices", "sample_ids", "cram_manifest", "output_basename")));
+
+    assertTrue(
+        allPipelineInputDefinitions.stream()
+            .filter(PipelineInputDefinition::isUserProvided)
+            .toList()
+            .stream()
+            .map(PipelineInputDefinition::getName)
+            .collect(Collectors.toSet())
+            .containsAll(
+                Set.of("crams", "cramIndices", "sampleIds", "cramManifest", "outputBasename")));
+
+    // check service-provided inputs
+    assertTrue(
+        allPipelineInputDefinitions.stream()
+            .filter(Predicate.not(PipelineInputDefinition::isUserProvided))
+            .toList()
+            .stream()
+            .map(PipelineInputDefinition::getWdlVariableName)
+            .collect(Collectors.toSet())
+            .containsAll(
+                Set.of("contigs", "ref_dict", "reference_panel_prefix", "fasta", "fasta_index")));
+
+    assertTrue(
+        allPipelineInputDefinitions.stream()
+            .filter(Predicate.not(PipelineInputDefinition::isUserProvided))
+            .toList()
+            .stream()
+            .map(PipelineInputDefinition::getName)
+            .collect(Collectors.toSet())
+            .containsAll(
+                Set.of("contigs", "refDict", "referencePanelPrefix", "fasta", "fastaIndex")));
+
+    // make sure the inputs are associated with the correct pipeline
+    assertEquals(
+        Set.of(pipeline.getId()),
+        allPipelineInputDefinitions.stream()
+            .map(PipelineInputDefinition::getPipelineId)
+            .collect(Collectors.toSet()));
+
+    // check outputs
+    List<PipelineOutputDefinition> allPipelineOutputDefinitions =
+        pipeline.getPipelineOutputDefinitions();
+
+    // there should be 5 outputs
+    assertEquals(5, allPipelineOutputDefinitions.stream().count());
+    assertTrue(
+        allPipelineOutputDefinitions.stream()
+            .map(PipelineOutputDefinition::getWdlVariableName)
+            .collect(Collectors.toSet())
+            .containsAll(
+                Set.of(
+                    "imputed_vcf",
+                    "imputed_vcf_index",
+                    "imputed_hom_ref_sites_only_vcf",
+                    "imputed_hom_ref_sites_only_vcf_index",
+                    "qc_metrics")));
+
+    assertTrue(
+        allPipelineOutputDefinitions.stream()
+            .map(PipelineOutputDefinition::getName)
+            .collect(Collectors.toSet())
+            .containsAll(
+                Set.of(
+                    "imputedVcf",
+                    "imputedVcfIndex",
+                    "imputedHomRefSitesOnlyVcf",
+                    "imputedHomRefSitesOnlyVcfIndex",
+                    "qcMetrics")));
+
+    // make sure the outputs are associated with the correct pipeline
+    assertEquals(
+        Set.of(pipeline.getId()),
+        allPipelineOutputDefinitions.stream()
+            .map(PipelineOutputDefinition::getPipelineId)
+            .collect(Collectors.toSet()));
+  }
+
+  @Test
+  void addDuplicatePipelineInputThrows() {
+    Pipeline pipeline = pipelinesRepository.findByNameAndVersion(PipelinesEnum.ARRAY_IMPUTATION, 1);
 
     // add a pipeline input that already exists
     PipelineInputDefinition newInput = new PipelineInputDefinition();
@@ -302,54 +399,15 @@ class PipelinesServiceDatabaseTest extends BaseEmbeddedDbTest {
 
   @Test
   void allPipelinesHaveDefinedOutputs() {
-    // make sure all the pipelines in the enum have defined outputs
+    // make sure all the pipelines in the enum have defined outputs for each version
     for (PipelinesEnum p : PipelinesEnum.values()) {
-      Pipeline pipeline = pipelinesRepository.findByNameAndHiddenIsFalse(p);
-      assertNotNull(pipeline.getPipelineOutputDefinitions());
+      List<Pipeline> pipelines = pipelinesRepository.findAllByOrderByNameAscVersionDesc();
+      for (Pipeline pipeline : pipelines) {
+        if (pipeline.getName() == p) {
+          assertNotNull(pipeline.getPipelineOutputDefinitions());
+        }
+      }
     }
-  }
-
-  @Test
-  void imputationPipelineHasCorrectOutputs() {
-    // make sure the imputation pipeline has the correct outputs
-    Pipeline pipeline =
-        pipelinesRepository.findByNameAndHiddenIsFalse(PipelinesEnum.ARRAY_IMPUTATION);
-
-    List<PipelineOutputDefinition> allPipelineOutputDefinitions =
-        pipeline.getPipelineOutputDefinitions();
-
-    // there should be 4 outputs
-    assertEquals(4, allPipelineOutputDefinitions.stream().count());
-
-    // check outputs
-    assertTrue(
-        allPipelineOutputDefinitions.stream()
-            .map(PipelineOutputDefinition::getWdlVariableName)
-            .collect(Collectors.toSet())
-            .containsAll(
-                Set.of(
-                    "imputed_multi_sample_vcf",
-                    "imputed_multi_sample_vcf_index",
-                    "chunks_info",
-                    "contigs_info")));
-
-    assertTrue(
-        allPipelineOutputDefinitions.stream()
-            .map(PipelineOutputDefinition::getName)
-            .collect(Collectors.toSet())
-            .containsAll(
-                Set.of(
-                    "imputedMultiSampleVcf",
-                    "imputedMultiSampleVcfIndex",
-                    "chunksInfo",
-                    "contigsInfo")));
-
-    // make sure the outputs are associated with the correct pipeline
-    assertEquals(
-        Set.of(pipeline.getId()),
-        allPipelineOutputDefinitions.stream()
-            .map(PipelineOutputDefinition::getPipelineId)
-            .collect(Collectors.toSet()));
   }
 
   @Test
@@ -357,7 +415,7 @@ class PipelinesServiceDatabaseTest extends BaseEmbeddedDbTest {
     // make sure all the pipelines in the pipeline quotas table have defined pipelines in the
     // pipelines table
     for (PipelineQuota pq : pipelineQuotasRepository.findAll()) {
-      assertTrue(pipelinesRepository.existsByNameAndHiddenIsFalse(pq.getPipelineName()));
+      assertNotNull(pipelinesRepository.findAllByNameOrderByVersionDesc(pq.getPipelineName()));
     }
   }
 }

--- a/service/src/test/java/bio/terra/pipelines/service/PipelinesServiceMockTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/PipelinesServiceMockTest.java
@@ -19,7 +19,9 @@ class PipelinesServiceMockTest extends BaseEmbeddedDbTest {
   @Test
   void getPipelinesOk() {
     // getPipelines should return a list of Pipelines
-    List<Pipeline> pipelinesList = List.of(TestUtils.TEST_PIPELINE_1, TestUtils.TEST_PIPELINE_2);
+    List<Pipeline> pipelinesList =
+        List.of(
+            TestUtils.TEST_ARRAY_IMPUTATION_PIPELINE_1, TestUtils.TEST_ARRAY_IMPUTATION_PIPELINE_2);
     when(pipelinesRepository.findAllByHiddenIsFalseOrderByNameAscVersionDesc())
         .thenReturn(pipelinesList);
 

--- a/service/src/test/java/bio/terra/pipelines/service/PipelinesServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/PipelinesServiceTest.java
@@ -36,6 +36,10 @@ class PipelinesServiceTest extends BaseEmbeddedDbTest {
 
   @Test
   void getCorrectNumberOfPipelines() {
+    // migrations insert one non-hidden pipeline and two hidden pipelines so make sure we find them
+    List<Pipeline> pipelineListIncludingHidden = pipelinesService.getPipelines(true);
+    assertEquals(3, pipelineListIncludingHidden.size());
+
     // migrations insert one non-hidden pipeline (imputation) so make sure we find it
     List<Pipeline> pipelineList = pipelinesService.getPipelines(false);
     assertEquals(1, pipelineList.size());
@@ -84,9 +88,9 @@ class PipelinesServiceTest extends BaseEmbeddedDbTest {
     assertEquals(PipelinesEnum.ARRAY_IMPUTATION, originalPipeline.getName());
     assertEquals(arrayImputationNonHiddenInLiquiBasePipelineVersion, originalPipeline.getVersion());
 
-    // test how many hidden pipelines exist
+    // test how many hidden pipelines exist - 3 originally, + 1 added in this test = 4
     pipelineList = pipelinesService.getPipelines(true);
-    assertEquals(3, pipelineList.size());
+    assertEquals(4, pipelineList.size());
 
     // save a hidden pipeline
     pipelinesRepository.save(
@@ -112,7 +116,7 @@ class PipelinesServiceTest extends BaseEmbeddedDbTest {
     assertEquals(2, pipelineList.size());
 
     pipelineList = pipelinesService.getPipelines(true);
-    assertEquals(4, pipelineList.size());
+    assertEquals(5, pipelineList.size());
   }
 
   @Test
@@ -474,6 +478,10 @@ class PipelinesServiceTest extends BaseEmbeddedDbTest {
 
   @Test
   void getPipelinesOrderedByNameAndVersionIncludingHidden() {
+    // should be 3 pipelines in the table from Liquibase migrations
+    List<Pipeline> pipelineList = pipelinesService.getPipelines(true);
+    assertEquals(3, pipelineList.size());
+
     pipelinesRepository.save(
         TestUtils.createTestPipeline(
             PipelinesEnum.ARRAY_IMPUTATION, 5, true, "Array Imputation v5", "1.3.0"));
@@ -486,12 +494,27 @@ class PipelinesServiceTest extends BaseEmbeddedDbTest {
         TestUtils.createTestPipeline(
             PipelinesEnum.ARRAY_IMPUTATION, 4, true, "Array Imputation v4", "1.2.3"));
 
-    List<Pipeline> pipelineList = pipelinesService.getPipelines(true);
+    pipelinesRepository.save(
+        TestUtils.createTestPipeline(
+            PipelinesEnum.LOW_PASS_IMPUTATION, 2, true, "Low Pass Imputation v2", "1.2.3"));
 
-    assertEquals(5, pipelineList.size());
+    // we added 4 pipelines, 3+4=7
+    List<Pipeline> updatedPipelineList = pipelinesService.getPipelines(true);
+    assertEquals(7, updatedPipelineList.size());
 
     // Verify versions are in descending order
-    List<Integer> actualVersions = pipelineList.stream().map(Pipeline::getVersion).toList();
-    assertEquals(List.of(5, 4, 3, 2, 1), actualVersions);
+    List<Integer> arrayImputationActualVersions =
+        updatedPipelineList.stream()
+            .filter(p -> p.getName().equals(PipelinesEnum.ARRAY_IMPUTATION))
+            .map(Pipeline::getVersion)
+            .toList();
+    assertEquals(List.of(5, 4, 3, 2, 1), arrayImputationActualVersions);
+
+    List<Integer> lowPassImputationActualVersions =
+        updatedPipelineList.stream()
+            .filter(p -> p.getName().equals(PipelinesEnum.LOW_PASS_IMPUTATION))
+            .map(Pipeline::getVersion)
+            .toList();
+    assertEquals(List.of(2, 1), lowPassImputationActualVersions);
   }
 }

--- a/service/src/test/java/bio/terra/pipelines/service/ToolConfigServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/ToolConfigServiceTest.java
@@ -47,15 +47,16 @@ class ToolConfigServiceTest extends BaseTest {
   private final Long pollingIntervalSecondsInputQc = 1L;
   private final boolean useCallCachingInputQc = true;
 
-  private final int pipelineVersion = 2;
+  private final int arrayImputationPipelineVersion = 2;
+  private final int lowPassImputationPipelineVersion = 10;
 
   @BeforeEach
   void setUp() {
     MockitoAnnotations.openMocks(this);
     toolConfigService = new ToolConfigService(pipelineConfigurations);
 
-    // mock imputation config
-    PipelineConfigurations.WdlBasedPipelineConfig wdlBasedPipelineConfig =
+    // mock array imputation config
+    PipelineConfigurations.WdlBasedPipelineConfig arrayImputationPipelineConfig =
         new PipelineConfigurations.WdlBasedPipelineConfig(
             pollingIntervalSecondsPipeline,
             List.of(),
@@ -64,9 +65,23 @@ class ToolConfigServiceTest extends BaseTest {
             useCallCachingPipeline,
             deleteIntermediateFilesPipeline,
             memoryRetryMultiplierPipeline);
-    Map<String, PipelineConfigurations.WdlBasedPipelineConfig> imputationConfigMap =
-        Map.of(String.valueOf(pipelineVersion), wdlBasedPipelineConfig);
-    when(pipelineConfigurations.getArrayImputation()).thenReturn(imputationConfigMap);
+    Map<String, PipelineConfigurations.WdlBasedPipelineConfig> arrayImputationConfigMap =
+        Map.of(String.valueOf(arrayImputationPipelineVersion), arrayImputationPipelineConfig);
+    when(pipelineConfigurations.getArrayImputation()).thenReturn(arrayImputationConfigMap);
+
+    // mock low pass imputation config
+    PipelineConfigurations.WdlBasedPipelineConfig lowPassImputationPipelineConfig =
+        new PipelineConfigurations.WdlBasedPipelineConfig(
+            pollingIntervalSecondsPipeline,
+            List.of(),
+            "",
+            Map.of(),
+            useCallCachingPipeline,
+            deleteIntermediateFilesPipeline,
+            memoryRetryMultiplierPipeline);
+    Map<String, PipelineConfigurations.WdlBasedPipelineConfig> lowPassImputationConfigMap =
+        Map.of(String.valueOf(lowPassImputationPipelineVersion), lowPassImputationPipelineConfig);
+    when(pipelineConfigurations.getLowPassImputation()).thenReturn(lowPassImputationConfigMap);
 
     // mock pipelinesCommonConfiguration
     PipelineConfigurations.PipelinesCommonConfiguration pipelinesCommonConfiguration =
@@ -83,11 +98,11 @@ class ToolConfigServiceTest extends BaseTest {
   }
 
   @Test
-  void testGetPipelineMainToolConfig_WithImputationPipeline() {
+  void testGetPipelineMainToolConfigWithArrayImputationPipeline() {
     // create pipeline
     Pipeline pipeline = new Pipeline();
     pipeline.setName(pipelineName);
-    pipeline.setVersion(pipelineVersion);
+    pipeline.setVersion(arrayImputationPipelineVersion);
     pipeline.setToolName(toolName);
     pipeline.setToolVersion(toolVersion);
     pipeline.setPipelineInputDefinitions(pipelineInputDefinitions);
@@ -100,9 +115,10 @@ class ToolConfigServiceTest extends BaseTest {
     assertEquals(toolName, toolConfig.methodName());
     assertEquals(toolVersion, toolConfig.methodVersion());
     assertEquals(
-        "%s_v%s".formatted(toolName, pipelineVersion), toolConfig.methodNameWithPipelineVersion());
+        "%s_v%s".formatted(toolName, arrayImputationPipelineVersion),
+        toolConfig.methodNameWithPipelineVersion());
     assertEquals(
-        "%s_v%s".formatted(pipelineName.getValue(), pipelineVersion),
+        "%s_v%s".formatted(pipelineName.getValue(), arrayImputationPipelineVersion),
         toolConfig.dataTableEntityName());
     assertEquals(pipelineInputDefinitions, toolConfig.inputDefinitions());
     assertEquals(pipelineOutputDefinitions, toolConfig.outputDefinitions());
@@ -114,7 +130,41 @@ class ToolConfigServiceTest extends BaseTest {
   }
 
   @Test
-  void testGetPipelineMainToolConfig_WithUnsupportedPipeline() {
+  void testGetPipelineMainToolConfigWithLowPassImputationPipeline() {
+    // create pipeline
+    PipelinesEnum lowPassPipelineName = PipelinesEnum.LOW_PASS_IMPUTATION;
+
+    Pipeline pipeline = new Pipeline();
+    pipeline.setName(lowPassPipelineName);
+    pipeline.setVersion(lowPassImputationPipelineVersion);
+    pipeline.setToolName(toolName);
+    pipeline.setToolVersion(toolVersion);
+    pipeline.setPipelineInputDefinitions(pipelineInputDefinitions);
+    pipeline.setPipelineOutputDefinitions(pipelineOutputDefinitions);
+
+    // create main tool config
+    ToolConfig toolConfig = toolConfigService.getPipelineMainToolConfig(pipeline);
+
+    // check values
+    assertEquals(toolName, toolConfig.methodName());
+    assertEquals(toolVersion, toolConfig.methodVersion());
+    assertEquals(
+        "%s_v%s".formatted(toolName, lowPassImputationPipelineVersion),
+        toolConfig.methodNameWithPipelineVersion());
+    assertEquals(
+        "%s_v%s".formatted(lowPassPipelineName.getValue(), lowPassImputationPipelineVersion),
+        toolConfig.dataTableEntityName());
+    assertEquals(pipelineInputDefinitions, toolConfig.inputDefinitions());
+    assertEquals(pipelineOutputDefinitions, toolConfig.outputDefinitions());
+    assertEquals(useCallCachingPipeline, toolConfig.callCache());
+    assertEquals(monitoringScriptPath, toolConfig.monitoringScriptPath());
+    assertEquals(deleteIntermediateFilesPipeline, toolConfig.deleteIntermediateOutputFiles());
+    assertEquals(memoryRetryMultiplierPipeline, toolConfig.memoryRetryMultiplier());
+    assertEquals(pollingIntervalSecondsPipeline, toolConfig.pollingIntervalSeconds());
+  }
+
+  @Test
+  void testGetPipelineMainToolConfigWithUnsupportedPipeline() {
     // Arrange
     Pipeline pipeline = new Pipeline();
 
@@ -127,7 +177,7 @@ class ToolConfigServiceTest extends BaseTest {
 
   @Test
   void testGetQuotaConsumedToolConfig() {
-    Pipeline pipeline = TestUtils.TEST_PIPELINE_1; // this has pipeline version 0
+    Pipeline pipeline = TestUtils.TEST_ARRAY_IMPUTATION_PIPELINE_1; // this has pipeline version 0
     pipeline.setToolVersion(toolVersion);
     pipeline.setPipelineInputDefinitions(pipelineInputDefinitions);
 
@@ -158,7 +208,7 @@ class ToolConfigServiceTest extends BaseTest {
 
   @Test
   void getInputQcToolConfig() {
-    Pipeline pipeline = TestUtils.TEST_PIPELINE_1; // this has pipeline version 0
+    Pipeline pipeline = TestUtils.TEST_ARRAY_IMPUTATION_PIPELINE_1; // this has pipeline version 0
     pipeline.setToolVersion(toolVersion);
     pipeline.setPipelineInputDefinitions(pipelineInputDefinitions);
 

--- a/service/src/test/java/bio/terra/pipelines/service/ToolConfigServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/ToolConfigServiceTest.java
@@ -55,8 +55,8 @@ class ToolConfigServiceTest extends BaseTest {
     toolConfigService = new ToolConfigService(pipelineConfigurations);
 
     // mock imputation config
-    PipelineConfigurations.ArrayImputationConfig arrayImputationConfig =
-        new PipelineConfigurations.ArrayImputationConfig(
+    PipelineConfigurations.WdlBasedPipelineConfig wdlBasedPipelineConfig =
+        new PipelineConfigurations.WdlBasedPipelineConfig(
             pollingIntervalSecondsPipeline,
             List.of(),
             "",
@@ -64,8 +64,8 @@ class ToolConfigServiceTest extends BaseTest {
             useCallCachingPipeline,
             deleteIntermediateFilesPipeline,
             memoryRetryMultiplierPipeline);
-    Map<String, PipelineConfigurations.ArrayImputationConfig> imputationConfigMap =
-        Map.of(String.valueOf(pipelineVersion), arrayImputationConfig);
+    Map<String, PipelineConfigurations.WdlBasedPipelineConfig> imputationConfigMap =
+        Map.of(String.valueOf(pipelineVersion), wdlBasedPipelineConfig);
     when(pipelineConfigurations.getArrayImputation()).thenReturn(imputationConfigMap);
 
     // mock pipelinesCommonConfiguration

--- a/service/src/test/java/bio/terra/pipelines/stairway/flights/imputation/v20251002/RunImputationGcpFlightTest.java
+++ b/service/src/test/java/bio/terra/pipelines/stairway/flights/imputation/v20251002/RunImputationGcpFlightTest.java
@@ -96,7 +96,8 @@ class RunImputationGcpFlightTest extends BaseEmbeddedDbTest {
   @Test
   void expectedStepsInFlight() {
     RunImputationGcpJobFlight runImputationGcpJobFlight =
-        new RunImputationGcpJobFlight(StairwayTestUtils.CREATE_JOB_INPUT_PARAMS, flightBeanBag);
+        new RunImputationGcpJobFlight(
+            StairwayTestUtils.CREATE_ARRAY_IMPUTATION_JOB_INPUT_PARAMS, flightBeanBag);
     assertEquals(expectedStepNames.size(), runImputationGcpJobFlight.getSteps().size());
 
     Set<String> stepNames =
@@ -118,7 +119,8 @@ class RunImputationGcpFlightTest extends BaseEmbeddedDbTest {
     assertNull(counter);
 
     // run setup so counter gets incremented
-    new RunImputationGcpJobFlight(StairwayTestUtils.CREATE_JOB_INPUT_PARAMS, flightBeanBag);
+    new RunImputationGcpJobFlight(
+        StairwayTestUtils.CREATE_ARRAY_IMPUTATION_JOB_INPUT_PARAMS, flightBeanBag);
 
     counter = meterRegistry.find("teaspoons.pipeline.run.count").counter();
     assertNotNull(counter);

--- a/service/src/test/java/bio/terra/pipelines/stairway/flights/imputation/v20251002/RunImputationGcpFlightTest.java
+++ b/service/src/test/java/bio/terra/pipelines/stairway/flights/imputation/v20251002/RunImputationGcpFlightTest.java
@@ -27,7 +27,7 @@ class RunImputationGcpFlightTest extends BaseEmbeddedDbTest {
 
   private final List<String> expectedStepNames =
       List.of(
-          "PrepareImputationInputsStep",
+          "PrepareInputsStep",
           "AddDataTableRowStep",
           // quota wdl steps
           "SubmitCromwellSubmissionStep",

--- a/service/src/test/java/bio/terra/pipelines/stairway/flights/imputation/v20251002/RunImputationGcpFlightTest.java
+++ b/service/src/test/java/bio/terra/pipelines/stairway/flights/imputation/v20251002/RunImputationGcpFlightTest.java
@@ -6,7 +6,7 @@ import bio.terra.pipelines.common.utils.FlightBeanBag;
 import bio.terra.pipelines.common.utils.PipelinesEnum;
 import bio.terra.pipelines.dependencies.stairway.JobMapKeys;
 import bio.terra.pipelines.dependencies.stairway.JobService;
-import bio.terra.pipelines.stairway.flights.imputation.ImputationJobMapKeys;
+import bio.terra.pipelines.stairway.flights.wdlbasedpipelinerun.WdlBasedPipelineJobMapKeys;
 import bio.terra.pipelines.testutils.BaseEmbeddedDbTest;
 import bio.terra.pipelines.testutils.StairwayTestUtils;
 import bio.terra.pipelines.testutils.TestUtils;
@@ -79,16 +79,18 @@ class RunImputationGcpFlightTest extends BaseEmbeddedDbTest {
                 .addParameter(JobMapKeys.PIPELINE_VERSION, TestUtils.TEST_PIPELINE_VERSION_1)
                 .addParameter(JobMapKeys.PIPELINE_ID, TestUtils.TEST_PIPELINE_ID_1)
                 .addParameter(
-                    ImputationJobMapKeys.PIPELINE_INPUT_DEFINITIONS,
+                    WdlBasedPipelineJobMapKeys.PIPELINE_INPUT_DEFINITIONS,
                     TestUtils.TEST_PIPELINE_INPUTS_DEFINITION_LIST)
                 .addParameter(
-                    ImputationJobMapKeys.USER_PROVIDED_PIPELINE_INPUTS,
+                    WdlBasedPipelineJobMapKeys.USER_PROVIDED_PIPELINE_INPUTS,
                     TestUtils.TEST_PIPELINE_INPUTS)
                 .addParameter(
-                    ImputationJobMapKeys.PIPELINE_TOOL_CONFIG, TestUtils.TOOL_CONFIG_GENERIC)
-                .addParameter(ImputationJobMapKeys.QUOTA_TOOL_CONFIG, TestUtils.TOOL_CONFIG_GENERIC)
+                    WdlBasedPipelineJobMapKeys.PIPELINE_TOOL_CONFIG, TestUtils.TOOL_CONFIG_GENERIC)
                 .addParameter(
-                    ImputationJobMapKeys.INPUT_QC_TOOL_CONFIG, TestUtils.TOOL_CONFIG_GENERIC));
+                    WdlBasedPipelineJobMapKeys.QUOTA_TOOL_CONFIG, TestUtils.TOOL_CONFIG_GENERIC)
+                .addParameter(
+                    WdlBasedPipelineJobMapKeys.INPUT_QC_TOOL_CONFIG,
+                    TestUtils.TOOL_CONFIG_GENERIC));
   }
 
   @Test

--- a/service/src/test/java/bio/terra/pipelines/stairway/flights/pipelinerun/v20260428/RunWdlBasedPipelineJobFlightTest.java
+++ b/service/src/test/java/bio/terra/pipelines/stairway/flights/pipelinerun/v20260428/RunWdlBasedPipelineJobFlightTest.java
@@ -1,0 +1,129 @@
+package bio.terra.pipelines.stairway.flights.pipelinerun.v20260428;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import bio.terra.pipelines.common.utils.FlightBeanBag;
+import bio.terra.pipelines.common.utils.PipelinesEnum;
+import bio.terra.pipelines.dependencies.stairway.JobMapKeys;
+import bio.terra.pipelines.dependencies.stairway.JobService;
+import bio.terra.pipelines.stairway.flights.imputation.ImputationJobMapKeys;
+import bio.terra.pipelines.testutils.BaseEmbeddedDbTest;
+import bio.terra.pipelines.testutils.StairwayTestUtils;
+import bio.terra.pipelines.testutils.TestUtils;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class RunWdlBasedPipelineJobFlightTest extends BaseEmbeddedDbTest {
+
+  @Autowired private JobService jobService;
+
+  private final List<String> expectedStepNames =
+      List.of(
+          "PrepareInputsStep",
+          "AddDataTableRowStep",
+          // quota wdl steps
+          "SubmitCromwellSubmissionStep",
+          "PollCromwellSubmissionStatusStep",
+          "FetchOutputsFromDataTableStep",
+          "QuotaConsumedValidationStep",
+          // input qc wdl steps
+          "SubmitCromwellSubmissionStep",
+          "PollCromwellSubmissionStatusStep",
+          "FetchOutputsFromDataTableStep",
+          "InputQcValidationStep",
+          // imputation wdl steps
+          "SubmitCromwellSubmissionStep",
+          "PollCromwellSubmissionStatusStep",
+          "FetchOutputsFromDataTableStep",
+          "PopulateFileOutputSizeStep",
+          "CompletePipelineRunStep",
+          "SendJobSucceededNotificationStep");
+
+  @Autowired FlightBeanBag flightBeanBag;
+  private SimpleMeterRegistry meterRegistry;
+
+  @BeforeEach
+  void setup() {
+    meterRegistry = new SimpleMeterRegistry();
+    Metrics.globalRegistry.add(meterRegistry);
+  }
+
+  @AfterEach
+  void tearDown() {
+    meterRegistry.clear();
+    Metrics.globalRegistry.clear();
+  }
+
+  @Test
+  void createJobFlightSetup() {
+    // this tests the setters for this flight in JobBuilder. note this doesn't check for required
+    // input parameters
+    assertDoesNotThrow(
+        () ->
+            jobService
+                .newJob()
+                .jobId(TestUtils.TEST_NEW_UUID)
+                .flightClass(RunWdlBasedPipelineJobFlight.class)
+                .addParameter(JobMapKeys.DESCRIPTION, "test RunWdlBasedPipelineJobFlight")
+                .addParameter(JobMapKeys.USER_ID, TestUtils.TEST_USER_1_ID)
+                .addParameter(JobMapKeys.PIPELINE_NAME, PipelinesEnum.ARRAY_IMPUTATION)
+                .addParameter(JobMapKeys.PIPELINE_VERSION, TestUtils.TEST_PIPELINE_VERSION_1)
+                .addParameter(JobMapKeys.PIPELINE_VERSION, TestUtils.TEST_PIPELINE_VERSION_1)
+                .addParameter(JobMapKeys.PIPELINE_ID, TestUtils.TEST_PIPELINE_ID_1)
+                .addParameter(
+                    ImputationJobMapKeys.PIPELINE_INPUT_DEFINITIONS,
+                    TestUtils.TEST_PIPELINE_INPUTS_DEFINITION_LIST)
+                .addParameter(
+                    ImputationJobMapKeys.USER_PROVIDED_PIPELINE_INPUTS,
+                    TestUtils.TEST_PIPELINE_INPUTS)
+                .addParameter(
+                    ImputationJobMapKeys.PIPELINE_TOOL_CONFIG, TestUtils.TOOL_CONFIG_GENERIC)
+                .addParameter(ImputationJobMapKeys.QUOTA_TOOL_CONFIG, TestUtils.TOOL_CONFIG_GENERIC)
+                .addParameter(
+                    ImputationJobMapKeys.INPUT_QC_TOOL_CONFIG, TestUtils.TOOL_CONFIG_GENERIC));
+  }
+
+  @Test
+  void expectedStepsInFlight() {
+    RunWdlBasedPipelineJobFlight runWdlBasedPipelineJobFlight =
+        new RunWdlBasedPipelineJobFlight(StairwayTestUtils.CREATE_JOB_INPUT_PARAMS, flightBeanBag);
+    assertEquals(expectedStepNames.size(), runWdlBasedPipelineJobFlight.getSteps().size());
+
+    Set<String> stepNames =
+        runWdlBasedPipelineJobFlight.getSteps().stream()
+            .map(step -> step.getClass().getSimpleName())
+            .collect(Collectors.toSet());
+    for (String step : expectedStepNames) {
+      assertTrue(stepNames.contains(step));
+    }
+
+    Counter counter = meterRegistry.find("teaspoons.pipeline.run.count").counter();
+    assertNotNull(counter);
+    assertEquals(1, counter.count());
+  }
+
+  @Test
+  void pipelineRunCountIncremented() {
+    Counter counter = meterRegistry.find("teaspoons.pipeline.run.count").counter();
+    assertNull(counter);
+
+    // run setup so counter gets incremented
+    new RunWdlBasedPipelineJobFlight(StairwayTestUtils.CREATE_JOB_INPUT_PARAMS, flightBeanBag);
+
+    counter = meterRegistry.find("teaspoons.pipeline.run.count").counter();
+    assertNotNull(counter);
+    assertEquals(1, counter.count());
+  }
+}

--- a/service/src/test/java/bio/terra/pipelines/stairway/flights/wdlbasedpipelinerun/v20260428/RunWdlBasedPipelineJobFlightTest.java
+++ b/service/src/test/java/bio/terra/pipelines/stairway/flights/wdlbasedpipelinerun/v20260428/RunWdlBasedPipelineJobFlightTest.java
@@ -43,7 +43,7 @@ class RunWdlBasedPipelineJobFlightTest extends BaseEmbeddedDbTest {
           "PollCromwellSubmissionStatusStep",
           "FetchOutputsFromDataTableStep",
           "InputQcValidationStep",
-          // imputation wdl steps
+          // pipeline wdl steps
           "SubmitCromwellSubmissionStep",
           "PollCromwellSubmissionStatusStep",
           "FetchOutputsFromDataTableStep",
@@ -67,9 +67,9 @@ class RunWdlBasedPipelineJobFlightTest extends BaseEmbeddedDbTest {
   }
 
   @Test
-  void createArrayImputationJobFlightSetup() {
+  void createJobFlightSetup() {
     // this tests the setters for this flight in JobBuilder. note this doesn't check for required
-    // input parameters
+    // input parameters, nor does it do anything pipeline-specific
     assertDoesNotThrow(
         () ->
             jobService
@@ -80,7 +80,6 @@ class RunWdlBasedPipelineJobFlightTest extends BaseEmbeddedDbTest {
                 .addParameter(JobMapKeys.USER_ID, TestUtils.TEST_USER_1_ID)
                 .addParameter(JobMapKeys.PIPELINE_NAME, PipelinesEnum.ARRAY_IMPUTATION)
                 .addParameter(JobMapKeys.PIPELINE_VERSION, TestUtils.TEST_PIPELINE_VERSION_1)
-                .addParameter(JobMapKeys.PIPELINE_VERSION, TestUtils.TEST_PIPELINE_VERSION_1)
                 .addParameter(JobMapKeys.PIPELINE_ID, TestUtils.TEST_PIPELINE_ID_1)
                 .addParameter(
                     WdlBasedPipelineJobMapKeys.PIPELINE_INPUT_DEFINITIONS,
@@ -98,40 +97,31 @@ class RunWdlBasedPipelineJobFlightTest extends BaseEmbeddedDbTest {
   }
 
   @Test
-  void createLowPassImputationJobFlightSetup() {
-    // this tests the setters for this flight in JobBuilder. note this doesn't check for required
-    // input parameters
-    assertDoesNotThrow(
-        () ->
-            jobService
-                .newJob()
-                .jobId(TestUtils.TEST_NEW_UUID)
-                .flightClass(RunWdlBasedPipelineJobFlight.class)
-                .addParameter(JobMapKeys.DESCRIPTION, "test RunWdlBasedPipelineJobFlight")
-                .addParameter(JobMapKeys.USER_ID, TestUtils.TEST_USER_1_ID)
-                .addParameter(JobMapKeys.PIPELINE_NAME, PipelinesEnum.LOW_PASS_IMPUTATION)
-                .addParameter(JobMapKeys.PIPELINE_VERSION, TestUtils.TEST_PIPELINE_VERSION_1)
-                .addParameter(JobMapKeys.PIPELINE_VERSION, TestUtils.TEST_PIPELINE_VERSION_1)
-                .addParameter(JobMapKeys.PIPELINE_ID, TestUtils.TEST_PIPELINE_ID_1)
-                .addParameter(
-                    WdlBasedPipelineJobMapKeys.PIPELINE_INPUT_DEFINITIONS,
-                    TestUtils.TEST_PIPELINE_INPUTS_DEFINITION_LIST)
-                .addParameter(
-                    WdlBasedPipelineJobMapKeys.USER_PROVIDED_PIPELINE_INPUTS,
-                    TestUtils.TEST_PIPELINE_INPUTS)
-                .addParameter(
-                    WdlBasedPipelineJobMapKeys.PIPELINE_TOOL_CONFIG, TestUtils.TOOL_CONFIG_GENERIC)
-                .addParameter(
-                    WdlBasedPipelineJobMapKeys.QUOTA_TOOL_CONFIG, TestUtils.TOOL_CONFIG_GENERIC)
-                .addParameter(
-                    WdlBasedPipelineJobMapKeys.INPUT_QC_TOOL_CONFIG,
-                    TestUtils.TOOL_CONFIG_GENERIC));
+  void flightRunsExpectedPipeline() {
+    RunWdlBasedPipelineJobFlight runArrayImputationPipelineJobFlight =
+        new RunWdlBasedPipelineJobFlight(
+            StairwayTestUtils.CREATE_ARRAY_IMPUTATION_JOB_INPUT_PARAMS, flightBeanBag);
+    assertEquals(
+        PipelinesEnum.ARRAY_IMPUTATION,
+        runArrayImputationPipelineJobFlight
+            .getInputParameters()
+            .get(JobMapKeys.PIPELINE_NAME, PipelinesEnum.class));
+
+    RunWdlBasedPipelineJobFlight runLowPassImputationPipelineJobFlight =
+        new RunWdlBasedPipelineJobFlight(
+            StairwayTestUtils.CREATE_LOW_PASS_IMPUTATION_JOB_INPUT_PARAMS, flightBeanBag);
+    assertEquals(
+        PipelinesEnum.LOW_PASS_IMPUTATION,
+        runLowPassImputationPipelineJobFlight
+            .getInputParameters()
+            .get(JobMapKeys.PIPELINE_NAME, PipelinesEnum.class));
   }
 
   @Test
   void expectedStepsInFlight() {
     RunWdlBasedPipelineJobFlight runWdlBasedPipelineJobFlight =
-        new RunWdlBasedPipelineJobFlight(StairwayTestUtils.CREATE_JOB_INPUT_PARAMS, flightBeanBag);
+        new RunWdlBasedPipelineJobFlight(
+            StairwayTestUtils.CREATE_ARRAY_IMPUTATION_JOB_INPUT_PARAMS, flightBeanBag);
     assertEquals(expectedStepNames.size(), runWdlBasedPipelineJobFlight.getSteps().size());
 
     Set<String> stepNames =
@@ -153,7 +143,8 @@ class RunWdlBasedPipelineJobFlightTest extends BaseEmbeddedDbTest {
     assertNull(counter);
 
     // run setup so counter gets incremented
-    new RunWdlBasedPipelineJobFlight(StairwayTestUtils.CREATE_JOB_INPUT_PARAMS, flightBeanBag);
+    new RunWdlBasedPipelineJobFlight(
+        StairwayTestUtils.CREATE_ARRAY_IMPUTATION_JOB_INPUT_PARAMS, flightBeanBag);
 
     counter = meterRegistry.find("teaspoons.pipeline.run.count").counter();
     assertNotNull(counter);

--- a/service/src/test/java/bio/terra/pipelines/stairway/flights/wdlbasedpipelinerun/v20260428/RunWdlBasedPipelineJobFlightTest.java
+++ b/service/src/test/java/bio/terra/pipelines/stairway/flights/wdlbasedpipelinerun/v20260428/RunWdlBasedPipelineJobFlightTest.java
@@ -67,7 +67,7 @@ class RunWdlBasedPipelineJobFlightTest extends BaseEmbeddedDbTest {
   }
 
   @Test
-  void createJobFlightSetup() {
+  void createArrayImputationJobFlightSetup() {
     // this tests the setters for this flight in JobBuilder. note this doesn't check for required
     // input parameters
     assertDoesNotThrow(
@@ -79,6 +79,37 @@ class RunWdlBasedPipelineJobFlightTest extends BaseEmbeddedDbTest {
                 .addParameter(JobMapKeys.DESCRIPTION, "test RunWdlBasedPipelineJobFlight")
                 .addParameter(JobMapKeys.USER_ID, TestUtils.TEST_USER_1_ID)
                 .addParameter(JobMapKeys.PIPELINE_NAME, PipelinesEnum.ARRAY_IMPUTATION)
+                .addParameter(JobMapKeys.PIPELINE_VERSION, TestUtils.TEST_PIPELINE_VERSION_1)
+                .addParameter(JobMapKeys.PIPELINE_VERSION, TestUtils.TEST_PIPELINE_VERSION_1)
+                .addParameter(JobMapKeys.PIPELINE_ID, TestUtils.TEST_PIPELINE_ID_1)
+                .addParameter(
+                    WdlBasedPipelineJobMapKeys.PIPELINE_INPUT_DEFINITIONS,
+                    TestUtils.TEST_PIPELINE_INPUTS_DEFINITION_LIST)
+                .addParameter(
+                    WdlBasedPipelineJobMapKeys.USER_PROVIDED_PIPELINE_INPUTS,
+                    TestUtils.TEST_PIPELINE_INPUTS)
+                .addParameter(
+                    WdlBasedPipelineJobMapKeys.PIPELINE_TOOL_CONFIG, TestUtils.TOOL_CONFIG_GENERIC)
+                .addParameter(
+                    WdlBasedPipelineJobMapKeys.QUOTA_TOOL_CONFIG, TestUtils.TOOL_CONFIG_GENERIC)
+                .addParameter(
+                    WdlBasedPipelineJobMapKeys.INPUT_QC_TOOL_CONFIG,
+                    TestUtils.TOOL_CONFIG_GENERIC));
+  }
+
+  @Test
+  void createLowPassImputationJobFlightSetup() {
+    // this tests the setters for this flight in JobBuilder. note this doesn't check for required
+    // input parameters
+    assertDoesNotThrow(
+        () ->
+            jobService
+                .newJob()
+                .jobId(TestUtils.TEST_NEW_UUID)
+                .flightClass(RunWdlBasedPipelineJobFlight.class)
+                .addParameter(JobMapKeys.DESCRIPTION, "test RunWdlBasedPipelineJobFlight")
+                .addParameter(JobMapKeys.USER_ID, TestUtils.TEST_USER_1_ID)
+                .addParameter(JobMapKeys.PIPELINE_NAME, PipelinesEnum.LOW_PASS_IMPUTATION)
                 .addParameter(JobMapKeys.PIPELINE_VERSION, TestUtils.TEST_PIPELINE_VERSION_1)
                 .addParameter(JobMapKeys.PIPELINE_VERSION, TestUtils.TEST_PIPELINE_VERSION_1)
                 .addParameter(JobMapKeys.PIPELINE_ID, TestUtils.TEST_PIPELINE_ID_1)

--- a/service/src/test/java/bio/terra/pipelines/stairway/flights/wdlbasedpipelinerun/v20260428/RunWdlBasedPipelineJobFlightTest.java
+++ b/service/src/test/java/bio/terra/pipelines/stairway/flights/wdlbasedpipelinerun/v20260428/RunWdlBasedPipelineJobFlightTest.java
@@ -1,4 +1,4 @@
-package bio.terra.pipelines.stairway.flights.pipelinerun.v20260428;
+package bio.terra.pipelines.stairway.flights.wdlbasedpipelinerun.v20260428;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -10,7 +10,7 @@ import bio.terra.pipelines.common.utils.FlightBeanBag;
 import bio.terra.pipelines.common.utils.PipelinesEnum;
 import bio.terra.pipelines.dependencies.stairway.JobMapKeys;
 import bio.terra.pipelines.dependencies.stairway.JobService;
-import bio.terra.pipelines.stairway.flights.imputation.ImputationJobMapKeys;
+import bio.terra.pipelines.stairway.flights.wdlbasedpipelinerun.WdlBasedPipelineJobMapKeys;
 import bio.terra.pipelines.testutils.BaseEmbeddedDbTest;
 import bio.terra.pipelines.testutils.StairwayTestUtils;
 import bio.terra.pipelines.testutils.TestUtils;
@@ -83,16 +83,18 @@ class RunWdlBasedPipelineJobFlightTest extends BaseEmbeddedDbTest {
                 .addParameter(JobMapKeys.PIPELINE_VERSION, TestUtils.TEST_PIPELINE_VERSION_1)
                 .addParameter(JobMapKeys.PIPELINE_ID, TestUtils.TEST_PIPELINE_ID_1)
                 .addParameter(
-                    ImputationJobMapKeys.PIPELINE_INPUT_DEFINITIONS,
+                    WdlBasedPipelineJobMapKeys.PIPELINE_INPUT_DEFINITIONS,
                     TestUtils.TEST_PIPELINE_INPUTS_DEFINITION_LIST)
                 .addParameter(
-                    ImputationJobMapKeys.USER_PROVIDED_PIPELINE_INPUTS,
+                    WdlBasedPipelineJobMapKeys.USER_PROVIDED_PIPELINE_INPUTS,
                     TestUtils.TEST_PIPELINE_INPUTS)
                 .addParameter(
-                    ImputationJobMapKeys.PIPELINE_TOOL_CONFIG, TestUtils.TOOL_CONFIG_GENERIC)
-                .addParameter(ImputationJobMapKeys.QUOTA_TOOL_CONFIG, TestUtils.TOOL_CONFIG_GENERIC)
+                    WdlBasedPipelineJobMapKeys.PIPELINE_TOOL_CONFIG, TestUtils.TOOL_CONFIG_GENERIC)
                 .addParameter(
-                    ImputationJobMapKeys.INPUT_QC_TOOL_CONFIG, TestUtils.TOOL_CONFIG_GENERIC));
+                    WdlBasedPipelineJobMapKeys.QUOTA_TOOL_CONFIG, TestUtils.TOOL_CONFIG_GENERIC)
+                .addParameter(
+                    WdlBasedPipelineJobMapKeys.INPUT_QC_TOOL_CONFIG,
+                    TestUtils.TOOL_CONFIG_GENERIC));
   }
 
   @Test

--- a/service/src/test/java/bio/terra/pipelines/stairway/steps/common/AddDataTableRowStepTest.java
+++ b/service/src/test/java/bio/terra/pipelines/stairway/steps/common/AddDataTableRowStepTest.java
@@ -10,7 +10,7 @@ import bio.terra.pipelines.dependencies.rawls.RawlsService;
 import bio.terra.pipelines.dependencies.rawls.RawlsServiceApiException;
 import bio.terra.pipelines.dependencies.rawls.RawlsServiceException;
 import bio.terra.pipelines.dependencies.sam.SamService;
-import bio.terra.pipelines.stairway.flights.imputation.ImputationJobMapKeys;
+import bio.terra.pipelines.stairway.flights.wdlbasedpipelinerun.WdlBasedPipelineJobMapKeys;
 import bio.terra.pipelines.stairway.steps.utils.ToolConfig;
 import bio.terra.pipelines.testutils.BaseEmbeddedDbTest;
 import bio.terra.pipelines.testutils.StairwayTestUtils;
@@ -44,7 +44,7 @@ class AddDataTableRowStepTest extends BaseEmbeddedDbTest {
     inputParameters.put(toolConfigKey, toolConfig);
     FlightMap workingMap = new FlightMap();
 
-    workingMap.put(ImputationJobMapKeys.ALL_PIPELINE_INPUTS, TestUtils.TEST_PIPELINE_INPUTS);
+    workingMap.put(WdlBasedPipelineJobMapKeys.ALL_PIPELINE_INPUTS, TestUtils.TEST_PIPELINE_INPUTS);
 
     when(flightContext.getInputParameters()).thenReturn(inputParameters);
     when(flightContext.getWorkingMap()).thenReturn(workingMap);

--- a/service/src/test/java/bio/terra/pipelines/stairway/steps/common/AddDataTableRowStepTest.java
+++ b/service/src/test/java/bio/terra/pipelines/stairway/steps/common/AddDataTableRowStepTest.java
@@ -1,4 +1,4 @@
-package bio.terra.pipelines.stairway.steps.imputation;
+package bio.terra.pipelines.stairway.steps.common;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;

--- a/service/src/test/java/bio/terra/pipelines/stairway/steps/common/CompletePipelineRunStepTest.java
+++ b/service/src/test/java/bio/terra/pipelines/stairway/steps/common/CompletePipelineRunStepTest.java
@@ -11,7 +11,7 @@ import bio.terra.pipelines.db.repositories.PipelineOutputsRepository;
 import bio.terra.pipelines.db.repositories.PipelineRunsRepository;
 import bio.terra.pipelines.dependencies.stairway.JobMapKeys;
 import bio.terra.pipelines.service.PipelineRunsService;
-import bio.terra.pipelines.stairway.flights.imputation.ImputationJobMapKeys;
+import bio.terra.pipelines.stairway.flights.wdlbasedpipelinerun.WdlBasedPipelineJobMapKeys;
 import bio.terra.pipelines.testutils.BaseEmbeddedDbTest;
 import bio.terra.pipelines.testutils.StairwayTestUtils;
 import bio.terra.pipelines.testutils.TestUtils;
@@ -43,8 +43,8 @@ class CompletePipelineRunStepTest extends BaseEmbeddedDbTest {
     workingMap = new FlightMap();
 
     workingMap.put(
-        ImputationJobMapKeys.PIPELINE_RUN_OUTPUTS, TestUtils.TEST_PIPELINE_OUTPUTS_WITH_FILE);
-    workingMap.put(ImputationJobMapKeys.EFFECTIVE_QUOTA_CONSUMED, effectiveQuotaConsumed);
+        WdlBasedPipelineJobMapKeys.PIPELINE_RUN_OUTPUTS, TestUtils.TEST_PIPELINE_OUTPUTS_WITH_FILE);
+    workingMap.put(WdlBasedPipelineJobMapKeys.EFFECTIVE_QUOTA_CONSUMED, effectiveQuotaConsumed);
 
     when(flightContext.getInputParameters()).thenReturn(inputParameters);
     when(flightContext.getWorkingMap()).thenReturn(workingMap);
@@ -54,7 +54,7 @@ class CompletePipelineRunStepTest extends BaseEmbeddedDbTest {
   void doStepSuccessWithFileSizes() {
     // setup
     workingMap.put(
-        ImputationJobMapKeys.PIPELINE_RUN_OUTPUTS_FILE_SIZE,
+        WdlBasedPipelineJobMapKeys.PIPELINE_RUN_OUTPUTS_FILE_SIZE,
         TestUtils.TEST_PIPELINE_OUTPUTS_WITH_FILE_SIZE);
     when(flightContext.getFlightId()).thenReturn(testJobId.toString());
 

--- a/service/src/test/java/bio/terra/pipelines/stairway/steps/common/InputQcValidationStepTest.java
+++ b/service/src/test/java/bio/terra/pipelines/stairway/steps/common/InputQcValidationStepTest.java
@@ -4,7 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
-import bio.terra.pipelines.stairway.flights.imputation.ImputationJobMapKeys;
+import bio.terra.pipelines.stairway.flights.wdlbasedpipelinerun.WdlBasedPipelineJobMapKeys;
 import bio.terra.pipelines.testutils.BaseEmbeddedDbTest;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
@@ -31,7 +31,7 @@ class InputQcValidationStepTest extends BaseEmbeddedDbTest {
   @Test
   void testDoStepPassesQc() {
     Map<String, ?> inputQcOutputs = new HashMap<>(Map.of("passesQc", true, "qcMessages", ""));
-    flightContext.getWorkingMap().put(ImputationJobMapKeys.INPUT_QC_OUTPUTS, inputQcOutputs);
+    flightContext.getWorkingMap().put(WdlBasedPipelineJobMapKeys.INPUT_QC_OUTPUTS, inputQcOutputs);
 
     // do the step
     InputQcValidationStep inputQcValidationStep = new InputQcValidationStep();
@@ -45,7 +45,7 @@ class InputQcValidationStepTest extends BaseEmbeddedDbTest {
   void testDoStepFailsQc() {
     Map<String, ?> inputQcOutputs =
         new HashMap<>(Map.of("passesQc", false, "qcMessages", "File format error."));
-    flightContext.getWorkingMap().put(ImputationJobMapKeys.INPUT_QC_OUTPUTS, inputQcOutputs);
+    flightContext.getWorkingMap().put(WdlBasedPipelineJobMapKeys.INPUT_QC_OUTPUTS, inputQcOutputs);
 
     // do the step
     InputQcValidationStep inputQcValidationStep = new InputQcValidationStep();

--- a/service/src/test/java/bio/terra/pipelines/stairway/steps/common/PopulateFileOutputSizeStepTest.java
+++ b/service/src/test/java/bio/terra/pipelines/stairway/steps/common/PopulateFileOutputSizeStepTest.java
@@ -15,7 +15,7 @@ import bio.terra.pipelines.dependencies.gcs.GcsService;
 import bio.terra.pipelines.dependencies.stairway.JobMapKeys;
 import bio.terra.pipelines.service.PipelineInputsOutputsService;
 import bio.terra.pipelines.service.PipelinesService;
-import bio.terra.pipelines.stairway.flights.imputation.ImputationJobMapKeys;
+import bio.terra.pipelines.stairway.flights.wdlbasedpipelinerun.WdlBasedPipelineJobMapKeys;
 import bio.terra.pipelines.testutils.BaseEmbeddedDbTest;
 import bio.terra.pipelines.testutils.TestUtils;
 import bio.terra.stairway.FlightContext;
@@ -47,7 +47,7 @@ class PopulateFileOutputSizeStepTest extends BaseEmbeddedDbTest {
     pipelineOutputDefinitionsRepository.deleteAll();
 
     // create and save a test pipeline with file and string outputs defined
-    Pipeline testPipeline = updateTestPipeline1WithTestValues();
+    Pipeline testPipeline = updateArrayImputationTestPipeline1WithTestValues();
     pipelinesRepository.save(testPipeline);
 
     Long testPipelineId = testPipeline.getId();
@@ -80,7 +80,7 @@ class PopulateFileOutputSizeStepTest extends BaseEmbeddedDbTest {
 
     inputParameters.put(JobMapKeys.PIPELINE_ID, testPipelineId);
     workingMap.put(
-        ImputationJobMapKeys.PIPELINE_RUN_OUTPUTS, TestUtils.TEST_PIPELINE_OUTPUTS_WITH_FILE);
+        WdlBasedPipelineJobMapKeys.PIPELINE_RUN_OUTPUTS, TestUtils.TEST_PIPELINE_OUTPUTS_WITH_FILE);
 
     when(flightContext.getInputParameters()).thenReturn(inputParameters);
     when(flightContext.getWorkingMap()).thenReturn(workingMap);
@@ -106,7 +106,7 @@ class PopulateFileOutputSizeStepTest extends BaseEmbeddedDbTest {
         TEST_PIPELINE_OUTPUTS_WITH_FILE_SIZE,
         flightContext
             .getWorkingMap()
-            .get(ImputationJobMapKeys.PIPELINE_RUN_OUTPUTS_FILE_SIZE, Map.class));
+            .get(WdlBasedPipelineJobMapKeys.PIPELINE_RUN_OUTPUTS_FILE_SIZE, Map.class));
   }
 
   @Test
@@ -131,7 +131,7 @@ class PopulateFileOutputSizeStepTest extends BaseEmbeddedDbTest {
     assertNull(
         flightContext
             .getWorkingMap()
-            .get(ImputationJobMapKeys.PIPELINE_RUN_OUTPUTS_FILE_SIZE, Map.class));
+            .get(WdlBasedPipelineJobMapKeys.PIPELINE_RUN_OUTPUTS_FILE_SIZE, Map.class));
   }
 
   @Test

--- a/service/src/test/java/bio/terra/pipelines/stairway/steps/common/PrepareInputsStepTest.java
+++ b/service/src/test/java/bio/terra/pipelines/stairway/steps/common/PrepareInputsStepTest.java
@@ -1,4 +1,4 @@
-package bio.terra.pipelines.stairway.steps.imputation;
+package bio.terra.pipelines.stairway.steps.common;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 
-class PrepareImputationInputsStepTest extends BaseEmbeddedDbTest {
+class PrepareInputsStepTest extends BaseEmbeddedDbTest {
 
   @Mock PipelineInputsOutputsService pipelineInputsOutputsService;
   @Autowired PipelinesService pipelinesService;
@@ -107,7 +107,7 @@ class PrepareImputationInputsStepTest extends BaseEmbeddedDbTest {
 
     // do the step
     var prepareImputationInputsStep =
-        new PrepareImputationInputsStep(
+        new PrepareInputsStep(
             pipelineInputsOutputsService, pipelineConfigurations.getArrayImputation().get("1"));
     var result = prepareImputationInputsStep.doStep(flightContext);
 
@@ -128,7 +128,7 @@ class PrepareImputationInputsStepTest extends BaseEmbeddedDbTest {
   @Test
   void undoStepSuccess() {
     var prepareImputationInputsStep =
-        new PrepareImputationInputsStep(
+        new PrepareInputsStep(
             pipelineInputsOutputsService, pipelineConfigurations.getArrayImputation().get("1"));
     var result = prepareImputationInputsStep.undoStep(flightContext);
 

--- a/service/src/test/java/bio/terra/pipelines/stairway/steps/common/PrepareInputsStepTest.java
+++ b/service/src/test/java/bio/terra/pipelines/stairway/steps/common/PrepareInputsStepTest.java
@@ -11,7 +11,7 @@ import bio.terra.pipelines.db.repositories.PipelineRunsRepository;
 import bio.terra.pipelines.db.repositories.PipelinesRepository;
 import bio.terra.pipelines.service.PipelineInputsOutputsService;
 import bio.terra.pipelines.service.PipelinesService;
-import bio.terra.pipelines.stairway.flights.imputation.ImputationJobMapKeys;
+import bio.terra.pipelines.stairway.flights.wdlbasedpipelinerun.WdlBasedPipelineJobMapKeys;
 import bio.terra.pipelines.testutils.BaseEmbeddedDbTest;
 import bio.terra.pipelines.testutils.StairwayTestUtils;
 import bio.terra.pipelines.testutils.TestUtils;
@@ -87,7 +87,7 @@ class PrepareInputsStepTest extends BaseEmbeddedDbTest {
     assertNull(
         flightContext
             .getWorkingMap()
-            .get(ImputationJobMapKeys.ALL_PIPELINE_INPUTS, new TypeReference<>() {}));
+            .get(WdlBasedPipelineJobMapKeys.ALL_PIPELINE_INPUTS, new TypeReference<>() {}));
 
     // mock the service call to format the pipeline inputs
     Map<String, Object> expectedFormattedPipelineInputs =
@@ -118,7 +118,7 @@ class PrepareInputsStepTest extends BaseEmbeddedDbTest {
 
     // make sure the full pipeline inputs were populated in the working map
     Map<String, Object> fullInputs =
-        workingMap.get(ImputationJobMapKeys.ALL_PIPELINE_INPUTS, new TypeReference<>() {});
+        workingMap.get(WdlBasedPipelineJobMapKeys.ALL_PIPELINE_INPUTS, new TypeReference<>() {});
     assertNotNull(fullInputs);
     for (String key : expectedFormattedPipelineInputs.keySet()) {
       assertEquals(expectedFormattedPipelineInputs.get(key), fullInputs.get(key));

--- a/service/src/test/java/bio/terra/pipelines/stairway/steps/common/QuotaConsumedValidationStepTest.java
+++ b/service/src/test/java/bio/terra/pipelines/stairway/steps/common/QuotaConsumedValidationStepTest.java
@@ -12,7 +12,7 @@ import bio.terra.pipelines.db.repositories.PipelineRunsRepository;
 import bio.terra.pipelines.db.repositories.UserQuotasRepository;
 import bio.terra.pipelines.service.PipelineRunsService;
 import bio.terra.pipelines.service.QuotasService;
-import bio.terra.pipelines.stairway.flights.imputation.ImputationJobMapKeys;
+import bio.terra.pipelines.stairway.flights.wdlbasedpipelinerun.WdlBasedPipelineJobMapKeys;
 import bio.terra.pipelines.testutils.BaseEmbeddedDbTest;
 import bio.terra.pipelines.testutils.StairwayTestUtils;
 import bio.terra.pipelines.testutils.TestUtils;
@@ -62,7 +62,7 @@ class QuotaConsumedValidationStepTest extends BaseEmbeddedDbTest {
     final Integer quotaConsumedBelowPipelineMinQuota = 30;
     final Map<String, String> quotaOutputs =
         new HashMap<>(Map.of("quotaConsumed", quotaConsumedBelowPipelineMinQuota.toString()));
-    flightContext.getWorkingMap().put(ImputationJobMapKeys.QUOTA_OUTPUTS, quotaOutputs);
+    flightContext.getWorkingMap().put(WdlBasedPipelineJobMapKeys.QUOTA_OUTPUTS, quotaOutputs);
 
     // before running make sure quota consumed for user is 0
     UserQuota userQuota =
@@ -97,10 +97,12 @@ class QuotaConsumedValidationStepTest extends BaseEmbeddedDbTest {
         pipelineQuota.getMinQuotaConsumed(),
         flightContext
             .getWorkingMap()
-            .get(ImputationJobMapKeys.EFFECTIVE_QUOTA_CONSUMED, Integer.class));
+            .get(WdlBasedPipelineJobMapKeys.EFFECTIVE_QUOTA_CONSUMED, Integer.class));
     assertEquals(
         quotaConsumedBelowPipelineMinQuota,
-        flightContext.getWorkingMap().get(ImputationJobMapKeys.RAW_QUOTA_CONSUMED, Integer.class));
+        flightContext
+            .getWorkingMap()
+            .get(WdlBasedPipelineJobMapKeys.RAW_QUOTA_CONSUMED, Integer.class));
   }
 
   @Test
@@ -112,7 +114,7 @@ class QuotaConsumedValidationStepTest extends BaseEmbeddedDbTest {
     final Integer quotaConsumedAbovePipelineMinQuota = 2000;
     final Map<String, String> quotaOutputs =
         new HashMap<>(Map.of("quotaConsumed", quotaConsumedAbovePipelineMinQuota.toString()));
-    flightContext.getWorkingMap().put(ImputationJobMapKeys.QUOTA_OUTPUTS, quotaOutputs);
+    flightContext.getWorkingMap().put(WdlBasedPipelineJobMapKeys.QUOTA_OUTPUTS, quotaOutputs);
 
     // before running make sure quota consumed for user is 0
     UserQuota userQuota =
@@ -145,12 +147,14 @@ class QuotaConsumedValidationStepTest extends BaseEmbeddedDbTest {
     // assert raw and effective quota consumed are correctly stored in the working map
     assertEquals(
         quotaConsumedAbovePipelineMinQuota,
-        flightContext.getWorkingMap().get(ImputationJobMapKeys.RAW_QUOTA_CONSUMED, Integer.class));
+        flightContext
+            .getWorkingMap()
+            .get(WdlBasedPipelineJobMapKeys.RAW_QUOTA_CONSUMED, Integer.class));
     assertEquals(
         quotaConsumedAbovePipelineMinQuota,
         flightContext
             .getWorkingMap()
-            .get(ImputationJobMapKeys.EFFECTIVE_QUOTA_CONSUMED, Integer.class));
+            .get(WdlBasedPipelineJobMapKeys.EFFECTIVE_QUOTA_CONSUMED, Integer.class));
   }
 
   @Test
@@ -160,7 +164,7 @@ class QuotaConsumedValidationStepTest extends BaseEmbeddedDbTest {
 
     // set quota consumed in working map to above the pipeline quota limit
     final Map<String, String> quotaOutputs = new HashMap<>(Map.of("quotaConsumed", "11000"));
-    flightContext.getWorkingMap().put(ImputationJobMapKeys.QUOTA_OUTPUTS, quotaOutputs);
+    flightContext.getWorkingMap().put(WdlBasedPipelineJobMapKeys.QUOTA_OUTPUTS, quotaOutputs);
 
     // do the step
     QuotaConsumedValidationStep quotaConsumedValidationStep =
@@ -185,7 +189,7 @@ class QuotaConsumedValidationStepTest extends BaseEmbeddedDbTest {
 
     // missing quota consumed in working map
     final Map<String, String> quotaOutputs = new HashMap<>(Map.of());
-    flightContext.getWorkingMap().put(ImputationJobMapKeys.QUOTA_OUTPUTS, quotaOutputs);
+    flightContext.getWorkingMap().put(WdlBasedPipelineJobMapKeys.QUOTA_OUTPUTS, quotaOutputs);
 
     // do the step
     QuotaConsumedValidationStep quotaConsumedValidationStep =
@@ -206,7 +210,7 @@ class QuotaConsumedValidationStepTest extends BaseEmbeddedDbTest {
 
     // set quota consumed in working map to a negative value
     final Map<String, String> quotaOutputs = new HashMap<>(Map.of("quotaConsumed", "-5"));
-    flightContext.getWorkingMap().put(ImputationJobMapKeys.QUOTA_OUTPUTS, quotaOutputs);
+    flightContext.getWorkingMap().put(WdlBasedPipelineJobMapKeys.QUOTA_OUTPUTS, quotaOutputs);
 
     // do the step
     QuotaConsumedValidationStep quotaConsumedValidationStep =
@@ -229,7 +233,7 @@ class QuotaConsumedValidationStepTest extends BaseEmbeddedDbTest {
         new UserQuota(PipelinesEnum.ARRAY_IMPUTATION, TestUtils.TEST_USER_1_ID, 10000, 600));
 
     // make sure quota consumed is updated properly for undoStep
-    flightContext.getWorkingMap().put(ImputationJobMapKeys.EFFECTIVE_QUOTA_CONSUMED, 500);
+    flightContext.getWorkingMap().put(WdlBasedPipelineJobMapKeys.EFFECTIVE_QUOTA_CONSUMED, 500);
 
     // set up the pipeline run with raw quota consumed of 500
     UUID undoStepTestJobId = TestUtils.TEST_NEW_UUID_2;

--- a/service/src/test/java/bio/terra/pipelines/testutils/StairwayTestUtils.java
+++ b/service/src/test/java/bio/terra/pipelines/testutils/StairwayTestUtils.java
@@ -7,7 +7,7 @@ import bio.terra.pipelines.common.utils.PipelinesEnum;
 import bio.terra.pipelines.dependencies.stairway.JobMapKeys;
 import bio.terra.pipelines.dependencies.stairway.model.EnumeratedJob;
 import bio.terra.pipelines.dependencies.stairway.model.EnumeratedJobs;
-import bio.terra.pipelines.stairway.flights.imputation.ImputationJobMapKeys;
+import bio.terra.pipelines.stairway.flights.wdlbasedpipelinerun.WdlBasedPipelineJobMapKeys;
 import bio.terra.pipelines.stairway.steps.utils.ToolConfig;
 import bio.terra.stairway.*;
 import bio.terra.stairway.exception.DatabaseOperationException;
@@ -189,19 +189,19 @@ public class StairwayTestUtils {
     inputParameters.put(JobMapKeys.DO_INCREMENT_METRICS_FAILED_COUNTER_HOOK, true);
     inputParameters.put(JobMapKeys.DO_SEND_JOB_FAILURE_NOTIFICATION_HOOK, true);
     inputParameters.put(JobMapKeys.DO_SET_PIPELINE_RUN_STATUS_FAILED_HOOK, true);
-    inputParameters.put(ImputationJobMapKeys.USER_PROVIDED_PIPELINE_INPUTS, pipelineInputs);
+    inputParameters.put(WdlBasedPipelineJobMapKeys.USER_PROVIDED_PIPELINE_INPUTS, pipelineInputs);
     inputParameters.put(
-        ImputationJobMapKeys.CONTROL_WORKSPACE_BILLING_PROJECT, controlWorkspaceProject);
-    inputParameters.put(ImputationJobMapKeys.CONTROL_WORKSPACE_NAME, controlWorkspaceName);
+        WdlBasedPipelineJobMapKeys.CONTROL_WORKSPACE_BILLING_PROJECT, controlWorkspaceProject);
+    inputParameters.put(WdlBasedPipelineJobMapKeys.CONTROL_WORKSPACE_NAME, controlWorkspaceName);
     inputParameters.put(
-        ImputationJobMapKeys.CONTROL_WORKSPACE_STORAGE_CONTAINER_NAME,
+        WdlBasedPipelineJobMapKeys.CONTROL_WORKSPACE_STORAGE_CONTAINER_NAME,
         controlWorkspaceStorageContainerUrl);
     inputParameters.put(
-        ImputationJobMapKeys.CONTROL_WORKSPACE_STORAGE_CONTAINER_PROTOCOL,
+        WdlBasedPipelineJobMapKeys.CONTROL_WORKSPACE_STORAGE_CONTAINER_PROTOCOL,
         controlWorkspaceStorageContainerProtocol);
-    inputParameters.put(ImputationJobMapKeys.PIPELINE_TOOL_CONFIG, pipelineToolConfig);
-    inputParameters.put(ImputationJobMapKeys.QUOTA_TOOL_CONFIG, quotaToolConfig);
-    inputParameters.put(ImputationJobMapKeys.INPUT_QC_TOOL_CONFIG, inputQcToolConfig);
+    inputParameters.put(WdlBasedPipelineJobMapKeys.PIPELINE_TOOL_CONFIG, pipelineToolConfig);
+    inputParameters.put(WdlBasedPipelineJobMapKeys.QUOTA_TOOL_CONFIG, quotaToolConfig);
+    inputParameters.put(WdlBasedPipelineJobMapKeys.INPUT_QC_TOOL_CONFIG, inputQcToolConfig);
 
     return inputParameters;
   }

--- a/service/src/test/java/bio/terra/pipelines/testutils/StairwayTestUtils.java
+++ b/service/src/test/java/bio/terra/pipelines/testutils/StairwayTestUtils.java
@@ -30,11 +30,26 @@ public class StairwayTestUtils {
   public static final Instant TIME_SUBMITTED_2 = Instant.parse("2024-01-02T01:00:00.00Z");
   public static final Instant TIME_COMPLETED_1 = Instant.parse("2024-01-01T00:30:00.00Z");
   public static final Instant TIME_COMPLETED_2 = Instant.parse("2024-01-02T01:30:00.00Z");
-  public static final FlightMap CREATE_JOB_INPUT_PARAMS =
+  public static final FlightMap CREATE_ARRAY_IMPUTATION_JOB_INPUT_PARAMS =
       StairwayTestUtils.constructCreateJobInputs(
           TestUtils.TEST_PIPELINE_1_IMPUTATION_ENUM,
           TestUtils.TEST_PIPELINE_ID_1,
           TestUtils.TEST_PIPELINE_VERSION_1,
+          TestUtils.TEST_USER_1_ID,
+          TestUtils.TEST_PIPELINE_INPUTS_ARRAY_IMPUTATION,
+          TestUtils.CONTROL_WORKSPACE_BILLING_PROJECT,
+          TestUtils.CONTROL_WORKSPACE_NAME,
+          TestUtils.CONTROL_WORKSPACE_CONTAINER_NAME,
+          TestUtils.GCP_STORAGE_PROTOCOL,
+          TestUtils.TEST_DOMAIN,
+          TestUtils.TOOL_CONFIG_GENERIC,
+          TestUtils.TOOL_CONFIG_GENERIC,
+          TestUtils.TOOL_CONFIG_GENERIC);
+  public static final FlightMap CREATE_LOW_PASS_IMPUTATION_JOB_INPUT_PARAMS =
+      StairwayTestUtils.constructCreateJobInputs(
+          TestUtils.TEST_LOW_PASS_IMPUTATION_PIPELINE.getName(),
+          TestUtils.TEST_LOW_PASS_IMPUTATION_PIPELINE.getId(),
+          TestUtils.TEST_LOW_PASS_IMPUTATION_PIPELINE_VERSION,
           TestUtils.TEST_USER_1_ID,
           TestUtils.TEST_PIPELINE_INPUTS_ARRAY_IMPUTATION,
           TestUtils.CONTROL_WORKSPACE_BILLING_PROJECT,
@@ -52,7 +67,7 @@ public class StairwayTestUtils {
       StairwayTestUtils.constructFlightStateWithStatusAndId(
           FlightStatus.SUCCESS,
           TestUtils.TEST_NEW_UUID,
-          CREATE_JOB_INPUT_PARAMS,
+          CREATE_ARRAY_IMPUTATION_JOB_INPUT_PARAMS,
           EMPTY_WORKING_MAP,
           TIME_SUBMITTED_1,
           TIME_COMPLETED_1);
@@ -60,7 +75,7 @@ public class StairwayTestUtils {
       StairwayTestUtils.constructFlightStateWithStatusAndId(
           FlightStatus.SUCCESS,
           TestUtils.TEST_NEW_UUID_2,
-          CREATE_JOB_INPUT_PARAMS,
+          CREATE_ARRAY_IMPUTATION_JOB_INPUT_PARAMS,
           EMPTY_WORKING_MAP,
           TIME_SUBMITTED_2,
           TIME_COMPLETED_2);

--- a/service/src/test/java/bio/terra/pipelines/testutils/TestUtils.java
+++ b/service/src/test/java/bio/terra/pipelines/testutils/TestUtils.java
@@ -33,7 +33,6 @@ public class TestUtils {
   public static final String TEST_TOOL_NAME_WITH_PIPELINE_VERSION_1 = "methodName1_v0";
   public static final String TEST_DATA_TABLE_ENTITY_NAME_1 = "array_imputation_v1";
   public static final String TEST_TOOL_VERSION_1 = "0.1.12";
-
   public static final int TEST_PIPELINE_VERSION_2 = 1;
   public static final boolean TEST_PIPELINE_HIDDEN_2 = false;
   public static final String TEST_PIPELINE_DISPLAY_NAME_2 = "Test Pipeline Name Two";
@@ -42,6 +41,7 @@ public class TestUtils {
   public static final String TEST_WDL_URL_2 = "http://nowhere2";
   public static final String TEST_TOOL_NAME_2 = "methodName2";
   public static final String TEST_TOOL_VERSION_2 = "1.1.12";
+  public static final int TEST_LOW_PASS_IMPUTATION_PIPELINE_VERSION = 1;
   public static final UUID CONTROL_WORKSPACE_ID =
       UUID.fromString("fafafafa-fafa-fafa-fafa-fafafafafafa");
   public static final String CONTROL_WORKSPACE_BILLING_PROJECT = "testTerraProject";
@@ -228,7 +228,7 @@ public class TestUtils {
               123,
               "outputBooleanOptional",
               false)); // matches TestUtils.TOOL_CONFIG_GENERIC output definitions
-  public static final Pipeline TEST_PIPELINE_1 =
+  public static final Pipeline TEST_ARRAY_IMPUTATION_PIPELINE_1 =
       new Pipeline(
           PipelinesEnum.ARRAY_IMPUTATION,
           TEST_PIPELINE_VERSION_1,
@@ -245,7 +245,7 @@ public class TestUtils {
           CONTROL_WORKSPACE_GOOGLE_PROJECT,
           TEST_PIPELINE_INPUTS_DEFINITION_LIST,
           TEST_PIPELINE_OUTPUTS_DEFINITION_LIST);
-  public static final Pipeline TEST_PIPELINE_2 =
+  public static final Pipeline TEST_ARRAY_IMPUTATION_PIPELINE_2 =
       new Pipeline(
           PipelinesEnum.ARRAY_IMPUTATION,
           TEST_PIPELINE_VERSION_2,
@@ -262,28 +262,67 @@ public class TestUtils {
           CONTROL_WORKSPACE_GOOGLE_PROJECT,
           TEST_PIPELINE_INPUTS_DEFINITION_LIST,
           TEST_PIPELINE_OUTPUTS_DEFINITION_LIST);
+  public static final Pipeline TEST_LOW_PASS_IMPUTATION_PIPELINE =
+      new Pipeline(
+          PipelinesEnum.LOW_PASS_IMPUTATION,
+          TEST_LOW_PASS_IMPUTATION_PIPELINE_VERSION,
+          TEST_PIPELINE_HIDDEN_1,
+          TEST_PIPELINE_DISPLAY_NAME_1,
+          TEST_PIPELINE_DESCRIPTION_1,
+          TEST_PIPELINE_TYPE_1,
+          TEST_WDL_URL_1,
+          TEST_TOOL_NAME_1,
+          TEST_TOOL_VERSION_1,
+          CONTROL_WORKSPACE_BILLING_PROJECT,
+          CONTROL_WORKSPACE_NAME,
+          CONTROL_WORKSPACE_CONTAINER_NAME,
+          CONTROL_WORKSPACE_GOOGLE_PROJECT,
+          TEST_PIPELINE_INPUTS_DEFINITION_LIST,
+          TEST_PIPELINE_OUTPUTS_DEFINITION_LIST);
 
-  public static Pipeline addNewTestPipelineWithTestValues() {
+  public static Pipeline addNewArrayImputationTestPipelineWithTestValues() {
     return new Pipeline(
-        TestUtils.TEST_PIPELINE_1.getName(),
-        TestUtils.TEST_PIPELINE_1.getVersion(),
-        TestUtils.TEST_PIPELINE_1.isHidden(),
-        TestUtils.TEST_PIPELINE_1.getDisplayName(),
-        TestUtils.TEST_PIPELINE_1.getDescription(),
-        TestUtils.TEST_PIPELINE_1.getPipelineType(),
-        TestUtils.TEST_PIPELINE_1.getWdlUrl(),
-        TestUtils.TEST_PIPELINE_1.getToolName(),
-        TestUtils.TEST_PIPELINE_1.getToolVersion(),
-        TestUtils.TEST_PIPELINE_1.getWorkspaceBillingProject(),
-        TestUtils.TEST_PIPELINE_1.getWorkspaceName(),
-        TestUtils.TEST_PIPELINE_1.getWorkspaceStorageContainerName(),
-        TestUtils.TEST_PIPELINE_1.getWorkspaceGoogleProject(),
+        TestUtils.TEST_ARRAY_IMPUTATION_PIPELINE_1.getName(),
+        TestUtils.TEST_ARRAY_IMPUTATION_PIPELINE_1.getVersion(),
+        TestUtils.TEST_ARRAY_IMPUTATION_PIPELINE_1.isHidden(),
+        TestUtils.TEST_ARRAY_IMPUTATION_PIPELINE_1.getDisplayName(),
+        TestUtils.TEST_ARRAY_IMPUTATION_PIPELINE_1.getDescription(),
+        TestUtils.TEST_ARRAY_IMPUTATION_PIPELINE_1.getPipelineType(),
+        TestUtils.TEST_ARRAY_IMPUTATION_PIPELINE_1.getWdlUrl(),
+        TestUtils.TEST_ARRAY_IMPUTATION_PIPELINE_1.getToolName(),
+        TestUtils.TEST_ARRAY_IMPUTATION_PIPELINE_1.getToolVersion(),
+        TestUtils.TEST_ARRAY_IMPUTATION_PIPELINE_1.getWorkspaceBillingProject(),
+        TestUtils.TEST_ARRAY_IMPUTATION_PIPELINE_1.getWorkspaceName(),
+        TestUtils.TEST_ARRAY_IMPUTATION_PIPELINE_1.getWorkspaceStorageContainerName(),
+        TestUtils.TEST_ARRAY_IMPUTATION_PIPELINE_1.getWorkspaceGoogleProject(),
         TestUtils.TEST_PIPELINE_INPUTS_DEFINITION_LIST,
         TestUtils.TEST_PIPELINE_OUTPUTS_DEFINITION_LIST);
   }
 
-  public static Pipeline updateTestPipeline1WithTestValues() {
-    Pipeline pipeline = addNewTestPipelineWithTestValues();
+  public static Pipeline updateLowPassImputationTestPipelineWithTestValues() {
+    Pipeline lowPassImputationPipeline =
+        new Pipeline(
+            TestUtils.TEST_LOW_PASS_IMPUTATION_PIPELINE.getName(),
+            TestUtils.TEST_LOW_PASS_IMPUTATION_PIPELINE.getVersion(),
+            TestUtils.TEST_LOW_PASS_IMPUTATION_PIPELINE.isHidden(),
+            TestUtils.TEST_LOW_PASS_IMPUTATION_PIPELINE.getDisplayName(),
+            TestUtils.TEST_LOW_PASS_IMPUTATION_PIPELINE.getDescription(),
+            TestUtils.TEST_LOW_PASS_IMPUTATION_PIPELINE.getPipelineType(),
+            TestUtils.TEST_LOW_PASS_IMPUTATION_PIPELINE.getWdlUrl(),
+            TestUtils.TEST_LOW_PASS_IMPUTATION_PIPELINE.getToolName(),
+            TestUtils.TEST_LOW_PASS_IMPUTATION_PIPELINE.getToolVersion(),
+            TestUtils.TEST_LOW_PASS_IMPUTATION_PIPELINE.getWorkspaceBillingProject(),
+            TestUtils.TEST_LOW_PASS_IMPUTATION_PIPELINE.getWorkspaceName(),
+            TestUtils.TEST_LOW_PASS_IMPUTATION_PIPELINE.getWorkspaceStorageContainerName(),
+            TestUtils.TEST_LOW_PASS_IMPUTATION_PIPELINE.getWorkspaceGoogleProject(),
+            TestUtils.TEST_PIPELINE_INPUTS_DEFINITION_LIST,
+            TestUtils.TEST_PIPELINE_OUTPUTS_DEFINITION_LIST);
+    lowPassImputationPipeline.setId(1L);
+    return lowPassImputationPipeline;
+  }
+
+  public static Pipeline updateArrayImputationTestPipeline1WithTestValues() {
+    Pipeline pipeline = addNewArrayImputationTestPipelineWithTestValues();
     pipeline.setId(1L);
     return pipeline;
   }

--- a/service/src/test/resources/pipelines-config-test.yml
+++ b/service/src/test/resources/pipelines-config-test.yml
@@ -16,6 +16,7 @@ pipelines:
         useCallCaching: true
         deleteIntermediateFiles: false
         useReferenceDisk: false
+        memoryRetryMultiplier: 0.0
       0:
         cromwellSubmissionPollingIntervalInSeconds: 2
         inputKeysToPrependWithStorageWorkspaceContainerUrl: [ "prepend1", "prepend2" ]
@@ -25,3 +26,13 @@ pipelines:
         useCallCaching: false
         deleteIntermediateFiles: false
         memoryRetryMultiplier: 1.4
+    lowPassImputation:
+      1:
+        cromwellSubmissionPollingIntervalInSeconds: 1 # only wait 1 second when testing
+        storageWorkspaceContainerUrl: "https://test_storage_workspace_url"
+        inputsWithCustomValues:
+          referencePanelPrefix: "/test_reference_panel_path_prefix/file_path"
+        useCallCaching: true
+        deleteIntermediateFiles: false
+        useReferenceDisk: false
+        memoryRetryMultiplier: 2.0


### PR DESCRIPTION
### Description 

Here we add a second pipeline to Teaspoons: low_pass_imputation.

This PR includes refactoring of the PipelineRunsService and flight/steps to make the formerly-array_imputation-specific resources generic to "WDL based pipelines".
- `RunImputationGcpJobFlight` -> `RunWdlBasedPipelineJobFlight`
- `PrepareImputationInputsStep` -> `PrepareInputsStep`
- `ImputationJobMapKeys` -> `WdlBasedPipelineJobMapKeys`
- PipelineConfiguration `ArrayImputationConfig` -> `WdlBasedPipelineConfig`

The additions specific to the new low_pass_imputation pipeline are:
- new PipelinesEnum `LOW_PASS_IMPUTATION`
- database migration to add low_pass_imputation pipeline metadata to the database: inserts to pipelines, pipeline_quotas, pipeline_input_definitions, and pipeline_output_definitions tables
- addition to pipelines-config.yaml
- add new case (LOW_PASS_IMPUTATION) to PipelineRunsService start(), ToolConfigService, and RunWdlBasedPipelineJobFlight


This allows a successful run of the low_pass_imputation pipeline using the empty WDLs (tested with no file inputs). Processing of file inputs has not been addressed here and will be covered by future work.

Also tested that array_imputation pipeline still works.

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-824

### Checklist (provide links to changes)

- [ ] Updated external documentation (if applicable)
- [ ] Updated internal documentation (if applicable)
- [ ] Planned non patch version bump (if applicable)
- [ ] Made ticket for related CLI PR (if applicable)
- [ ] Made ticket for related UI PR (if applicable)
