### PR TITLE
TSPS-809 Update jib to 3.5.3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,9 +19,11 @@ updates:
         update-types:
           - "minor"
           - "patch"
-      build-tools:
-        patterns:
-          - "*"
+    ignore:
+      - dependency-name: "com.fasterxml.jackson.core:*"
+        versions: [ "> 2.17.3" ] # Keeps swagger-generator safe
+      - dependency-name: "org.apache.commons:commons-lang3"
+        versions: [ "> 3.20.0" ] # Preserves Jib vs SourceClear balance
 
   # GitHub Actions
   - package-ecosystem: "github-actions"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,9 @@ updates:
         update-types:
           - "minor"
           - "patch"
+      build-tools:
+        patterns:
+          - "*"
 
   # GitHub Actions
   - package-ecosystem: "github-actions"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+See [AGENTS.md](AGENTS.md) for architecture, conventions, and guidance. Also see [README.md](README.md) for setup and commands.

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,27 +1,38 @@
 plugins {
     id 'groovy-gradle-plugin'
 }
-
 repositories {
     gradlePluginPortal()
+    mavenCentral()
 }
 
 dependencies {
+    // core binary wrappers needed by your precompiled convention scripts
     implementation 'io.spring.dependency-management:io.spring.dependency-management.gradle.plugin:1.1.7'
     implementation 'org.springframework.boot:spring-boot-gradle-plugin:3.5.14'
     implementation 'com.diffplug.spotless:spotless-plugin-gradle:8.6.0'
     implementation 'com.felipefzdz.gradle.shellcheck:shellcheck:1.4.6'
-    implementation 'com.google.cloud.tools.jib:com.google.cloud.tools.jib.gradle.plugin:3.5.3'
+    implementation 'com.google.cloud.tools.jib:com.google.cloud.tools.jib.gradle.plugin:3.4.4'
     implementation 'com.srcclr.gradle:com.srcclr.gradle.gradle.plugin:3.1.12'
     implementation 'de.undercouch.download:de.undercouch.download.gradle.plugin:5.7.0'
     implementation 'org.hidetake.swagger.generator:org.hidetake.swagger.generator.gradle.plugin:2.19.1'
     implementation 'org.sonarqube:org.sonarqube.gradle.plugin:5.1.0.4882'
-    // The following are required due to dependency conflicts between jib and srcclr. Removing them will cause jib to fail.
-    implementation 'org.apache.commons:commons-lang3:3.20.0'
-    implementation 'org.apache.commons:commons-compress:1.21'
-    // Jackson 2.18+ changed JsonProperty.isRequired() from OptBoolean -> boolean, breaking swagger-generator and other plugins.
-    // Pin to 2.17.x to retain the OptBoolean signature expected by those plugins.
-    implementation 'com.fasterxml.jackson.core:jackson-core:2.17.3'
-    implementation 'com.fasterxml.jackson.core:jackson-annotations:2.17.3'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.3'
+
+    // lock conflicting transient versions across these plugins
+    constraints {
+        // Keeps Jib from failing over old SourceClear transitive downgrades
+        implementation('org.apache.commons:commons-lang3:3.20.0') {
+            because 'Required balance version to satisfy Jib and SourceClear'
+        }
+        implementation('org.apache.commons:commons-compress:1.21') {
+            because 'Required alongside commons-lang3 upgrade'
+        }
+
+        // Retains the old OptBoolean signature expected by swagger-generator
+        implementation('com.fasterxml.jackson.core:jackson-core:2.17.3') {
+            because 'Jackson 2.18+ breaks swagger-generator due to OptBoolean signature changes'
+        }
+        implementation('com.fasterxml.jackson.core:jackson-annotations:2.17.3')
+        implementation('com.fasterxml.jackson.core:jackson-databind:2.17.3')
+    }
 }

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -27,9 +27,14 @@ dependencies {
             because 'Required alongside commons-lang3 upgrade'
         }
 
-        // retains the old OptBoolean signature expected by swagger-generator
+        // Pin Jackson to 2.17.x for two independent reasons on the plugin classpath:
+        //  1. Jib 3.5.3 calls NumberInput.parseBigDecimal(String, boolean), which breaks on the
+        //     2.21.x that Spring Boot pulls in (NoSuchMethodError at jibDockerBuild time).
+        //  2. swagger-generator (swagger-codegen-cli 3.0.47) breaks on Jackson 2.18+ due to
+        //     OptBoolean signature changes.
+        // Revisit if Jib gains Jackson 2.18+ support; bumping swagger-codegen-cli alone is not enough.
         implementation('com.fasterxml.jackson.core:jackson-core:2.17.3') {
-            because 'Jackson 2.18+ breaks swagger-generator due to OptBoolean signature changes'
+            because 'Jib 3.5.3 and swagger-codegen-cli 3.0.47 both require Jackson <= 2.17.x'
         }
         implementation('com.fasterxml.jackson.core:jackson-annotations:2.17.3')
         implementation('com.fasterxml.jackson.core:jackson-databind:2.17.3')

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-gradle-plugin:3.5.14'
     implementation 'com.diffplug.spotless:spotless-plugin-gradle:8.6.0'
     implementation 'com.felipefzdz.gradle.shellcheck:shellcheck:1.4.6'
-    implementation 'com.google.cloud.tools.jib:com.google.cloud.tools.jib.gradle.plugin:3.4.4'
+    implementation 'com.google.cloud.tools.jib:com.google.cloud.tools.jib.gradle.plugin:3.5.3'
     implementation 'com.srcclr.gradle:com.srcclr.gradle.gradle.plugin:3.1.12'
     implementation 'de.undercouch.download:de.undercouch.download.gradle.plugin:5.7.0'
     implementation 'org.hidetake.swagger.generator:org.hidetake.swagger.generator.gradle.plugin:2.19.1'

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,13 +1,12 @@
 plugins {
     id 'groovy-gradle-plugin'
 }
+
 repositories {
     gradlePluginPortal()
-    mavenCentral()
 }
 
 dependencies {
-    // core binary wrappers needed by precompiled convention scripts
     implementation 'io.spring.dependency-management:io.spring.dependency-management.gradle.plugin:1.1.7'
     implementation 'org.springframework.boot:spring-boot-gradle-plugin:3.5.14'
     implementation 'com.diffplug.spotless:spotless-plugin-gradle:8.6.0'
@@ -18,7 +17,7 @@ dependencies {
     implementation 'org.hidetake.swagger.generator:org.hidetake.swagger.generator.gradle.plugin:2.19.1'
     implementation 'org.sonarqube:org.sonarqube.gradle.plugin:5.1.0.4882'
 
-    // lock conflicting transient versions across these plugins
+    // lock conflicting transient versions for the build context if they are pulled in
     constraints {
         // keeps Jib from failing over old SourceClear transitive downgrades
         implementation('org.apache.commons:commons-lang3:3.20.0') {

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -7,12 +7,12 @@ repositories {
 }
 
 dependencies {
-    // core binary wrappers needed by your precompiled convention scripts
+    // core binary wrappers needed by precompiled convention scripts
     implementation 'io.spring.dependency-management:io.spring.dependency-management.gradle.plugin:1.1.7'
     implementation 'org.springframework.boot:spring-boot-gradle-plugin:3.5.14'
     implementation 'com.diffplug.spotless:spotless-plugin-gradle:8.6.0'
     implementation 'com.felipefzdz.gradle.shellcheck:shellcheck:1.4.6'
-    implementation 'com.google.cloud.tools.jib:com.google.cloud.tools.jib.gradle.plugin:3.4.4'
+    implementation 'com.google.cloud.tools.jib:com.google.cloud.tools.jib.gradle.plugin:3.5.3'
     implementation 'com.srcclr.gradle:com.srcclr.gradle.gradle.plugin:3.1.12'
     implementation 'de.undercouch.download:de.undercouch.download.gradle.plugin:5.7.0'
     implementation 'org.hidetake.swagger.generator:org.hidetake.swagger.generator.gradle.plugin:2.19.1'
@@ -20,7 +20,7 @@ dependencies {
 
     // lock conflicting transient versions across these plugins
     constraints {
-        // Keeps Jib from failing over old SourceClear transitive downgrades
+        // keeps Jib from failing over old SourceClear transitive downgrades
         implementation('org.apache.commons:commons-lang3:3.20.0') {
             because 'Required balance version to satisfy Jib and SourceClear'
         }
@@ -28,7 +28,7 @@ dependencies {
             because 'Required alongside commons-lang3 upgrade'
         }
 
-        // Retains the old OptBoolean signature expected by swagger-generator
+        // retains the old OptBoolean signature expected by swagger-generator
         implementation('com.fasterxml.jackson.core:jackson-core:2.17.3') {
             because 'Jackson 2.18+ breaks swagger-generator due to OptBoolean signature changes'
         }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,9 +1,12 @@
 pluginManagement {
     repositories {
         gradlePluginPortal()
+        mavenCentral()
     }
     plugins {
-        id 'com.google.cloud.artifactregistry.gradle-plugin' version '2.2.5'
+        id 'io.spring.dependency-management' version '1.1.7'
+        id 'org.springframework.boot' version '3.5.14'
+        id 'org.hidetake.swagger.generator' version '2.19.1'
     }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,12 +1,9 @@
 pluginManagement {
     repositories {
         gradlePluginPortal()
-        mavenCentral()
     }
     plugins {
-        id 'io.spring.dependency-management' version '1.1.7'
-        id 'org.springframework.boot' version '3.5.14'
-        id 'org.hidetake.swagger.generator' version '2.19.1'
+        id 'com.google.cloud.artifactregistry.gradle-plugin' version '2.2.5'
     }
 }
 


### PR DESCRIPTION
### Description 

We update jib to the latest version (3.5.3).

We also change the way we pin some of the dependencies in the build context to be slightly cleaner in terms of dependency management. This doesn't change the existing behavior in which the service and clients are already using the most up-to-date package dependencies, while pinning the build infrastructure to compatible versions.

e.g. service itself is using up-to-date jackson-core, not pinned version:
<img width="676" height="430" alt="image" src="https://github.com/user-attachments/assets/395bf32d-ebf5-4bab-b2c8-d5a42ae6d942" />

Also adding CLAUDE.md since we're going to be using Claude more.

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-809

### Checklist (provide links to changes)

- [ ] Updated external documentation (if applicable)
- [ ] Updated internal documentation (if applicable)
- [ ] Planned non patch version bump (if applicable)
- [ ] Made ticket for related CLI PR (if applicable)
- [ ] Made ticket for related UI PR (if applicable)
