### PR TITLE
TSPS-822 Add low pass imputation env secrets, update pipeline env values to be clear about pipeline and version

### DIFF
--- a/service/src/main/java/bio/terra/pipelines/service/PipelinesService.java
+++ b/service/src/main/java/bio/terra/pipelines/service/PipelinesService.java
@@ -29,7 +29,7 @@ public class PipelinesService {
   private final SamService samService;
 
   private static final String SEM_VER_REGEX_STRING =
-      "^(0|[1-9]\\d*|[a-zA-Z_]*v\\d+)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$";
+      "^(0|[1-9]\\d*|[a-zA-Z0-9_]*v\\d+)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$";
 
   @Autowired
   public PipelinesService(

--- a/service/src/main/java/bio/terra/pipelines/service/PipelinesService.java
+++ b/service/src/main/java/bio/terra/pipelines/service/PipelinesService.java
@@ -29,7 +29,7 @@ public class PipelinesService {
   private final SamService samService;
 
   private static final String SEM_VER_REGEX_STRING =
-      "^(0|[1-9]\\d*|[a-zA-Z0-9_]*v\\d+)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$";
+      "^([0-9]+|[a-zA-Z0-9_]*v[0-9]+)\\.([0-9]+)\\.([0-9]+)$";
 
   @Autowired
   public PipelinesService(

--- a/service/src/main/java/bio/terra/pipelines/service/PipelinesService.java
+++ b/service/src/main/java/bio/terra/pipelines/service/PipelinesService.java
@@ -28,10 +28,8 @@ public class PipelinesService {
   private final RawlsService rawlsService;
   private final SamService samService;
 
-  private static final String SEM_VER_REGEX_STRING =
-      "^(\\d+|\\w*v\\d+)\\.(\\d+)\\.(\\d+)$"; // \\d means digit [0-9]; \\w means word-like
-
-  // [a-zA-Z0-9_]
+  // \\d means digit [0-9]; \\w means word-like [a-zA-Z0-9_]
+  private static final String SEM_VER_REGEX_STRING = "^(\\d+|\\w*v\\d+)\\.(\\d+)\\.(\\d+)$";
 
   @Autowired
   public PipelinesService(

--- a/service/src/main/java/bio/terra/pipelines/service/PipelinesService.java
+++ b/service/src/main/java/bio/terra/pipelines/service/PipelinesService.java
@@ -29,7 +29,9 @@ public class PipelinesService {
   private final SamService samService;
 
   private static final String SEM_VER_REGEX_STRING =
-      "^([0-9]+|[a-zA-Z0-9_]*v[0-9]+)\\.([0-9]+)\\.([0-9]+)$";
+      "^(\\d+|\\w*v\\d+)\\.(\\d+)\\.(\\d+)$"; // \\d means digit [0-9]; \\w means word-like
+
+  // [a-zA-Z0-9_]
 
   @Autowired
   public PipelinesService(

--- a/service/src/main/resources/pipelines-config.yml
+++ b/service/src/main/resources/pipelines-config.yml
@@ -14,7 +14,7 @@ env:
       "1":
         # the default currently points to the GCP dev workspace teaspoons-lowpass-imputation-dev/teaspoons_low_pass_imputation_dev_storage_workspace_20260515
         storageWorkspaceContainerUrl: ${LOW_PASS_IMPUTATION_STORAGE_WORKSPACE_STORAGE_URL:gs://fc-secure-13abc91f-fc43-479e-8d3b-80cd4ab887b2}
-        referencePanelPrefixCustomValue: ${LOW_PASS_IMPUTATION_REFERENCE_PANEL_PREFIX_CUSTOM_VALUE_V1:/hg38/ref_panels/1000G_HGDP_no_singletons/hgdp.tgp.gwaspy.AN_added.bcf.ac2}
+        referencePanelPrefixCustomValue: ${LOW_PASS_IMPUTATION_REFERENCE_PANEL_PREFIX_CUSTOM_VALUE_V1:/hg38/ref_panels/1000G_HGDP_with_trio_information/auxiliary_files/}
 
 pipelines:
   configurations:

--- a/service/src/main/resources/pipelines-config.yml
+++ b/service/src/main/resources/pipelines-config.yml
@@ -4,17 +4,17 @@ env:
     arrayImputation:
       "1":
         # the default currently points to the GCP dev workspace teaspoons-imputation-dev/teaspoons_imputation_dev_storage_workspace_20240726
-        storageWorkspaceContainerUrl: ${IMPUTATION_STORAGE_WORKSPACE_STORAGE_URL:gs://fc-secure-10efd4d7-392a-4e9e-89ea-d6629fbb06cc}
-        referencePanelPathPrefixCustomValue: ${IMPUTATION_REFERENCE_PANEL_PATH_PREFIX_CUSTOM_VALUE:/hg38/ref_panels/1000G_HGDP_no_singletons/hgdp.tgp.gwaspy.AN_added.bcf.ac2}
+        storageWorkspaceContainerUrl: ${ARRAY_IMPUTATION_STORAGE_WORKSPACE_STORAGE_URL:gs://fc-secure-10efd4d7-392a-4e9e-89ea-d6629fbb06cc}
+        referencePanelPathPrefixCustomValue: ${ARRAY_IMPUTATION_REFERENCE_PANEL_PATH_PREFIX_CUSTOM_VALUE_V1:/hg38/ref_panels/1000G_HGDP_no_singletons/hgdp.tgp.gwaspy.AN_added.bcf.ac2}
       "2":
         # the default currently points to the GCP dev workspace teaspoons-imputation-dev/teaspoons_imputation_dev_storage_workspace_20240726
-        storageWorkspaceContainerUrl: ${IMPUTATION_STORAGE_WORKSPACE_STORAGE_URL:gs://fc-secure-10efd4d7-392a-4e9e-89ea-d6629fbb06cc}
-        referencePanelPathPrefixCustomValue: ${IMPUTATION_REFERENCE_PANEL_PATH_PREFIX_CUSTOM_VALUE_V2:/hg38/ref_panels/1000G_HGDP_no_singletons/hgdp.tgp.gwaspy.AN_added.bcf.ac2}
+        storageWorkspaceContainerUrl: ${ARRAY_IMPUTATION_STORAGE_WORKSPACE_STORAGE_URL:gs://fc-secure-10efd4d7-392a-4e9e-89ea-d6629fbb06cc}
+        referencePanelPathPrefixCustomValue: ${ARRAY_IMPUTATION_REFERENCE_PANEL_PATH_PREFIX_CUSTOM_VALUE_V2:/hg38/ref_panels/1000G_HGDP_no_singletons/hgdp.tgp.gwaspy.AN_added.bcf.ac2}
     lowPassImputation:
       "1":
-        # the default currently points to the GCP dev workspace teaspoons-imputation-dev/teaspoons_imputation_dev_storage_workspace_20240726
-        storageWorkspaceContainerUrl: ${LOW_PASS_IMPUTATION_STORAGE_WORKSPACE_STORAGE_URL:gs://fc-secure-10efd4d7-392a-4e9e-89ea-d6629fbb06cc}
-        referencePanelPathPrefixCustomValue: ${LOW_PASS_IMPUTATION_REFERENCE_PANEL_PATH_PREFIX_CUSTOM_VALUE:/hg38/ref_panels/1000G_HGDP_no_singletons/hgdp.tgp.gwaspy.AN_added.bcf.ac2}
+        # the default currently points to the GCP dev workspace teaspoons-lowpass-imputation-dev/teaspoons_low_pass_imputation_dev_storage_workspace_20260515
+        storageWorkspaceContainerUrl: ${LOW_PASS_IMPUTATION_STORAGE_WORKSPACE_STORAGE_URL:gs://fc-secure-13abc91f-fc43-479e-8d3b-80cd4ab887b2}
+        referencePanelPrefixCustomValue: ${LOW_PASS_IMPUTATION_REFERENCE_PANEL_PREFIX_CUSTOM_VALUE_V1:/hg38/ref_panels/1000G_HGDP_no_singletons/hgdp.tgp.gwaspy.AN_added.bcf.ac2}
 
 pipelines:
   configurations:

--- a/service/src/test/java/bio/terra/pipelines/service/PipelinesServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/PipelinesServiceTest.java
@@ -375,7 +375,9 @@ class PipelinesServiceTest extends BaseEmbeddedDbTest {
         arguments("ImputationBeagle-development_v0.0.0"), // dashes not allowed
         arguments(
             "ImputationBeagle_development_0.0.0"), // missing a "v" before the semantic version
-        arguments("hiiv.1.4"));
+        arguments("hiiv.1.4"),
+        arguments(".."),
+        arguments("..3"));
   }
 
   @ParameterizedTest

--- a/service/src/test/java/bio/terra/pipelines/service/PipelinesServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/PipelinesServiceTest.java
@@ -405,7 +405,8 @@ class PipelinesServiceTest extends BaseEmbeddedDbTest {
         arguments("stringwithvinthemiddlev0.0.0"),
         arguments("v0.1.32"),
         arguments("stringv0.1.32"),
-        arguments("1.13.1"));
+        arguments("1.13.1"),
+        arguments("PipelineHasANumber8InIt_v1.2.3"));
   }
 
   @ParameterizedTest


### PR DESCRIPTION
### Description 

Updating existing array imputation secrets to be clear about pipeline name and version, and adding/updating low pass imputation secrets.

Associated terra-helmfire PR: https://github.com/broadinstitute/terra-helmfile/pull/6438

Local test w/dev control and storage workspaces succeeded (note the # samples is wrong, but that is being fixed in [this warp PR](https://github.com/broadinstitute/warp/pull/1841))
```
✗ terralab jobs details 5c46580d-0a93-4d6a-9e64-4bcb575d48f4
Status: Succeeded

Details:
  Pipeline Name: low_pass_imputation
  Pipeline Version: 1
  Description: local test with real wdl in dev control workspace
  Inputs:
    outputBasename:
      NA12878.test
    cramManifest:
      gs://fc-431ee27b-67d9-4a5c-b087-226db01368f8/lowpass_imputation_test_inputs/cramManifestGoodDev.tsv
  Input size: 2 samples
  Submitted: 2026-05-18 13:25 EDT
  Completed: 2026-05-18 15:21 EDT
  Quota Consumed: 500
  Outputs:
    imputedVcf:
      NA12878.test.imputed.vcf.gz (46.9 MiB)
    imputedHomRefSitesOnlyVcf:
      NA12878.test.imputed.hom_ref_sites_only.vcf.gz (647.1 MiB)
    imputedVcfIndex:
      NA12878.test.imputed.vcf.gz.tbi (1.3 MiB)
    imputedHomRefSitesOnlyVcfIndex:
      NA12878.test.imputed.hom_ref_sites_only.vcf.gz.tbi (1.7 MiB)
    qcMetrics:
      NA12878.test.qc_metrics.tsv (330 B)
  File Download Expiration: 2026-06-01 15:21 EDT
```

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-822

### Checklist (provide links to changes)

- [ ] Updated external documentation (if applicable)
- [ ] Updated internal documentation (if applicable)
- [ ] Planned non patch version bump (if applicable)
- [ ] Made ticket for related CLI PR (if applicable)
- [ ] Made ticket for related UI PR (if applicable)
