### PR TITLE
TSPS-941 force netty librares to 4.2.13.FINAL 

### DIFF
--- a/buildSrc/src/main/groovy/bio.terra.pipelines.java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/bio.terra.pipelines.java-common-conventions.gradle
@@ -44,7 +44,7 @@ dependencies {
 
     testImplementation 'org.hamcrest:hamcrest:2.2'
 
-    implementation 'bio.terra:terra-common-lib:1.1.74-SNAPSHOT'
+    implementation 'bio.terra:terra-common-lib:1.1.76-SNAPSHOT'
     implementation platform('com.google.cloud:libraries-bom:26.33.0') // required for TCL
 
     implementation 'io.swagger.core.v3:swagger-annotations:2.2.12'

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -36,6 +36,20 @@ configurations {
     // resolves "Standard Commons Logging discovery in action with spring-jcl: please remove commons-logging.jar from classpath in order to avoid potential conflicts"
     configureEach {
         exclude group: 'commons-logging', module: 'commons-logging'
+
+        // Spring Boot BOM constrains io.netty to 4.1.x (via io.spring.dependency-management's
+        // VersionConfiguringAction). Because that rule fires during resolution — after ext properties
+        // and BOM imports are already processed — the only reliable override is a resolutionStrategy
+        // rule registered *after* the plugin's own configureEach action (which was registered at
+        // plugin-application time, before this build script runs).
+        resolutionStrategy.eachDependency { DependencyResolveDetails details ->
+            // Only override core Netty 4.x modules — netty-tcnative-boringssl-static and similar
+            // artifacts use a separate versioning scheme (2.x.y.Final) and must not be touched.
+            if (details.requested.group == 'io.netty' && details.requested.version?.startsWith('4.')) {
+                details.useVersion '4.2.13.Final'
+                details.because 'Upgrade Netty to 4.2.x as required by terra-common-lib/stairway-azure'
+            }
+        }
     }
 }
 


### PR DESCRIPTION


### Description 

Because of this [CVE](https://nvd.nist.gov/vuln/detail/CVE-2026-42587) we need to update our netty dependencies.  I don't think we actually use these libraries as they seem to coming from stairway-azure but it almost certain be much harder to get rid of that.  That being said this fix is pretty gross and came after the robot thought for a long long time

output from depedency tree
```
|    +--- bio.terra:stairway-azure:1.1.74-SNAPSHOT
|    |    +--- org.slf4j:slf4j-api:2.0.13 -> 2.0.12
|    |    +--- org.apache.commons:commons-lang3:3.20.0 -> 3.17.0
|    |    +--- com.azure:azure-messaging-servicebus:7.17.18
|    |    |    +--- com.azure:azure-core:1.58.0
|    |    |    |    +--- com.azure:azure-json:1.5.1
|    |    |    |    +--- com.azure:azure-xml:1.2.1
|    |    |    |    +--- com.fasterxml.jackson.core:jackson-annotations:2.18.6 -> 2.21
|    |    |    |    +--- com.fasterxml.jackson.core:jackson-core:2.18.6 -> 2.21.2 (*)
|    |    |    |    +--- com.fasterxml.jackson.core:jackson-databind:2.18.6 -> 2.21.2 (*)
|    |    |    |    +--- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.18.6 -> 2.21.2 (*)
|    |    |    |    +--- org.slf4j:slf4j-api:1.7.36 -> 2.0.12
|    |    |    |    \--- io.projectreactor:reactor-core:3.7.17 -> 3.7.18
|    |    |    |         \--- org.reactivestreams:reactive-streams:1.0.4
|    |    |    +--- com.azure:azure-xml:1.2.1
|    |    |    +--- com.azure:azure-core-amqp:2.11.4
|    |    |    |    +--- com.azure:azure-core:1.58.0 (*)
|    |    |    |    +--- com.microsoft.azure:qpid-proton-j-extensions:1.2.6
|    |    |    |    |    +--- org.apache.qpid:proton-j:0.34.1
|    |    |    |    |    \--- org.slf4j:slf4j-api:1.7.36 -> 2.0.12
|    |    |    |    \--- org.apache.qpid:proton-j:0.34.1
|    |    |    \--- com.azure:azure-core-http-netty:1.16.4
|    |    |         +--- com.azure:azure-core:1.58.0 (*)
|    |    |         +--- io.netty:netty-handler:4.1.132.Final -> 4.2.13.Final (*)
|    |    |         +--- io.netty:netty-handler-proxy:4.1.132.Final -> 4.2.13.Final
|    |    |         |    +--- io.netty:netty-common:4.2.13.Final
|    |    |         |    +--- io.netty:netty-buffer:4.2.13.Final (*)
|    |    |         |    +--- io.netty:netty-transport:4.2.13.Final (*)
|    |    |         |    +--- io.netty:netty-codec-base:4.2.13.Final (*)
|    |    |         |    +--- io.netty:netty-codec-socks:4.2.13.Final
|    |    |         |    |    +--- io.netty:netty-common:4.2.13.Final
|    |    |         |    |    +--- io.netty:netty-buffer:4.2.13.Final (*)
|    |    |         |    |    +--- io.netty:netty-transport:4.2.13.Final (*)
|    |    |         |    |    \--- io.netty:netty-codec-base:4.2.13.Final (*)
|    |    |         |    +--- io.netty:netty-codec-http:4.2.13.Final (*)
|    |    |         |    \--- io.netty:netty-handler:4.2.13.Final (*)
|    |    |         +--- io.netty:netty-buffer:4.1.132.Final -> 4.2.13.Final (*)
|    |    |         +--- io.netty:netty-codec:4.1.132.Final -> 4.2.13.Final (*)
|    |    |         +--- io.netty:netty-codec-http:4.1.132.Final -> 4.2.13.Final (*)
|    |    |         +--- io.netty:netty-codec-http2:4.1.132.Final -> 4.2.13.Final (*)
|    |    |         +--- io.netty:netty-transport-native-unix-common:4.1.132.Final -> 4.2.13.Final (*)
|    |    |         +--- io.netty:netty-transport-native-epoll:4.1.132.Final -> 4.2.13.Final
|    |    |         |    +--- io.netty:netty-common:4.2.13.Final
|    |    |         |    +--- io.netty:netty-buffer:4.2.13.Final (*)
|    |    |         |    +--- io.netty:netty-transport:4.2.13.Final (*)
|    |    |         |    +--- io.netty:netty-transport-native-unix-common:4.2.13.Final (*)
|    |    |         |    \--- io.netty:netty-transport-classes-epoll:4.2.13.Final (*)
|    |    |         +--- io.netty:netty-transport-native-kqueue:4.1.132.Final -> 4.2.13.Final
|    |    |         |    +--- io.netty:netty-common:4.2.13.Final
|    |    |         |    +--- io.netty:netty-buffer:4.2.13.Final (*)
|    |    |         |    +--- io.netty:netty-transport:4.2.13.Final (*)
|    |    |         |    +--- io.netty:netty-transport-native-unix-common:4.2.13.Final (*)
|    |    |         |    \--- io.netty:netty-transport-classes-kqueue:4.2.13.Final
|    |    |         |         +--- io.netty:netty-common:4.2.13.Final
|    |    |         |         +--- io.netty:netty-buffer:4.2.13.Final (*)
|    |    |         |         +--- io.netty:netty-transport:4.2.13.Final (*)
|    |    |         |         \--- io.netty:netty-transport-native-unix-common:4.2.13.Final (*)
|    |    |         +--- io.netty:netty-tcnative-boringssl-static:2.0.75.Final
|    |    |         |    \--- io.netty:netty-tcnative-classes:2.0.75.Final
|    |    |         +--- io.projectreactor.netty:reactor-netty-http:1.2.16 -> 1.2.17
|    |    |         |    +--- io.netty:netty-codec-http:4.1.132.Final -> 4.2.13.Final (*)
|    |    |         |    +--- io.netty:netty-codec-http2:4.1.132.Final -> 4.2.13.Final (*)
|    |    |         |    +--- io.netty:netty-resolver-dns:4.1.132.Final -> 4.2.13.Final
|    |    |         |    |    +--- io.netty:netty-common:4.2.13.Final
|    |    |         |    |    +--- io.netty:netty-buffer:4.2.13.Final (*)
|    |    |         |    |    +--- io.netty:netty-resolver:4.2.13.Final (*)
|    |    |         |    |    +--- io.netty:netty-transport:4.2.13.Final (*)
|    |    |         |    |    +--- io.netty:netty-codec-base:4.2.13.Final (*)
|    |    |         |    |    +--- io.netty:netty-codec-dns:4.2.13.Final
|    |    |         |    |    |    +--- io.netty:netty-common:4.2.13.Final
|    |    |         |    |    |    +--- io.netty:netty-buffer:4.2.13.Final (*)
|    |    |         |    |    |    +--- io.netty:netty-transport:4.2.13.Final (*)
|    |    |         |    |    |    \--- io.netty:netty-codec-base:4.2.13.
```

### Jira Ticket

https://broadworkbench.atlassian.net/browse/TSPS-941

### Checklist (provide links to changes)

- [ ] Updated external documentation (if applicable)
- [ ] Updated internal documentation (if applicable)
- [ ] Planned non patch version bump (if applicable)
- [ ] Made ticket for related CLI PR (if applicable)
- [ ] Made ticket for related UI PR (if applicable)
