### PR TITLE
TSPS-923 remove 200 response from /start endpoint

### DIFF
--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -247,12 +247,6 @@ paths:
             schema:
               $ref: '#/components/schemas/StartPipelineRunRequestBody'
       responses:
-        200:
-          description: PipelineRun is complete (succeeded or failed)
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/AsyncPipelineRunResponseV2'
         202:
           description: PipelineRun is running
           content:


### PR DESCRIPTION
### Description 
This was probably an early on copy pasta error.  Its not possible for our `/start` endpoint to return a 200

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-923

### Checklist (provide links to changes)

- [ ] Updated external documentation (if applicable)
- [ ] Updated internal documentation (if applicable)
- [ ] Planned non patch version bump (if applicable)
- [ ] Made ticket for related CLI PR (if applicable)
- [ ] Made ticket for related UI PR (if applicable)
