### PR TITLE
TSPS-939 update thymeleaf version to 3.1.5.RELEASE for CVE-2026-41901

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -19,5 +19,9 @@ dependencies {
     // The following are required due to dependency conflicts between jib and srcclr. Removing them will cause jib to fail.
     implementation 'org.apache.commons:commons-lang3:3.20.0'
     implementation 'org.apache.commons:commons-compress:1.21'
-    implementation 'com.fasterxml.jackson.core:jackson-core:2.18.2'
+    // Jackson 2.18+ changed JsonProperty.isRequired() from OptBoolean -> boolean, breaking swagger-generator and other plugins.
+    // Pin to 2.17.x to retain the OptBoolean signature expected by those plugins.
+    implementation 'com.fasterxml.jackson.core:jackson-core:2.17.3'
+    implementation 'com.fasterxml.jackson.core:jackson-annotations:2.17.3'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.3'
 }

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
     implementation 'io.spring.dependency-management:io.spring.dependency-management.gradle.plugin:1.1.7'
-    implementation 'org.springframework.boot:spring-boot-gradle-plugin:3.5.12'
+    implementation 'org.springframework.boot:spring-boot-gradle-plugin:3.5.14'
     implementation 'com.diffplug.spotless:spotless-plugin-gradle:8.5.1'
     implementation 'com.felipefzdz.gradle.shellcheck:shellcheck:1.4.6'
     implementation 'com.google.cloud.tools.jib:com.google.cloud.tools.jib.gradle.plugin:3.4.4'

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -29,13 +29,6 @@ dependencyManagement {
     imports {
         mavenBom(SpringBootPlugin.BOM_COORDINATES)
     }
-
-    // Explicit dependency overrides here take precedence over BOM-managed versions.
-    dependencies {
-        // Force thymeleaf 3.1.5.RELEASE for https://nvd.nist.gov/vuln/detail/CVE-2026-41901
-        dependency 'org.thymeleaf:thymeleaf:3.1.5.RELEASE'
-        dependency 'org.thymeleaf:thymeleaf-spring6:3.1.5.RELEASE'
-    }
 }
 
 configurations {

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -29,6 +29,12 @@ dependencyManagement {
     imports {
         mavenBom(SpringBootPlugin.BOM_COORDINATES)
     }
+    // Force thymeleaf to 3.1.5.RELEASE for https://nvd.nist.gov/vuln/detail/CVE-2026-41901
+    // Explicit dependency overrides here take precedence over BOM-managed versions.
+    dependencies {
+        dependency 'org.thymeleaf:thymeleaf:3.1.5.RELEASE'
+        dependency 'org.thymeleaf:thymeleaf-spring6:3.1.5.RELEASE'
+    }
 }
 
 configurations {

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -29,9 +29,10 @@ dependencyManagement {
     imports {
         mavenBom(SpringBootPlugin.BOM_COORDINATES)
     }
-    // Force thymeleaf to 3.1.5.RELEASE for https://nvd.nist.gov/vuln/detail/CVE-2026-41901
+
     // Explicit dependency overrides here take precedence over BOM-managed versions.
     dependencies {
+        // Force thymeleaf 3.1.5.RELEASE for https://nvd.nist.gov/vuln/detail/CVE-2026-41901
         dependency 'org.thymeleaf:thymeleaf:3.1.5.RELEASE'
         dependency 'org.thymeleaf:thymeleaf-spring6:3.1.5.RELEASE'
     }


### PR DESCRIPTION
### Description 
Dependencies before changes:
```
(base) ~/Documents/repos/terra-scientific-pipelines-service (main) $ ./gradlew :service:dependencies --configuration runtimeClasspath | grep thymeleaf
+--- org.springframework.boot:spring-boot-starter-thymeleaf -> 3.5.12
|    \--- org.thymeleaf:thymeleaf-spring6:3.1.3.RELEASE
|         +--- org.thymeleaf:thymeleaf:3.1.3.RELEASE
```

dependence after changes:
```
(base) ~/Documents/repos/terra-scientific-pipelines-service (js_TSPS-939) $ ./gradlew :service:dependencies --configuration runtimeClasspath | grep thymeleaf
+--- org.springframework.boot:spring-boot-starter-thymeleaf -> 3.5.14
|    \--- org.thymeleaf:thymeleaf-spring6:3.1.5.RELEASE
|         +--- org.thymeleaf:thymeleaf:3.1.5.RELEASE
```

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-939

### Checklist (provide links to changes)

- [ ] Updated external documentation (if applicable)
- [ ] Updated internal documentation (if applicable)
- [ ] Planned non patch version bump (if applicable)
- [ ] Made ticket for related CLI PR (if applicable)
- [ ] Made ticket for related UI PR (if applicable)
