### PR TITLE
TSPS-851 Handle requester pays error messages

### DIFF
--- a/service/src/main/java/bio/terra/pipelines/dependencies/gcs/GcsService.java
+++ b/service/src/main/java/bio/terra/pipelines/dependencies/gcs/GcsService.java
@@ -206,11 +206,21 @@ public class GcsService {
     return executionWithRetryTemplate(
         listenerResetRetryTemplate,
         () -> {
-          List<Boolean> accessResult =
-              gcsClient
-                  .getStorageService(accessToken)
-                  .testIamPermissions(bucketName, List.of("storage.objects.get"));
-          return accessResult.size() == 1 && accessResult.get(0);
+          try {
+            List<Boolean> accessResult =
+                gcsClient
+                    .getStorageService(accessToken)
+                    .testIamPermissions(bucketName, List.of("storage.objects.get"));
+            return accessResult.size() == 1 && accessResult.get(0);
+          } catch (StorageException e) {
+            if (e.getMessage().contains("Bucket is a requester pays bucket")) {
+              throw new RequesterPaysBucketException(
+                  "The bucket '%s' is a requester pays bucket, which is not currently supported. Please turn off requester pays or submit data from a non-requester pays bucket."
+                      .formatted(bucketName));
+            } else {
+              throw e;
+            }
+          }
         });
   }
 

--- a/service/src/main/java/bio/terra/pipelines/dependencies/gcs/GcsService.java
+++ b/service/src/main/java/bio/terra/pipelines/dependencies/gcs/GcsService.java
@@ -3,6 +3,7 @@ package bio.terra.pipelines.dependencies.gcs;
 import bio.terra.common.exception.InternalServerErrorException;
 import bio.terra.pipelines.app.configuration.external.GcsConfiguration;
 import bio.terra.pipelines.common.GcsFile;
+import bio.terra.pipelines.service.exception.RequesterPaysBucketException;
 import com.google.cloud.storage.*;
 import java.io.BufferedInputStream;
 import java.io.BufferedReader;
@@ -84,6 +85,7 @@ public class GcsService {
    * @param gcsFile GcsFile object representing the GCS path to the file
    * @param accessToken for the calling user. Pass null to use application default credentials.
    * @return Blob object if the file exists and is accessible, null otherwise
+   * @throws RequesterPaysBucketException if the bucket is a requester pays bucket
    */
   public Blob getFileBlob(GcsFile gcsFile, String accessToken) {
     BlobId blobId = BlobId.fromGsUtilUri(gcsFile.getFullPath());
@@ -94,11 +96,17 @@ public class GcsService {
           .get(
               blobId, Storage.BlobGetOption.fields(Storage.BlobField.NAME, Storage.BlobField.SIZE));
     } catch (StorageException e) {
-      logger.error(
-          "An error occurred retrieving GCS file metadata for path `{}`. Error: {}",
-          gcsFile.getFullPath(),
-          e.getMessage());
-      return null;
+      if (e.getMessage().contains("Bucket is a requester pays bucket")) {
+        throw new RequesterPaysBucketException(
+            "The bucket for file '%s' is a requester pays bucket, which is not currently supported. Please turn off requester pays or submit data from a non-requester pays bucket."
+                .formatted(gcsFile.getFullPath()));
+      } else {
+        logger.error(
+            "An error occurred retrieving GCS file metadata for path `{}`. Error: {}",
+            gcsFile.getFullPath(),
+            e.getMessage());
+        return null;
+      }
     }
   }
 
@@ -137,6 +145,7 @@ public class GcsService {
    * @param gcsFilePath the full GCS path to the file (e.g. gs://my-bucket/path/to/file.txt)
    * @return the size of the file in bytes
    * @throws InternalServerErrorException if the file does not exist
+   * @throws RequesterPaysBucketException if the bucket is requester pays
    */
   public Long getFileSizeInBytes(String gcsFilePath) {
     GcsFile gcsFile = new GcsFile(gcsFilePath);
@@ -158,6 +167,7 @@ public class GcsService {
    * @param gcsFile GcsFile object representing the GCS path to the file
    * @param accessToken for the calling user. pass null to use application default credentials.
    * @return boolean whether the caller has read access to the GCS file
+   * @throws RequesterPaysBucketException if the bucket is a requester pays bucket
    */
   private boolean hasFileReadAccess(GcsFile gcsFile, String accessToken) {
     try {

--- a/service/src/main/java/bio/terra/pipelines/dependencies/gcs/GcsService.java
+++ b/service/src/main/java/bio/terra/pipelines/dependencies/gcs/GcsService.java
@@ -90,23 +90,23 @@ public class GcsService {
   public Blob getFileBlob(GcsFile gcsFile, String accessToken) {
     BlobId blobId = BlobId.fromGsUtilUri(gcsFile.getFullPath());
     try {
-      // attempt to retrieve a client-side representation of the blob with minimal metadata
-      return gcsClient
-          .getStorageService(accessToken)
-          .get(
-              blobId, Storage.BlobGetOption.fields(Storage.BlobField.NAME, Storage.BlobField.SIZE));
-    } catch (StorageException e) {
-      if (e.getMessage().contains("Bucket is a requester pays bucket")) {
-        throw new RequesterPaysBucketException(
-            "The bucket for file '%s' is a requester pays bucket, which is not currently supported. Please turn off requester pays or submit data from a non-requester pays bucket."
-                .formatted(gcsFile.getFullPath()));
-      } else {
-        logger.error(
-            "An error occurred retrieving GCS file metadata for path `{}`. Error: {}",
-            gcsFile.getFullPath(),
-            e.getMessage());
-        return null;
-      }
+      return executionWithRetryTemplateAndRequesterPaysErrorHandling(
+          listenerResetRetryTemplate,
+          () -> {
+            // attempt to retrieve a client-side representation of the blob with minimal metadata
+            return gcsClient
+                .getStorageService(accessToken)
+                .get(
+                    blobId,
+                    Storage.BlobGetOption.fields(Storage.BlobField.NAME, Storage.BlobField.SIZE));
+          },
+          gcsFile.getBucketName());
+    } catch (GcsServiceException e) {
+      logger.error(
+          "An error occurred retrieving GCS file metadata for path `{}`. Error: {}",
+          gcsFile.getFullPath(),
+          e.getMessage());
+      return null;
     }
   }
 
@@ -170,16 +170,8 @@ public class GcsService {
    * @throws RequesterPaysBucketException if the bucket is a requester pays bucket
    */
   private boolean hasFileReadAccess(GcsFile gcsFile, String accessToken) {
-    try {
-      Blob blob = getFileBlob(gcsFile, accessToken);
-      if (blob != null && blob.exists()) {
-        return true;
-      }
-    } catch (StorageException e) {
-      logger.error("An error occurred checking blob access: {}", e.getMessage());
-      return false;
-    }
-    return false;
+    Blob blob = getFileBlob(gcsFile, accessToken);
+    return blob != null && blob.exists();
   }
 
   public boolean serviceHasBucketReadAccess(String bucketName) {
@@ -203,25 +195,16 @@ public class GcsService {
   }
 
   private boolean hasBucketReadAccess(String bucketName, String accessToken) {
-    return executionWithRetryTemplate(
+    return executionWithRetryTemplateAndRequesterPaysErrorHandling(
         listenerResetRetryTemplate,
         () -> {
-          try {
-            List<Boolean> accessResult =
-                gcsClient
-                    .getStorageService(accessToken)
-                    .testIamPermissions(bucketName, List.of("storage.objects.get"));
-            return accessResult.size() == 1 && accessResult.get(0);
-          } catch (StorageException e) {
-            if (e.getMessage().contains("Bucket is a requester pays bucket")) {
-              throw new RequesterPaysBucketException(
-                  "The bucket '%s' is a requester pays bucket, which is not currently supported. Please turn off requester pays or submit data from a non-requester pays bucket."
-                      .formatted(bucketName));
-            } else {
-              throw e;
-            }
-          }
-        });
+          List<Boolean> accessResult =
+              gcsClient
+                  .getStorageService(accessToken)
+                  .testIamPermissions(bucketName, List.of("storage.objects.get"));
+          return accessResult.size() == 1 && accessResult.get(0);
+        },
+        bucketName);
   }
 
   public boolean serviceHasBucketWriteAccess(String bucketName) {
@@ -453,6 +436,24 @@ public class GcsService {
           try {
             return action.execute();
           } catch (StorageException e) {
+            // Note: GCS' StorageException contains retryable exceptions - not sure how to handle
+            throw new GcsServiceException("Error executing GCS action", e);
+          }
+        });
+  }
+
+  static <T> T executionWithRetryTemplateAndRequesterPaysErrorHandling(
+      RetryTemplate retryTemplate, GcsAction<T> action, String queriedBucketName) {
+    return retryTemplate.execute(
+        context -> {
+          try {
+            return action.execute();
+          } catch (StorageException e) {
+            if (e.getMessage().contains("Bucket is a requester pays bucket")) {
+              throw new RequesterPaysBucketException(
+                  "The bucket '%s' is a requester pays bucket, which is not currently supported. Please turn off requester pays or submit data from a non-requester pays bucket."
+                      .formatted(queriedBucketName));
+            }
             // Note: GCS' StorageException contains retryable exceptions - not sure how to handle
             throw new GcsServiceException("Error executing GCS action", e);
           }

--- a/service/src/main/java/bio/terra/pipelines/dependencies/gcs/GcsService.java
+++ b/service/src/main/java/bio/terra/pipelines/dependencies/gcs/GcsService.java
@@ -92,14 +92,12 @@ public class GcsService {
     try {
       return executionWithRetryTemplateAndRequesterPaysErrorHandling(
           listenerResetRetryTemplate,
-          () -> {
-            // attempt to retrieve a client-side representation of the blob with minimal metadata
-            return gcsClient
-                .getStorageService(accessToken)
-                .get(
-                    blobId,
-                    Storage.BlobGetOption.fields(Storage.BlobField.NAME, Storage.BlobField.SIZE));
-          },
+          () ->
+              gcsClient
+                  .getStorageService(accessToken)
+                  .get(
+                      blobId,
+                      Storage.BlobGetOption.fields(Storage.BlobField.NAME, Storage.BlobField.SIZE)),
           gcsFile.getBucketName());
     } catch (GcsServiceException e) {
       logger.error(

--- a/service/src/main/java/bio/terra/pipelines/dependencies/gcs/GcsService.java
+++ b/service/src/main/java/bio/terra/pipelines/dependencies/gcs/GcsService.java
@@ -323,7 +323,7 @@ public class GcsService {
     // define target blob object resource
     BlobInfo blobInfo = BlobInfo.newBuilder(BlobId.fromGsUtilUri(gcsFile.getFullPath())).build();
 
-    // Add response-content-disposition to force download with a specified filename)
+    // Add response-content-disposition to force download with a specified filename
     Map<String, String> extensionHeaders = new HashMap<>();
     extensionHeaders.put(
         "response-content-disposition", "attachment; filename=\"" + gcsFile.getFileName() + "\"");

--- a/service/src/main/java/bio/terra/pipelines/dependencies/gcs/GcsService.java
+++ b/service/src/main/java/bio/terra/pipelines/dependencies/gcs/GcsService.java
@@ -80,12 +80,13 @@ public class GcsService {
   }
 
   /**
-   * Helper method to retrieve a Blob object for a given GCS file.
+   * Helper method to retrieve a Blob object for a given GCS file. Returns null if the file does not
+   * exist or is not accessible with the provided credentials. Throws a RequesterPaysBucketException
+   * if the file is in a RP bucket.
    *
    * @param gcsFile GcsFile object representing the GCS path to the file
    * @param accessToken for the calling user. Pass null to use application default credentials.
    * @return Blob object if the file exists and is accessible, null otherwise
-   * @throws RequesterPaysBucketException if the bucket is a requester pays bucket
    */
   public Blob getFileBlob(GcsFile gcsFile, String accessToken) {
     BlobId blobId = BlobId.fromGsUtilUri(gcsFile.getFullPath());
@@ -138,12 +139,12 @@ public class GcsService {
   }
 
   /**
-   * Helper method to retrieve the size of a file in GCS in bytes.
+   * Helper method to retrieve the size of a file in GCS in bytes. Throws
+   * InternalServerErrorException if the file is not found or accessible; throws a
+   * RequesterPaysBucketException if the file is in a RP bucket.
    *
    * @param gcsFilePath the full GCS path to the file (e.g. gs://my-bucket/path/to/file.txt)
    * @return the size of the file in bytes
-   * @throws InternalServerErrorException if the file does not exist
-   * @throws RequesterPaysBucketException if the bucket is requester pays
    */
   public Long getFileSizeInBytes(String gcsFilePath) {
     GcsFile gcsFile = new GcsFile(gcsFilePath);
@@ -160,12 +161,12 @@ public class GcsService {
   }
 
   /**
-   * Check if a given user has read access to a GCS file.
+   * Check if a given user has read access to a GCS file. Throws a RequesterPaysBucketException if
+   * the file is in a RP bucket.
    *
    * @param gcsFile GcsFile object representing the GCS path to the file
    * @param accessToken for the calling user. pass null to use application default credentials.
    * @return boolean whether the caller has read access to the GCS file
-   * @throws RequesterPaysBucketException if the bucket is a requester pays bucket
    */
   private boolean hasFileReadAccess(GcsFile gcsFile, String accessToken) {
     Blob blob = getFileBlob(gcsFile, accessToken);
@@ -440,6 +441,11 @@ public class GcsService {
         });
   }
 
+  /**
+   * Same executionWithRetryTemplate but catches RP errors and throws a RequesterPaysBucketException
+   * if the file is in a RP bucket, using the additional param queriedBucketName in the error
+   * message.
+   */
   static <T> T executionWithRetryTemplateAndRequesterPaysErrorHandling(
       RetryTemplate retryTemplate, GcsAction<T> action, String queriedBucketName) {
     return retryTemplate.execute(

--- a/service/src/main/java/bio/terra/pipelines/service/PipelineRunsService.java
+++ b/service/src/main/java/bio/terra/pipelines/service/PipelineRunsService.java
@@ -247,6 +247,7 @@ public class PipelineRunsService {
 
     try {
       if (pipelineInputsOutputsService.pipelineHasManifestInputs(pipeline)) {
+        logger.info("Pipeline has manifest inputs! Checking contents.");
         pipelineInputsOutputsService.validateUserAndServiceReadAccessToManifestBuckets(
             pipeline, preparedPipelineRun, authedUser);
       }

--- a/service/src/main/java/bio/terra/pipelines/service/exception/RequesterPaysBucketException.java
+++ b/service/src/main/java/bio/terra/pipelines/service/exception/RequesterPaysBucketException.java
@@ -1,0 +1,10 @@
+package bio.terra.pipelines.service.exception;
+
+import bio.terra.common.exception.BadRequestException;
+
+@SuppressWarnings("java:S110") // Disable "Inheritance tree of classes should not be too deep"
+public class RequesterPaysBucketException extends BadRequestException {
+  public RequesterPaysBucketException(String message) {
+    super(message);
+  }
+}

--- a/service/src/main/resources/db/changelog.xml
+++ b/service/src/main/resources/db/changelog.xml
@@ -34,6 +34,7 @@
   <include file="changesets/20260413_update_array_imputation_v2_description.yaml" relativeToChangelogFile="true"/>
   <include file="changesets/20260505_add_low_pass_imputation_pipeline_and_drop_wdl_url_col.yaml" relativeToChangelogFile="true"/>
   <include file="changesets/20260507_drop_pipeline_outputs_old.yaml" relativeToChangelogFile="true"/>
+  <include file="changesets/20260508_fix_manifest_input_type.yaml" relativeToChangelogFile="true"/>
 
   <include file="changesets/testdata.yaml" relativeToChangelogFile="true"/>
 

--- a/service/src/main/resources/db/changesets/20260508_fix_manifest_input_type.yaml
+++ b/service/src/main/resources/db/changesets/20260508_fix_manifest_input_type.yaml
@@ -1,0 +1,13 @@
+# make cram_manifest input MANIFEST type
+databaseChangeLog:
+  - changeSet:
+      id: make cram_manifest input MANIFEST type
+      author: mma
+      changes:
+        - update:
+            tableName: pipeline_input_definitions
+            columns:
+              - column:
+                  name: type
+                  value: 'MANIFEST'
+            where: name='cramManifest' AND pipeline_id=(SELECT id FROM pipelines WHERE name='low_pass_imputation' AND version=1)

--- a/service/src/test/java/bio/terra/pipelines/dependencies/gcs/GcsServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/dependencies/gcs/GcsServiceTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.when;
 import bio.terra.common.exception.InternalServerErrorException;
 import bio.terra.pipelines.app.configuration.internal.RetryConfiguration;
 import bio.terra.pipelines.common.GcsFile;
+import bio.terra.pipelines.service.exception.RequesterPaysBucketException;
 import bio.terra.pipelines.testutils.BaseEmbeddedDbTest;
 import com.google.cloud.ReadChannel;
 import com.google.cloud.storage.*;
@@ -620,6 +621,19 @@ class GcsServiceTest extends BaseEmbeddedDbTest {
 
     Blob result = gcsService.getFileBlob(gcsFile, userBearerToken);
     assertEquals(mockBlob, result);
+  }
+
+  @Test
+  void getFileBlobRequesterPaysBucket() {
+    BlobId blobId = BlobId.fromGsUtilUri(gcsFile.getFullPath());
+
+    when(mockStorageService.get(
+            blobId, Storage.BlobGetOption.fields(Storage.BlobField.NAME, Storage.BlobField.SIZE)))
+        .thenThrow(new StorageException(400, "Bucket is a requester pays bucket"));
+
+    // we rethrow StorageExceptions with this message as RequesterPaysBucketExceptions
+    assertThrows(
+        RequesterPaysBucketException.class, () -> gcsService.getFileBlob(gcsFile, userBearerToken));
   }
 
   @Test

--- a/service/src/test/java/bio/terra/pipelines/dependencies/gcs/GcsServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/dependencies/gcs/GcsServiceTest.java
@@ -174,6 +174,16 @@ class GcsServiceTest extends BaseEmbeddedDbTest {
     assertEquals(expectedHasAccess, gcsService.serviceHasBucketReadAccess(bucketName));
   }
 
+  @Test
+  void serviceHasBucketReadAccessRP() {
+    when(mockStorageService.testIamPermissions(bucketName, List.of("storage.objects.get")))
+        .thenThrow(new StorageException(400, ("Bucket is a requester pays bucket")));
+
+    assertThrows(
+        RequesterPaysBucketException.class,
+        () -> gcsService.serviceHasBucketReadAccess(bucketName));
+  }
+
   @ParameterizedTest
   @MethodSource("bucketReadAccessPermissionsTestArgs")
   void userHasBucketReadAccess(List<Boolean> permissionResults, boolean expectedHasAccess) {
@@ -188,6 +198,16 @@ class GcsServiceTest extends BaseEmbeddedDbTest {
   void userHasBucketReadAccessFalseNullToken() {
     assertThrows(
         NullPointerException.class, () -> gcsService.userHasBucketReadAccess(bucketName, null));
+  }
+
+  @Test
+  void userHasBucketReadAccessRP() {
+    when(mockStorageService.testIamPermissions(bucketName, List.of("storage.objects.get")))
+        .thenThrow(new StorageException(400, ("Bucket is a requester pays bucket")));
+
+    assertThrows(
+        RequesterPaysBucketException.class,
+        () -> gcsService.userHasBucketReadAccess(bucketName, userBearerToken));
   }
 
   @Test

--- a/service/src/test/java/bio/terra/pipelines/dependencies/gcs/GcsServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/dependencies/gcs/GcsServiceTest.java
@@ -184,6 +184,15 @@ class GcsServiceTest extends BaseEmbeddedDbTest {
         () -> gcsService.serviceHasBucketReadAccess(bucketName));
   }
 
+  @Test
+  void serviceHasBucketReadAccessNonRPError() {
+    when(mockStorageService.testIamPermissions(bucketName, List.of("storage.objects.get")))
+        .thenThrow(new StorageException(400, ("Something else is wrong")));
+
+    assertThrows(
+        GcsServiceException.class, () -> gcsService.serviceHasBucketReadAccess(bucketName));
+  }
+
   @ParameterizedTest
   @MethodSource("bucketReadAccessPermissionsTestArgs")
   void userHasBucketReadAccess(List<Boolean> permissionResults, boolean expectedHasAccess) {
@@ -207,6 +216,16 @@ class GcsServiceTest extends BaseEmbeddedDbTest {
 
     assertThrows(
         RequesterPaysBucketException.class,
+        () -> gcsService.userHasBucketReadAccess(bucketName, userBearerToken));
+  }
+
+  @Test
+  void userHasBucketReadAccessNonRPError() {
+    when(mockStorageService.testIamPermissions(bucketName, List.of("storage.objects.get")))
+        .thenThrow(new StorageException(400, ("Something else is wrong")));
+
+    assertThrows(
+        GcsServiceException.class,
         () -> gcsService.userHasBucketReadAccess(bucketName, userBearerToken));
   }
 

--- a/service/src/test/java/bio/terra/pipelines/dependencies/gcs/GcsServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/dependencies/gcs/GcsServiceTest.java
@@ -129,7 +129,6 @@ class GcsServiceTest extends BaseEmbeddedDbTest {
     // we rethrow StorageExceptions with this message as RequesterPaysBucketExceptions
     assertThrows(
         RequesterPaysBucketException.class, () -> gcsService.serviceHasFileReadAccess(gcsFile));
-    ;
   }
 
   @Test
@@ -184,7 +183,6 @@ class GcsServiceTest extends BaseEmbeddedDbTest {
     assertThrows(
         RequesterPaysBucketException.class,
         () -> gcsService.userHasFileReadAccess(gcsFile, userBearerToken));
-    ;
   }
 
   private static Stream<Arguments> bucketReadAccessPermissionsTestArgs() {

--- a/service/src/test/java/bio/terra/pipelines/dependencies/gcs/GcsServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/dependencies/gcs/GcsServiceTest.java
@@ -55,6 +55,7 @@ class GcsServiceTest extends BaseEmbeddedDbTest {
 
   private final Long testSignedUrlPutDuration = 8L;
   private final Long testSignedUrlGetDuration = 1L;
+  private static final String REQUESTER_PAYS_ERROR_TEXT = "Bucket is a requester pays bucket";
 
   final Answer<Object> errorAnswer =
       invocation -> {
@@ -118,6 +119,20 @@ class GcsServiceTest extends BaseEmbeddedDbTest {
   }
 
   @Test
+  void serviceHasBlobReadAccessRequesterPaysException() {
+    BlobId blobId = BlobId.fromGsUtilUri(gcsFile.getFullPath());
+    Storage.BlobGetOption blobOption =
+        Storage.BlobGetOption.fields(Storage.BlobField.NAME, Storage.BlobField.SIZE);
+
+    when(mockStorageService.get(blobId, blobOption))
+        .thenThrow(new StorageException(400, REQUESTER_PAYS_ERROR_TEXT));
+    // we rethrow StorageExceptions with this message as RequesterPaysBucketExceptions
+    assertThrows(
+        RequesterPaysBucketException.class, () -> gcsService.serviceHasFileReadAccess(gcsFile));
+    ;
+  }
+
+  @Test
   void userHasBlobReadAccessTrue() {
     BlobId blobId = BlobId.fromGsUtilUri(gcsFile.getFullPath());
     Storage.BlobGetOption blobOption =
@@ -156,6 +171,22 @@ class GcsServiceTest extends BaseEmbeddedDbTest {
     assertThrows(NullPointerException.class, () -> gcsService.userHasFileReadAccess(gcsFile, null));
   }
 
+  @Test
+  void userHasBlobReadAccessRequesterPaysException() {
+    BlobId blobId = BlobId.fromGsUtilUri(gcsFile.getFullPath());
+    Storage.BlobGetOption blobOption =
+        Storage.BlobGetOption.fields(Storage.BlobField.NAME, Storage.BlobField.SIZE);
+
+    when(mockStorageService.get(blobId, blobOption))
+        .thenThrow(new StorageException(400, REQUESTER_PAYS_ERROR_TEXT));
+
+    // we rethrow StorageExceptions with this message as RequesterPaysBucketExceptions
+    assertThrows(
+        RequesterPaysBucketException.class,
+        () -> gcsService.userHasFileReadAccess(gcsFile, userBearerToken));
+    ;
+  }
+
   private static Stream<Arguments> bucketReadAccessPermissionsTestArgs() {
     // used for both user and service check tests
     // arguments: list of permission results for "storage.objects.get", expected has access result
@@ -177,7 +208,7 @@ class GcsServiceTest extends BaseEmbeddedDbTest {
   @Test
   void serviceHasBucketReadAccessRP() {
     when(mockStorageService.testIamPermissions(bucketName, List.of("storage.objects.get")))
-        .thenThrow(new StorageException(400, ("Bucket is a requester pays bucket")));
+        .thenThrow(new StorageException(400, (REQUESTER_PAYS_ERROR_TEXT)));
 
     assertThrows(
         RequesterPaysBucketException.class,
@@ -212,7 +243,7 @@ class GcsServiceTest extends BaseEmbeddedDbTest {
   @Test
   void userHasBucketReadAccessRP() {
     when(mockStorageService.testIamPermissions(bucketName, List.of("storage.objects.get")))
-        .thenThrow(new StorageException(400, ("Bucket is a requester pays bucket")));
+        .thenThrow(new StorageException(400, (REQUESTER_PAYS_ERROR_TEXT)));
 
     assertThrows(
         RequesterPaysBucketException.class,
@@ -668,7 +699,7 @@ class GcsServiceTest extends BaseEmbeddedDbTest {
 
     when(mockStorageService.get(
             blobId, Storage.BlobGetOption.fields(Storage.BlobField.NAME, Storage.BlobField.SIZE)))
-        .thenThrow(new StorageException(400, "Bucket is a requester pays bucket"));
+        .thenThrow(new StorageException(400, REQUESTER_PAYS_ERROR_TEXT));
 
     // we rethrow StorageExceptions with this message as RequesterPaysBucketExceptions
     assertThrows(


### PR DESCRIPTION
### Description 

When users submit data from an RP bucket (either the manifest/input file, or the files a manifeset points to), currently we return a generic "user doesn't have access to the bucket" message. Here we catch RP issues and return descriptive error messages to the user.

When file is in a RP bucket:
```
✗ terralab submit array_imputation --multiSampleVcf gs://sshah-testing/NA12878_10_samples_chr1_chr20.vcf.gz --outputBasename test --description "test RP bucket with file input"
Generated job_id ba59a69d-355b-4db4-bda6-69e398e57534

API call failed with status code 400: The bucket 'sshah-testing' is a requester pays bucket, which is not currently supported. Please turn off requester pays or submit data from a non-requester pays bucket.

For help troubleshooting, email scientific-services-support@broadinstitute.org
```

When manifest is in a RP bucket:
```
✗ terralab submit low_pass_imputation --cramManifest gs://sshah-testing/morgan-rp-testing/fakeCramManifestRPTargets.tsv --outputBasename test --description "test RP bucket"
Generated job_id d5b45bbd-3141-407d-b5e5-17622700dcd1

API call failed with status code 400: The bucket 'sshah-testing' is a requester pays bucket, which is not currently supported. Please turn off requester pays or submit data from a non-requester pays bucket.

For help troubleshooting, email scientific-services-support@broadinstitute.org
```

When manifest is ok but crams are in a manifest bucket:
```
✗ terralab submit low_pass_imputation --cramManifest gs://fc-secure-972057b6-fce1-4ec9-be0c-0e5c97fdc3e8/morgan-rp-testing/fakeCramManifestRPTargets.tsv --outputBasename test --description "test RP crams"
Generated job_id 0c924b9d-d0af-427a-91fc-a7b3943a5457

API call failed with status code 400: The bucket 'sshah-testing' is a requester pays bucket, which is not currently supported. Please turn off requester pays or submit data from a non-requester pays bucket.

For help troubleshooting, email scientific-services-support@broadinstitute.org
```

### Jira Ticket

### Checklist (provide links to changes)

- [ ] Updated external documentation (if applicable)
- [ ] Updated internal documentation (if applicable)
- [ ] Planned non patch version bump (if applicable)
- [ ] Made ticket for related CLI PR (if applicable)
- [ ] Made ticket for related UI PR (if applicable)
