### PR TITLE
[TSPS-911] Add pipeline header input for low_pass_imputation pipeline

### DIFF
--- a/pipelines/low_pass_imputation/testing/Glimpse2LowPassImputationEmpty.wdl
+++ b/pipelines/low_pass_imputation/testing/Glimpse2LowPassImputationEmpty.wdl
@@ -13,7 +13,8 @@ workflow Glimpse2LowPassImputation {
         File fasta_index
         File ref_dict
 
-        String? pipeline_header_line # optional additional header lines to add to the output VCF
+        # optional additional header lines to add to the output VCF
+        String? pipeline_header_line
     }
 
     call WriteEmptyFile

--- a/pipelines/low_pass_imputation/testing/Glimpse2LowPassImputationEmpty.wdl
+++ b/pipelines/low_pass_imputation/testing/Glimpse2LowPassImputationEmpty.wdl
@@ -13,7 +13,7 @@ workflow Glimpse2LowPassImputation {
         File fasta_index
         File ref_dict
 
-        # optional additional header lines to add to the output VCF
+        # optional additional header line to add to the output VCF
         String? pipeline_header_line
     }
 

--- a/pipelines/low_pass_imputation/testing/Glimpse2LowPassImputationEmpty.wdl
+++ b/pipelines/low_pass_imputation/testing/Glimpse2LowPassImputationEmpty.wdl
@@ -12,6 +12,8 @@ workflow Glimpse2LowPassImputation {
         File fasta
         File fasta_index
         File ref_dict
+
+        String? pipeline_header_line # optional additional header lines to add to the output VCF
     }
 
     call WriteEmptyFile

--- a/pipelines/low_pass_imputation/testing/Glimpse2LowPassImputationInputQCEmpty.wdl
+++ b/pipelines/low_pass_imputation/testing/Glimpse2LowPassImputationInputQCEmpty.wdl
@@ -14,6 +14,8 @@ workflow InputQC {
         File fasta
         File fasta_index
         File ref_dict
+
+        String? pipeline_header_line # optional additional header lines to add to the output VCF
     }
 
     call MockValidateInputs

--- a/pipelines/low_pass_imputation/testing/Glimpse2LowPassImputationInputQCEmpty.wdl
+++ b/pipelines/low_pass_imputation/testing/Glimpse2LowPassImputationInputQCEmpty.wdl
@@ -15,7 +15,8 @@ workflow InputQC {
         File fasta_index
         File ref_dict
 
-        String? pipeline_header_line # optional additional header lines to add to the output VCF
+        # optional additional header lines to add to the output VCF
+        String? pipeline_header_line
     }
 
     call MockValidateInputs

--- a/pipelines/low_pass_imputation/testing/Glimpse2LowPassImputationInputQCEmpty.wdl
+++ b/pipelines/low_pass_imputation/testing/Glimpse2LowPassImputationInputQCEmpty.wdl
@@ -15,7 +15,7 @@ workflow InputQC {
         File fasta_index
         File ref_dict
 
-        # optional additional header lines to add to the output VCF
+        # optional additional header line to add to the output VCF
         String? pipeline_header_line
     }
 

--- a/pipelines/low_pass_imputation/testing/Glimpse2LowPassImputationQuotaConsumedEmpty.wdl
+++ b/pipelines/low_pass_imputation/testing/Glimpse2LowPassImputationQuotaConsumedEmpty.wdl
@@ -14,6 +14,8 @@ workflow QuotaConsumed {
         File fasta
         File fasta_index
         File ref_dict
+
+        String? pipeline_header_line # optional additional header lines to add to the output VCF
     }
 
     call CalculateMockQuota

--- a/pipelines/low_pass_imputation/testing/Glimpse2LowPassImputationQuotaConsumedEmpty.wdl
+++ b/pipelines/low_pass_imputation/testing/Glimpse2LowPassImputationQuotaConsumedEmpty.wdl
@@ -15,7 +15,8 @@ workflow QuotaConsumed {
         File fasta_index
         File ref_dict
 
-        String? pipeline_header_line # optional additional header lines to add to the output VCF
+        # optional additional header lines to add to the output VCF
+        String? pipeline_header_line
     }
 
     call CalculateMockQuota

--- a/pipelines/low_pass_imputation/testing/Glimpse2LowPassImputationQuotaConsumedEmpty.wdl
+++ b/pipelines/low_pass_imputation/testing/Glimpse2LowPassImputationQuotaConsumedEmpty.wdl
@@ -15,7 +15,7 @@ workflow QuotaConsumed {
         File fasta_index
         File ref_dict
 
-        # optional additional header lines to add to the output VCF
+        # optional additional header line to add to the output VCF
         String? pipeline_header_line
     }
 

--- a/service/src/main/resources/db/changelog.xml
+++ b/service/src/main/resources/db/changelog.xml
@@ -35,6 +35,7 @@
   <include file="changesets/20260505_add_low_pass_imputation_pipeline_and_drop_wdl_url_col.yaml" relativeToChangelogFile="true"/>
   <include file="changesets/20260507_drop_pipeline_outputs_old.yaml" relativeToChangelogFile="true"/>
   <include file="changesets/20260508_fix_manifest_input_type.yaml" relativeToChangelogFile="true"/>
+  <include file="changesets/20260518_add_low_pass_imputation_pipeline_header_input.yaml" relativeToChangelogFile="true"/>
 
   <include file="changesets/testdata.yaml" relativeToChangelogFile="true"/>
 

--- a/service/src/main/resources/db/changesets/20260518_add_low_pass_imputation_pipeline_header_input.yaml
+++ b/service/src/main/resources/db/changesets/20260518_add_low_pass_imputation_pipeline_header_input.yaml
@@ -1,0 +1,31 @@
+# add pipeline header input definition for low_pass_imputation v1 pipeline
+
+databaseChangeLog:
+  -  changeSet:
+       id:  add pipeline header input definition for low_pass_imputation v1 pipeline
+       author:  sshah
+       changes:
+         - insert:
+             tableName: pipeline_input_definitions
+             columns:
+               - column:
+                   name: pipeline_id
+                   valueComputed: (SELECT id FROM pipelines WHERE name='low_pass_imputation' and version='1')
+               - column:
+                   name: name
+                   value: pipelineHeaderLine
+               - column:
+                   name: type
+                   value: STRING
+               - column:
+                   name: is_required
+                   value: true
+               - column:
+                   name: user_provided
+                   value: false
+               - column:
+                   name: default_value
+                   value: ScientificServicesPipeline=LowPassImputation_v1
+               - column:
+                   name: wdl_variable_name
+                   value: pipeline_header_line

--- a/service/src/test/java/bio/terra/pipelines/service/PipelinesServiceDatabaseTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/PipelinesServiceDatabaseTest.java
@@ -349,14 +349,14 @@ class PipelinesServiceDatabaseTest extends BaseEmbeddedDbTest {
     List<PipelineInputDefinition> allPipelineInputDefinitions =
         pipeline.getPipelineInputDefinitions();
 
-    // there should be 2 user-provided inputs and 5 service-provided inputs
+    // there should be 2 user-provided inputs and 6 service-provided inputs
     assertEquals(
         2,
         allPipelineInputDefinitions.stream()
             .filter(PipelineInputDefinition::isUserProvided)
             .count());
     assertEquals(
-        5,
+        6,
         allPipelineInputDefinitions.stream()
             .filter(Predicate.not(PipelineInputDefinition::isUserProvided))
             .count());
@@ -389,7 +389,13 @@ class PipelinesServiceDatabaseTest extends BaseEmbeddedDbTest {
             .map(PipelineInputDefinition::getWdlVariableName)
             .collect(Collectors.toSet())
             .containsAll(
-                Set.of("contigs", "ref_dict", "reference_panel_prefix", "fasta", "fasta_index")));
+                Set.of(
+                    "contigs",
+                    "ref_dict",
+                    "reference_panel_prefix",
+                    "fasta",
+                    "fasta_index",
+                    "pipeline_header_line")));
 
     assertTrue(
         allPipelineInputDefinitions.stream()
@@ -399,7 +405,13 @@ class PipelinesServiceDatabaseTest extends BaseEmbeddedDbTest {
             .map(PipelineInputDefinition::getName)
             .collect(Collectors.toSet())
             .containsAll(
-                Set.of("contigs", "refDict", "referencePanelPrefix", "fasta", "fastaIndex")));
+                Set.of(
+                    "contigs",
+                    "refDict",
+                    "referencePanelPrefix",
+                    "fasta",
+                    "fastaIndex",
+                    "pipelineHeaderLine")));
 
     // make sure the inputs are associated with the correct pipeline
     assertEquals(


### PR DESCRIPTION
### Description 

Jira: https://broadworkbench.atlassian.net/browse/TSPS-911

This PR adds a pipeline header input to low_pass_imputation pipeline and sets its value to `ScientificServicesPipeline=LowPassImputation_v1`

Related WARP PR - https://github.com/broadinstitute/warp/pull/1838

### Jira Ticket

### Checklist (provide links to changes)

- [ ] Updated external documentation (if applicable)
- [ ] Updated internal documentation (if applicable)
- [x] Planned non patch version bump (if applicable)
- [ ] Made ticket for related CLI PR (if applicable)
- [ ] Made ticket for related UI PR (if applicable)
