### PR TITLE
TSPS-915 High Security Finding - Update Bouncy Castle Provider to 1.84 (achieved via update TCL to 1.1.74)

### DIFF
--- a/buildSrc/src/main/groovy/bio.terra.pipelines.java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/bio.terra.pipelines.java-common-conventions.gradle
@@ -44,7 +44,7 @@ dependencies {
 
     testImplementation 'org.hamcrest:hamcrest:2.2'
 
-    implementation 'bio.terra:terra-common-lib:1.1.70-SNAPSHOT'
+    implementation 'bio.terra:terra-common-lib:1.1.74-SNAPSHOT'
     implementation platform('com.google.cloud:libraries-bom:26.33.0') // required for TCL
 
     implementation 'io.swagger.core.v3:swagger-annotations:2.2.12'

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -47,7 +47,7 @@ dependencies {
     implementation group: "com.google.guava", name:"guava"
 
     // Get stairway via TCL
-    implementation "bio.terra:terra-common-lib" // 1.1.11-SNAPSHOT is defined in java-common-conventions
+    implementation "bio.terra:terra-common-lib" // 1.1.74-SNAPSHOT is defined in java-common-conventions
 
     // terra clients
     implementation "org.broadinstitute.dsde.workbench:sam-client_2.13:v0.0.213"


### PR DESCRIPTION
### Description 

We had a high security finding to update bouncy castle to 1.84. We get bouncy castle via TCL, and TCL version 1.1.74 has the updated bouncy castle version.

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-915

### Checklist (provide links to changes)

- [ ] Updated external documentation (if applicable)
- [ ] Updated internal documentation (if applicable)
- [ ] Planned non patch version bump (if applicable)
- [ ] Made ticket for related CLI PR (if applicable)
- [ ] Made ticket for related UI PR (if applicable)
