### PR TITLE
TSPS-879 add-on fix for "agreeToTerms" error message wording

### DIFF
--- a/service/src/main/java/bio/terra/pipelines/app/controller/PipelineRunsApiController.java
+++ b/service/src/main/java/bio/terra/pipelines/app/controller/PipelineRunsApiController.java
@@ -126,7 +126,7 @@ public class PipelineRunsApiController implements PipelineRunsApi {
 
     if (!agreeToTerms) {
       throw new BadRequestException(
-          "You must agree to the terms of service (https://services.terra.bio/#pipelines/terms-of-service) to run a pipeline. Please ensure that you set \"agreeToTerms\" to true.");
+          "You must agree to the terms of service (https://services.terra.bio/#pipelines/terms-of-service). Please set 'agreeToTerms' to true to run a pipeline.");
     }
 
     Integer pipelineVersion = body.getPipelineVersion();


### PR DESCRIPTION
### Description 

Updated from 
```
"You must agree to the terms of service (https://services.terra.bio/#pipelines/terms-of-service) to run a pipeline. Please ensure that you set \"agreeToTerms\" to true."
```

to 
```
"You must agree to the terms of service (https://services.terra.bio/#pipelines/terms-of-service). Please set 'agreeToTerms' to true to run a pipeline."
```

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-879

### Checklist (provide links to changes)

- [ ] Updated external documentation (if applicable)
- [ ] Updated internal documentation (if applicable)
- [ ] Planned non patch version bump (if applicable)
- [ ] Made ticket for related CLI PR (if applicable)
- [ ] Made ticket for related UI PR (if applicable)
