### PR TITLE
[TSPS-937] Add ToS link to marketing website

### DIFF
--- a/ui/allofus-anvil-imputation/css/style.css
+++ b/ui/allofus-anvil-imputation/css/style.css
@@ -468,6 +468,12 @@ body {
   line-height: 32px;
 }
 
+.terms-of-service a {
+  font-size: 18px;
+  font-weight: 500;
+  color: #92EEE3;
+}
+
 #acknowledgments .header {
   height: 100px;
   width: 100%;

--- a/ui/allofus-anvil-imputation/index.html
+++ b/ui/allofus-anvil-imputation/index.html
@@ -233,6 +233,10 @@
     <div class="main-acknowledgments">
       <a href="acknowledgments/">Scientific acknowledgments</a>
     </div>
+    <br/>
+    <div class="terms-of-service">
+      <a href="https://services.terra.bio/#pipelines/terms-of-service" target="_blank">Terms of Service</a>
+    </div>
   </div>
 
   </div>


### PR DESCRIPTION
### Description 

This PR adds ToS link to the bottom of marketing website. Link opens the ToS in a new tab.

Tested in dev - https://allofus-anvil-imputation.dsde-dev.broadinstitute.org/

<img width="1279" height="349" alt="Screenshot 2026-05-19 at 6 10 33 PM" src="https://github.com/user-attachments/assets/123d80e8-8b9f-43e8-9eda-f4ba0e86366c" />


### Jira Ticket: https://broadworkbench.atlassian.net/browse/TSPS-937

### Checklist (provide links to changes)

- [ ] Updated external documentation (if applicable)
- [ ] Updated internal documentation (if applicable)
- [ ] Planned non patch version bump (if applicable)
- [ ] Made ticket for related CLI PR (if applicable)
- [ ] Made ticket for related UI PR (if applicable)
