### PR TITLE
[TSPS-901] Update /status 503 response to reflect no object being returned

### DIFF
--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -733,12 +733,6 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/ErrorReport'
-    SystemStatusResponse:
-      description: A JSON description of the subsystems and their statuses.
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/SystemStatus'
     JobResultResponse:
       description: Result of a job (failed or succeeded)
       content:

--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -545,7 +545,7 @@ paths:
         500:
           $ref: '#/components/responses/ServerError'
         503:
-          $ref: '#/components/responses/SystemStatusResponse'
+          description: Service unavailable
 
   /version:
     get:


### PR DESCRIPTION
### Description 

When /status returns a 503, it doesn't actually return an object like the Swagger was saying. This gets the swagger docs in line with reality.

### Jira Ticket

https://broadworkbench.atlassian.net/browse/TSPS-901

### Checklist (provide links to changes)

- [ ] Updated external documentation (if applicable)
- [ ] Updated internal documentation (if applicable)
- [ ] Planned non patch version bump (if applicable)
- [ ] Made ticket for related CLI PR (if applicable)
- [ ] Made ticket for related UI PR (if applicable)
