### PR TITLE
TSPS-829 Genericize e2e tests and add low_pass_imputation test

### DIFF
--- a/.github/workflows/run-e2e-tests-live-env.yml
+++ b/.github/workflows/run-e2e-tests-live-env.yml
@@ -12,27 +12,9 @@ on:
         required: true
         default: 'main'
         type: string
-#      input-vcf-file-name:
-#        description: 'Name of the input VCF file to use in the test (just the file name and not the entire path)'
-#        required: true
-#        default: 'NA12878_10_samples_chr1_chr20.vcf.gz' # small VCF file with 10 samples, chr1 and chr20 data only
-#        type: string
-#      use-cloud-input:
-#        description: 'Whether to use a cloud input file (true) or a local file (false) for the test. Default true.'
-#        required: true
-#        default: 'true'
-#        type: string
-#      pipeline-name:
-#        description: 'name of the pipeline to run.'
-#        required: true
-#        type: string
-#      pipeline-version:
-#        description: 'version of the pipeline to run.'
-#        required: true
-#        type: string
 
 jobs:
-  run-live-env-e2e-test-job-array-imputation:
+  run-live-env-e2e-test-job-array-imputation-v2:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -56,29 +38,29 @@ jobs:
                  "use-cloud-input": "true"
             }'
 
-#  run-live-env-e2e-test-job-low-pass-imputation:
-#    runs-on: ubuntu-latest
-#    permissions:
-#      contents: read
-#      id-token: write
-#    steps:
-#      - name: Dispatch to terra-github-workflows
-#        uses: broadinstitute/workflow-dispatch@v4.0.1
-#        with:
-#          workflow: teaspoons-live-env-e2e-service-test
-#          run-name: "teaspoons-live-env-e2e-service-test-low-pass-imputation-v1-${{ github.run_id }}-${{ github.run_attempt }}"
-#          repo: broadinstitute/terra-github-workflows
-#          ref: refs/heads/TSPS-829_e2e_tests_add_low_pass_pipeline # TODO revert to main
-#          token: ${{ secrets.BROADBOT_TOKEN }} # GitHub token for access to kick off a job in the private repo
-#          wait-for-completion-timeout: 2h # default timeout is 1 hour, but this e2e test can sometimes take around 1.5 hours to complete
-#          inputs: '{
-#                 "run-name": "teaspoons-live-env-e2e-service-test-low-pass-imputation-v1-${{ github.run_id }}-${{ github.run_attempt }}",
-#                 "env-name": "${{inputs.env-name}}",
-#                 "repo-branch": "${{inputs.e2e-test-branch-name}}",
-#                 "pipeline-name": "low_pass_imputation",
-#                 "pipeline-version": "1",
-#                 "use-cloud-input": true,
-#            }'
+  run-live-env-e2e-test-job-low-pass-imputation-v1:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Dispatch to terra-github-workflows
+        uses: broadinstitute/workflow-dispatch@v4.0.1
+        with:
+          workflow: teaspoons-live-env-e2e-service-test
+          run-name: "teaspoons-live-env-e2e-service-test-low-pass-imputation-v1-${{ github.run_id }}-${{ github.run_attempt }}"
+          repo: broadinstitute/terra-github-workflows
+          ref: refs/heads/TSPS-829_e2e_tests_add_low_pass_pipeline # TODO revert to main
+          token: ${{ secrets.BROADBOT_TOKEN }} # GitHub token for access to kick off a job in the private repo
+          wait-for-completion-timeout: 2h # default timeout is 1 hour, but this e2e test can sometimes take around 1.5 hours to complete
+          inputs: '{
+                 "run-name": "teaspoons-live-env-e2e-service-test-low-pass-imputation-v1-${{ github.run_id }}-${{ github.run_attempt }}",
+                 "env-name": "${{inputs.env-name}}",
+                 "repo-branch": "${{inputs.e2e-test-branch-name}}",
+                 "pipeline-name": "low_pass_imputation",
+                 "pipeline-version": "1",
+                 "use-cloud-input": true,
+            }'
 
   report-workflow:
     uses: broadinstitute/sherlock/.github/workflows/client-report-workflow.yaml@main

--- a/.github/workflows/run-e2e-tests-live-env.yml
+++ b/.github/workflows/run-e2e-tests-live-env.yml
@@ -12,24 +12,27 @@ on:
         required: true
         default: 'main'
         type: string
-      input-vcf-file-name:
-        description: 'Name of the input VCF file to use in the test (just the file name and not the entire path)'
-        required: true
-        default: 'NA12878_10_samples_chr1_chr20.vcf.gz' # small VCF file with 10 samples, chr1 and chr20 data only
-        type: string
-      use-cloud-input:
-        description: 'Whether to use a cloud input file (true) or a local file (false) for the test. Default true.'
-        required: true
-        default: 'true'
-        type: string
-      pipeline-version:
-        description: 'version of the pipeline to run. default to 2.'
-        default: '2'
-        required: true
-        type: string
+#      input-vcf-file-name:
+#        description: 'Name of the input VCF file to use in the test (just the file name and not the entire path)'
+#        required: true
+#        default: 'NA12878_10_samples_chr1_chr20.vcf.gz' # small VCF file with 10 samples, chr1 and chr20 data only
+#        type: string
+#      use-cloud-input:
+#        description: 'Whether to use a cloud input file (true) or a local file (false) for the test. Default true.'
+#        required: true
+#        default: 'true'
+#        type: string
+#      pipeline-name:
+#        description: 'name of the pipeline to run.'
+#        required: true
+#        type: string
+#      pipeline-version:
+#        description: 'version of the pipeline to run.'
+#        required: true
+#        type: string
 
 jobs:
-  run-live-env-e2e-test-job:
+  run-live-env-e2e-test-job-array-imputation:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -39,19 +42,43 @@ jobs:
         uses: broadinstitute/workflow-dispatch@v4.0.1
         with:
           workflow: teaspoons-live-env-e2e-service-test
-          run-name: "teaspoons-live-env-e2e-service-test-${{ github.run_id }}-${{ github.run_attempt }}"
+          run-name: "teaspoons-live-env-e2e-service-test-array-imputation-${{ github.run_id }}-${{ github.run_attempt }}"
           repo: broadinstitute/terra-github-workflows
-          ref: refs/heads/main
+          ref: refs/heads/TSPS-829_e2e_tests_add_low_pass_pipeline # TODO revert to main
           token: ${{ secrets.BROADBOT_TOKEN }} # GitHub token for access to kick off a job in the private repo
           wait-for-completion-timeout: 2h # default timeout is 1 hour, but this e2e test can sometimes take around 1.5 hours to complete
           inputs: '{
                  "run-name": "teaspoons-live-env-e2e-service-test-${{ github.run_id }}-${{ github.run_attempt }}",
                  "env-name": "${{inputs.env-name}}",
                  "repo-branch": "${{inputs.e2e-test-branch-name}}",
-                 "input-vcf-file-name": "${{inputs.input-vcf-file-name}}",
+                 "pipeline-name": "array_imputation",
+                 "pipeline-version": "2",
                  "use-cloud-input": "${{inputs.use-cloud-input}}",
-                 "pipeline-version": "${{inputs.pipeline-version}}"
             }'
+
+#  run-live-env-e2e-test-job-low-pass-imputation:
+#    runs-on: ubuntu-latest
+#    permissions:
+#      contents: read
+#      id-token: write
+#    steps:
+#      - name: Dispatch to terra-github-workflows
+#        uses: broadinstitute/workflow-dispatch@v4.0.1
+#        with:
+#          workflow: teaspoons-live-env-e2e-service-test
+#          run-name: "teaspoons-live-env-e2e-service-test-low-pass-imputation-${{ github.run_id }}-${{ github.run_attempt }}"
+#          repo: broadinstitute/terra-github-workflows
+#          ref: refs/heads/TSPS-829_e2e_tests_add_low_pass_pipeline # TODO revert to main
+#          token: ${{ secrets.BROADBOT_TOKEN }} # GitHub token for access to kick off a job in the private repo
+#          wait-for-completion-timeout: 2h # default timeout is 1 hour, but this e2e test can sometimes take around 1.5 hours to complete
+#          inputs: '{
+#                 "run-name": "teaspoons-live-env-e2e-service-test-${{ github.run_id }}-${{ github.run_attempt }}",
+#                 "env-name": "${{inputs.env-name}}",
+#                 "repo-branch": "${{inputs.e2e-test-branch-name}}",
+#                 "pipeline-name": "low_pass_imputation",
+#                 "pipeline-version": "1",
+#                 "use-cloud-input": true,
+#            }'
 
   report-workflow:
     uses: broadinstitute/sherlock/.github/workflows/client-report-workflow.yaml@main

--- a/.github/workflows/run-e2e-tests-live-env.yml
+++ b/.github/workflows/run-e2e-tests-live-env.yml
@@ -53,7 +53,7 @@ jobs:
                  "repo-branch": "${{inputs.e2e-test-branch-name}}",
                  "pipeline-name": "array_imputation",
                  "pipeline-version": "2",
-                 "use-cloud-input": "true",
+                 "use-cloud-input": "true"
             }'
 
 #  run-live-env-e2e-test-job-low-pass-imputation:

--- a/.github/workflows/run-e2e-tests-live-env.yml
+++ b/.github/workflows/run-e2e-tests-live-env.yml
@@ -24,13 +24,13 @@ jobs:
         uses: broadinstitute/workflow-dispatch@v4.0.1
         with:
           workflow: teaspoons-live-env-e2e-service-test
-          run-name: "teaspoons-live-env-e2e-service-test-array-imputation-v2-${{ github.run_id }}-${{ github.run_attempt }}"
+          run-name: "teaspoons-${{inputs.env-name}}-live-env-e2e-service-test-array-imputation-v2-${{ github.run_id }}-${{ github.run_attempt }}"
           repo: broadinstitute/terra-github-workflows
           ref: refs/heads/TSPS-829_e2e_tests_add_low_pass_pipeline # TODO revert to main
           token: ${{ secrets.BROADBOT_TOKEN }} # GitHub token for access to kick off a job in the private repo
           wait-for-completion-timeout: 2h # default timeout is 1 hour, but this e2e test can sometimes take around 1.5 hours to complete
           inputs: '{
-                 "run-name": "teaspoons-live-env-e2e-service-test-array-imputation-v2-${{ github.run_id }}-${{ github.run_attempt }}",
+                 "run-name": "teaspoons-${{inputs.env-name}}-live-env-e2e-service-test-array-imputation-v2-${{ github.run_id }}-${{ github.run_attempt }}",
                  "env-name": "${{inputs.env-name}}",
                  "repo-branch": "${{inputs.e2e-test-branch-name}}",
                  "pipeline-name": "array_imputation",
@@ -48,13 +48,13 @@ jobs:
         uses: broadinstitute/workflow-dispatch@v4.0.1
         with:
           workflow: teaspoons-live-env-e2e-service-test
-          run-name: "teaspoons-live-env-e2e-service-test-low-pass-imputation-v1-${{ github.run_id }}-${{ github.run_attempt }}"
+          run-name: "teaspoons-${{inputs.env-name}}-live-env-e2e-service-test-low-pass-imputation-v1-${{ github.run_id }}-${{ github.run_attempt }}"
           repo: broadinstitute/terra-github-workflows
           ref: refs/heads/TSPS-829_e2e_tests_add_low_pass_pipeline # TODO revert to main
           token: ${{ secrets.BROADBOT_TOKEN }} # GitHub token for access to kick off a job in the private repo
           wait-for-completion-timeout: 2h # default timeout is 1 hour, but this e2e test can sometimes take around 1.5 hours to complete
           inputs: '{
-                 "run-name": "teaspoons-live-env-e2e-service-test-low-pass-imputation-v1-${{ github.run_id }}-${{ github.run_attempt }}",
+                 "run-name": "teaspoons-${{inputs.env-name}}-live-env-e2e-service-test-low-pass-imputation-v1-${{ github.run_id }}-${{ github.run_attempt }}",
                  "env-name": "${{inputs.env-name}}",
                  "repo-branch": "${{inputs.e2e-test-branch-name}}",
                  "pipeline-name": "low_pass_imputation",

--- a/.github/workflows/run-e2e-tests-live-env.yml
+++ b/.github/workflows/run-e2e-tests-live-env.yml
@@ -42,13 +42,13 @@ jobs:
         uses: broadinstitute/workflow-dispatch@v4.0.1
         with:
           workflow: teaspoons-live-env-e2e-service-test
-          run-name: "teaspoons-live-env-e2e-service-test-array-imputation-${{ github.run_id }}-${{ github.run_attempt }}"
+          run-name: "teaspoons-live-env-e2e-service-test-array-imputation-v2-${{ github.run_id }}-${{ github.run_attempt }}"
           repo: broadinstitute/terra-github-workflows
           ref: refs/heads/TSPS-829_e2e_tests_add_low_pass_pipeline # TODO revert to main
           token: ${{ secrets.BROADBOT_TOKEN }} # GitHub token for access to kick off a job in the private repo
           wait-for-completion-timeout: 2h # default timeout is 1 hour, but this e2e test can sometimes take around 1.5 hours to complete
           inputs: '{
-                 "run-name": "teaspoons-live-env-e2e-service-test-array-imputation-${{ github.run_id }}-${{ github.run_attempt }}",
+                 "run-name": "teaspoons-live-env-e2e-service-test-array-imputation-v2-${{ github.run_id }}-${{ github.run_attempt }}",
                  "env-name": "${{inputs.env-name}}",
                  "repo-branch": "${{inputs.e2e-test-branch-name}}",
                  "pipeline-name": "array_imputation",
@@ -66,13 +66,13 @@ jobs:
 #        uses: broadinstitute/workflow-dispatch@v4.0.1
 #        with:
 #          workflow: teaspoons-live-env-e2e-service-test
-#          run-name: "teaspoons-live-env-e2e-service-test-${{ github.run_id }}-${{ github.run_attempt }}"
+#          run-name: "teaspoons-live-env-e2e-service-test-low-pass-imputation-v1-${{ github.run_id }}-${{ github.run_attempt }}"
 #          repo: broadinstitute/terra-github-workflows
 #          ref: refs/heads/TSPS-829_e2e_tests_add_low_pass_pipeline # TODO revert to main
 #          token: ${{ secrets.BROADBOT_TOKEN }} # GitHub token for access to kick off a job in the private repo
 #          wait-for-completion-timeout: 2h # default timeout is 1 hour, but this e2e test can sometimes take around 1.5 hours to complete
 #          inputs: '{
-#                 "run-name": "teaspoons-live-env-e2e-service-test-${{ github.run_id }}-${{ github.run_attempt }}",
+#                 "run-name": "teaspoons-live-env-e2e-service-test-low-pass-imputation-v1-${{ github.run_id }}-${{ github.run_attempt }}",
 #                 "env-name": "${{inputs.env-name}}",
 #                 "repo-branch": "${{inputs.e2e-test-branch-name}}",
 #                 "pipeline-name": "low_pass_imputation",

--- a/.github/workflows/run-e2e-tests-live-env.yml
+++ b/.github/workflows/run-e2e-tests-live-env.yml
@@ -48,7 +48,7 @@ jobs:
           token: ${{ secrets.BROADBOT_TOKEN }} # GitHub token for access to kick off a job in the private repo
           wait-for-completion-timeout: 2h # default timeout is 1 hour, but this e2e test can sometimes take around 1.5 hours to complete
           inputs: '{
-                 "run-name": "teaspoons-live-env-e2e-service-test-${{ github.run_id }}-${{ github.run_attempt }}",
+                 "run-name": "teaspoons-live-env-e2e-service-test-array-imputation-${{ github.run_id }}-${{ github.run_attempt }}",
                  "env-name": "${{inputs.env-name}}",
                  "repo-branch": "${{inputs.e2e-test-branch-name}}",
                  "pipeline-name": "array_imputation",
@@ -66,7 +66,7 @@ jobs:
 #        uses: broadinstitute/workflow-dispatch@v4.0.1
 #        with:
 #          workflow: teaspoons-live-env-e2e-service-test
-#          run-name: "teaspoons-live-env-e2e-service-test-low-pass-imputation-${{ github.run_id }}-${{ github.run_attempt }}"
+#          run-name: "teaspoons-live-env-e2e-service-test-${{ github.run_id }}-${{ github.run_attempt }}"
 #          repo: broadinstitute/terra-github-workflows
 #          ref: refs/heads/TSPS-829_e2e_tests_add_low_pass_pipeline # TODO revert to main
 #          token: ${{ secrets.BROADBOT_TOKEN }} # GitHub token for access to kick off a job in the private repo

--- a/.github/workflows/run-e2e-tests-live-env.yml
+++ b/.github/workflows/run-e2e-tests-live-env.yml
@@ -59,7 +59,7 @@ jobs:
                  "repo-branch": "${{inputs.e2e-test-branch-name}}",
                  "pipeline-name": "low_pass_imputation",
                  "pipeline-version": "1",
-                 "use-cloud-input": true,
+                 "use-cloud-input": "true",
             }'
 
   report-workflow:

--- a/.github/workflows/run-e2e-tests-live-env.yml
+++ b/.github/workflows/run-e2e-tests-live-env.yml
@@ -59,7 +59,7 @@ jobs:
                  "repo-branch": "${{inputs.e2e-test-branch-name}}",
                  "pipeline-name": "low_pass_imputation",
                  "pipeline-version": "1",
-                 "use-cloud-input": "true",
+                 "use-cloud-input": "true"
             }'
 
   report-workflow:

--- a/.github/workflows/run-e2e-tests-live-env.yml
+++ b/.github/workflows/run-e2e-tests-live-env.yml
@@ -53,7 +53,7 @@ jobs:
                  "repo-branch": "${{inputs.e2e-test-branch-name}}",
                  "pipeline-name": "array_imputation",
                  "pipeline-version": "2",
-                 "use-cloud-input": "${{inputs.use-cloud-input}}",
+                 "use-cloud-input": "true",
             }'
 
 #  run-live-env-e2e-test-job-low-pass-imputation:


### PR DESCRIPTION
### Description 

Adapted e2e live env test to use pipeline-agnostic workflow, to now kick off the following tests:
- array_imputation v2 cloud inputs
- low_pass_imputation v1 cloud inputs - duration ~1 hour with call caching up to GlimpsePhase

terra-github-workflows PR: https://github.com/broadinstitute/terra-github-workflows/pull/257

test run: https://github.com/DataBiosphere/terra-scientific-pipelines-service/actions/runs/27038044505

GHA view in this repo:
<img width="1073" height="604" alt="image" src="https://github.com/user-attachments/assets/2143176c-1cb6-441a-b678-6cf5fab51a82" />

Inside one pipeline test workflow:
<img width="832" height="572" alt="image" src="https://github.com/user-attachments/assets/2b276951-f4fb-44f1-93c0-68d0951cedbe" />

GHA view in terra-github-workflows:
<img width="1030" height="536" alt="image" src="https://github.com/user-attachments/assets/6b1db224-8623-4a03-8381-ef3fdbbd760e" />


### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-829

### Jira Ticket

### Checklist (provide links to changes)

- [ ] Updated external documentation (if applicable)
- [ ] Updated internal documentation (if applicable)
- [ ] Planned non patch version bump (if applicable)
- [ ] Made ticket for related CLI PR (if applicable)
- [ ] Made ticket for related UI PR (if applicable)
