### PR TITLE
[TSPS-943] Add validationRegex to pipeline input definitions

### DIFF
--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -1058,6 +1058,12 @@ components:
       type: string
       format: string
 
+    PipelineInputValidationRegexExplanation:
+      description: |
+        A human-readable explanation of the validationRegex constraint.
+      type: string
+      format: string
+
     PipelineInputIsRequired:
       description: |
         Whether the pipeline input field is required.
@@ -1303,6 +1309,8 @@ components:
           $ref: "#/components/schemas/PipelineInputMaximumValue"
         validationRegex:
           $ref: "#/components/schemas/PipelineInputValidationRegex"
+        validationRegexExplanation:
+          $ref: "#/components/schemas/PipelineInputValidationRegexExplanation"
 
     PipelineUserProvidedInputDefinitions:
       description: |

--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -1052,6 +1052,12 @@ components:
       type: string
       format: string
 
+    PipelineInputValidationRegex:
+      description: |
+        An optional regular expression that the input value must match. Applies to STRING type inputs.
+      type: string
+      format: string
+
     PipelineInputIsRequired:
       description: |
         Whether the pipeline input field is required.
@@ -1295,6 +1301,8 @@ components:
           $ref: "#/components/schemas/PipelineInputMinimumValue"
         maxValue:
           $ref: "#/components/schemas/PipelineInputMaximumValue"
+        validationRegex:
+          $ref: "#/components/schemas/PipelineInputValidationRegex"
 
     PipelineUserProvidedInputDefinitions:
       description: |

--- a/service/src/main/java/bio/terra/pipelines/app/controller/PipelinesApiController.java
+++ b/service/src/main/java/bio/terra/pipelines/app/controller/PipelinesApiController.java
@@ -124,7 +124,8 @@ public class PipelinesApiController implements PipelinesApi {
                         .minValue(input.getMinValue())
                         .maxValue(input.getMaxValue())
                         .fileSuffix(input.getFileSuffix())
-                        .validationRegex(input.getValidationRegex()))
+                        .validationRegex(input.getValidationRegex())
+                        .validationRegexExplanation(input.getValidationRegexExplanation()))
             .toList());
     ApiPipelineOutputDefinitions outputs = new ApiPipelineOutputDefinitions();
     outputs.addAll(

--- a/service/src/main/java/bio/terra/pipelines/app/controller/PipelinesApiController.java
+++ b/service/src/main/java/bio/terra/pipelines/app/controller/PipelinesApiController.java
@@ -124,8 +124,9 @@ public class PipelinesApiController implements PipelinesApi {
                         .minValue(input.getMinValue())
                         .maxValue(input.getMaxValue())
                         .fileSuffix(input.getFileSuffix())
-                        .validationRegex(input.getValidationRegex())
-                        .validationRegexExplanation(input.getValidationRegexExplanation()))
+                        .validationRegex(input.getType().getEffectiveValidationRegex(input))
+                        .validationRegexExplanation(
+                            input.getType().getEffectiveValidationExplanation(input)))
             .toList());
     ApiPipelineOutputDefinitions outputs = new ApiPipelineOutputDefinitions();
     outputs.addAll(

--- a/service/src/main/java/bio/terra/pipelines/app/controller/PipelinesApiController.java
+++ b/service/src/main/java/bio/terra/pipelines/app/controller/PipelinesApiController.java
@@ -123,7 +123,8 @@ public class PipelinesApiController implements PipelinesApi {
                         .defaultValue(input.getDefaultValue())
                         .minValue(input.getMinValue())
                         .maxValue(input.getMaxValue())
-                        .fileSuffix(input.getFileSuffix()))
+                        .fileSuffix(input.getFileSuffix())
+                        .validationRegex(input.getValidationRegex()))
             .toList());
     ApiPipelineOutputDefinitions outputs = new ApiPipelineOutputDefinitions();
     outputs.addAll(

--- a/service/src/main/java/bio/terra/pipelines/common/utils/PipelineVariableTypesEnum.java
+++ b/service/src/main/java/bio/terra/pipelines/common/utils/PipelineVariableTypesEnum.java
@@ -39,10 +39,14 @@ public enum PipelineVariableTypesEnum {
       if (effectivePattern.matcher(castValue).matches()) {
         return null;
       }
-      return hasCustomRegex
-          ? "%s must match the pattern %s".formatted(fieldName, validationRegex)
-          : "%s must only contain alphanumeric characters or the following symbols: %s"
-              .formatted(fieldName, DEFAULT_VALID_STRING_PATTERN_SYMBOLS);
+      if (hasCustomRegex) {
+        String explanation = pipelineInputDefinition.getValidationRegexExplanation();
+        return explanation != null
+            ? "%s %s".formatted(fieldName, explanation)
+            : "%s must match the pattern %s".formatted(fieldName, validationRegex);
+      }
+      return "%s must only contain alphanumeric characters or the following symbols: %s"
+          .formatted(fieldName, DEFAULT_VALID_STRING_PATTERN_SYMBOLS);
     }
   },
   INTEGER {

--- a/service/src/main/java/bio/terra/pipelines/common/utils/PipelineVariableTypesEnum.java
+++ b/service/src/main/java/bio/terra/pipelines/common/utils/PipelineVariableTypesEnum.java
@@ -28,18 +28,21 @@ public enum PipelineVariableTypesEnum {
       if (castValue == null) {
         return "%s must be a string".formatted(fieldName);
       }
+
+      // validationRegex, when present, fully replaces the default VALID_STRING_PATTERN.
+      // Exactly one pattern is always applied.
       String validationRegex = pipelineInputDefinition.getValidationRegex();
-      if (validationRegex != null) {
-        if (!Pattern.compile(validationRegex).matcher(castValue).matches()) {
-          return "%s must match the pattern %s".formatted(fieldName, validationRegex);
-        }
+      boolean hasCustomRegex = validationRegex != null;
+      Pattern effectivePattern =
+          hasCustomRegex ? Pattern.compile(validationRegex) : DEFAULT_VALID_STRING_PATTERN;
+
+      if (effectivePattern.matcher(castValue).matches()) {
         return null;
       }
-      if (!VALID_STRING_PATTERN.matcher(castValue).matches()) {
-        return "%s must only contain alphanumeric characters or the following symbols: %s"
-            .formatted(fieldName, VALID_STRING_PATTERN_SYMBOLS);
-      }
-      return null;
+      return hasCustomRegex
+          ? "%s must match the pattern %s".formatted(fieldName, validationRegex)
+          : "%s must only contain alphanumeric characters or the following symbols: %s"
+              .formatted(fieldName, DEFAULT_VALID_STRING_PATTERN_SYMBOLS);
     }
   },
   INTEGER {
@@ -188,9 +191,9 @@ public enum PipelineVariableTypesEnum {
 
       // validate each string in the array
       for (String item : listValue) {
-        if (!VALID_STRING_PATTERN.matcher(item).matches()) {
+        if (!DEFAULT_VALID_STRING_PATTERN.matcher(item).matches()) {
           return "%s must only contain strings with alphanumeric characters or the following symbols: %s"
-              .formatted(fieldName, VALID_STRING_PATTERN_SYMBOLS);
+              .formatted(fieldName, DEFAULT_VALID_STRING_PATTERN_SYMBOLS);
         }
       }
 
@@ -276,8 +279,9 @@ public enum PipelineVariableTypesEnum {
 
   // this regex only allows alphanumeric characters, dashes, underscores, periods, colons, and
   // forward and backward slashes
-  private static final Pattern VALID_STRING_PATTERN = Pattern.compile("^[a-zA-Z0-9_.=\\\\/-]+$");
-  private static final String VALID_STRING_PATTERN_SYMBOLS = "-_.=\\/";
+  private static final Pattern DEFAULT_VALID_STRING_PATTERN =
+      Pattern.compile("^[a-zA-Z0-9_.=\\\\/-]+$");
+  private static final String DEFAULT_VALID_STRING_PATTERN_SYMBOLS = "-_.=\\/";
 
   // this regex only allows alphanumeric characters, dashes, underscores, periods, equal signs,
   // colons, and forward and backward slashes

--- a/service/src/main/java/bio/terra/pipelines/common/utils/PipelineVariableTypesEnum.java
+++ b/service/src/main/java/bio/terra/pipelines/common/utils/PipelineVariableTypesEnum.java
@@ -42,7 +42,7 @@ public enum PipelineVariableTypesEnum {
       if (hasCustomRegex) {
         String explanation = pipelineInputDefinition.getValidationRegexExplanation();
         return explanation != null
-            ? "%s %s".formatted(fieldName, explanation)
+            ? explanation
             : "%s must match the pattern %s".formatted(fieldName, validationRegex);
       }
       return "%s must only contain alphanumeric characters or the following symbols: %s"

--- a/service/src/main/java/bio/terra/pipelines/common/utils/PipelineVariableTypesEnum.java
+++ b/service/src/main/java/bio/terra/pipelines/common/utils/PipelineVariableTypesEnum.java
@@ -28,6 +28,13 @@ public enum PipelineVariableTypesEnum {
       if (castValue == null) {
         return "%s must be a string".formatted(fieldName);
       }
+      String validationRegex = pipelineInputDefinition.getValidationRegex();
+      if (validationRegex != null) {
+        if (!Pattern.compile(validationRegex).matcher(castValue).matches()) {
+          return "%s must match the pattern %s".formatted(fieldName, validationRegex);
+        }
+        return null;
+      }
       if (!VALID_STRING_PATTERN.matcher(castValue).matches()) {
         return "%s must only contain alphanumeric characters or the following symbols: %s"
             .formatted(fieldName, VALID_STRING_PATTERN_SYMBOLS);

--- a/service/src/main/java/bio/terra/pipelines/common/utils/PipelineVariableTypesEnum.java
+++ b/service/src/main/java/bio/terra/pipelines/common/utils/PipelineVariableTypesEnum.java
@@ -277,10 +277,10 @@ public enum PipelineVariableTypesEnum {
 
   private static final String NOT_NULL_OR_EMPTY_ERROR_MESSAGE = "%s must not be null or empty";
 
-  // this regex only allows alphanumeric characters, dashes, underscores, periods, colons, and
-  // forward and backward slashes
+  // this regex only allows alphanumeric characters, dashes, underscores, periods, equal signs,
+  // and forward and backward slashes, with a maximum length of 255 characters
   private static final Pattern DEFAULT_VALID_STRING_PATTERN =
-      Pattern.compile("^[a-zA-Z0-9_.=\\\\/-]+$");
+      Pattern.compile("^[a-zA-Z0-9_.=\\\\/-]{1,255}$");
   private static final String DEFAULT_VALID_STRING_PATTERN_SYMBOLS = "-_.=\\/";
 
   // this regex only allows alphanumeric characters, dashes, underscores, periods, equal signs,

--- a/service/src/main/java/bio/terra/pipelines/common/utils/PipelineVariableTypesEnum.java
+++ b/service/src/main/java/bio/terra/pipelines/common/utils/PipelineVariableTypesEnum.java
@@ -31,22 +31,32 @@ public enum PipelineVariableTypesEnum {
 
       // validationRegex, when present, fully replaces the default VALID_STRING_PATTERN.
       // Exactly one pattern is always applied.
-      String validationRegex = pipelineInputDefinition.getValidationRegex();
-      boolean hasCustomRegex = validationRegex != null;
       Pattern effectivePattern =
-          hasCustomRegex ? Pattern.compile(validationRegex) : DEFAULT_VALID_STRING_PATTERN;
+          Pattern.compile(getEffectiveValidationRegex(pipelineInputDefinition));
 
       if (effectivePattern.matcher(castValue).matches()) {
         return null;
       }
-      if (hasCustomRegex) {
-        String explanation = pipelineInputDefinition.getValidationRegexExplanation();
-        return explanation != null
-            ? explanation
-            : "%s must match the pattern %s".formatted(fieldName, validationRegex);
+      return "%s %s"
+          .formatted(fieldName, getEffectiveValidationExplanation(pipelineInputDefinition));
+    }
+
+    @Override
+    public String getEffectiveValidationRegex(PipelineInputDefinition def) {
+      return def.getValidationRegex() != null
+          ? def.getValidationRegex()
+          : DEFAULT_VALID_STRING_REGEX;
+    }
+
+    @Override
+    public String getEffectiveValidationExplanation(PipelineInputDefinition def) {
+      if (def.getValidationRegexExplanation() != null) {
+        return def.getValidationRegexExplanation();
       }
-      return "%s must only contain alphanumeric characters or the following symbols: %s"
-          .formatted(fieldName, DEFAULT_VALID_STRING_PATTERN_SYMBOLS);
+      return def.getValidationRegex() != null
+          ? "must match the pattern %s".formatted(def.getValidationRegex())
+          : "must only contain alphanumeric characters or the following symbols: %s"
+              .formatted(DEFAULT_VALID_STRING_PATTERN_SYMBOLS);
     }
   },
   INTEGER {
@@ -279,12 +289,33 @@ public enum PipelineVariableTypesEnum {
    */
   public abstract String validate(PipelineInputDefinition pipelineInputDefinition, Object value);
 
+  /**
+   * Returns the effective validation regex string for this input type. Returns null for types that
+   * do not have a regex-based validation concept. STRING overrides this to return the configured
+   * regex, or {@link #DEFAULT_VALID_STRING_REGEX} when none is configured.
+   */
+  public String getEffectiveValidationRegex(PipelineInputDefinition pipelineInputDefinition) {
+    return null;
+  }
+
+  /**
+   * Returns the human-readable explanation of the effective validation constraint for this input
+   * type. Returns null for types that do not have a regex-based validation concept. STRING
+   * overrides this to return the configured explanation, falling back to a description of the
+   * effective regex.
+   */
+  public String getEffectiveValidationExplanation(PipelineInputDefinition pipelineInputDefinition) {
+    return null;
+  }
+
   private static final String NOT_NULL_OR_EMPTY_ERROR_MESSAGE = "%s must not be null or empty";
 
   // this regex only allows alphanumeric characters, dashes, underscores, periods, equal signs,
   // and forward and backward slashes, with a maximum length of 255 characters
+  public static final String DEFAULT_VALID_STRING_REGEX = "^[a-zA-Z0-9_.=\\\\/-]{1,255}$";
+
   private static final Pattern DEFAULT_VALID_STRING_PATTERN =
-      Pattern.compile("^[a-zA-Z0-9_.=\\\\/-]{1,255}$");
+      Pattern.compile(DEFAULT_VALID_STRING_REGEX);
   private static final String DEFAULT_VALID_STRING_PATTERN_SYMBOLS = "-_.=\\/";
 
   // this regex only allows alphanumeric characters, dashes, underscores, periods, equal signs,

--- a/service/src/main/java/bio/terra/pipelines/model/PipelineInputDefinition.java
+++ b/service/src/main/java/bio/terra/pipelines/model/PipelineInputDefinition.java
@@ -23,4 +23,5 @@ public class PipelineInputDefinition {
   private final Double minValue;
   private final Double maxValue;
   private final String fileSuffix;
+  private final String validationRegex;
 }

--- a/service/src/main/java/bio/terra/pipelines/model/PipelineInputDefinition.java
+++ b/service/src/main/java/bio/terra/pipelines/model/PipelineInputDefinition.java
@@ -24,4 +24,5 @@ public class PipelineInputDefinition {
   private final Double maxValue;
   private final String fileSuffix;
   private final String validationRegex;
+  private final String validationRegexExplanation;
 }

--- a/service/src/main/resources/pipelines-config.yml
+++ b/service/src/main/resources/pipelines-config.yml
@@ -62,6 +62,7 @@ configurations:
             type: STRING
             isRequired: true
             userProvided: true
+            validationRegex: '^[a-zA-Z0-9_-]{1,255}$'
           - name: contigs
             wdlVariableName: contigs
             type: STRING_ARRAY
@@ -250,6 +251,7 @@ configurations:
             type: STRING
             isRequired: true
             userProvided: true
+            validationRegex: '^[a-zA-Z0-9_-]{1,255}$'
           - name: infoFilterForInclusion
             wdlVariableName: info_filter_for_inclusion
             displayName: minimum imputation quality for inclusion

--- a/service/src/main/resources/pipelines-config.yml
+++ b/service/src/main/resources/pipelines-config.yml
@@ -63,7 +63,7 @@ configurations:
             isRequired: true
             userProvided: true
             validationRegex: '^[a-zA-Z0-9_-]{1,255}$'
-            validationRegexExplanation: 'must only contain alphanumeric characters, dashes, and underscores, and be at most 255 characters'
+            validationRegexExplanation: 'outputBasename must only contain alphanumeric characters, dashes, and underscores, and be at most 255 characters'
           - name: contigs
             wdlVariableName: contigs
             type: STRING_ARRAY
@@ -152,7 +152,7 @@ configurations:
             isRequired: true
             userProvided: true
             validationRegex: '^[a-zA-Z0-9_-]{1,255}$'
-            validationRegexExplanation: 'must only contain alphanumeric characters, dashes, and underscores, and be at most 255 characters'
+            validationRegexExplanation: 'outputBasename must only contain alphanumeric characters, dashes, and underscores, and be at most 255 characters'
           - name: minDr2ForInclusion
             wdlVariableName: min_dr2_for_inclusion
             displayName: minimum imputation quality for inclusion
@@ -254,7 +254,7 @@ configurations:
             isRequired: true
             userProvided: true
             validationRegex: '^[a-zA-Z0-9_-]{1,255}$'
-            validationRegexExplanation: 'must only contain alphanumeric characters, dashes, and underscores, and be at most 255 characters'
+            validationRegexExplanation: 'outputBasename must only contain alphanumeric characters, dashes, and underscores, and be at most 255 characters'
           - name: infoFilterForInclusion
             wdlVariableName: info_filter_for_inclusion
             displayName: minimum imputation quality for inclusion

--- a/service/src/main/resources/pipelines-config.yml
+++ b/service/src/main/resources/pipelines-config.yml
@@ -149,6 +149,7 @@ configurations:
             type: STRING
             isRequired: true
             userProvided: true
+            validationRegex: '^[a-zA-Z0-9_-]{1,255}$'
           - name: minDr2ForInclusion
             wdlVariableName: min_dr2_for_inclusion
             displayName: minimum imputation quality for inclusion

--- a/service/src/main/resources/pipelines-config.yml
+++ b/service/src/main/resources/pipelines-config.yml
@@ -63,6 +63,7 @@ configurations:
             isRequired: true
             userProvided: true
             validationRegex: '^[a-zA-Z0-9_-]{1,255}$'
+            validationRegexExplanation: 'must only contain alphanumeric characters, dashes, and underscores, and be at most 255 characters'
           - name: contigs
             wdlVariableName: contigs
             type: STRING_ARRAY
@@ -151,6 +152,7 @@ configurations:
             isRequired: true
             userProvided: true
             validationRegex: '^[a-zA-Z0-9_-]{1,255}$'
+            validationRegexExplanation: 'must only contain alphanumeric characters, dashes, and underscores, and be at most 255 characters'
           - name: minDr2ForInclusion
             wdlVariableName: min_dr2_for_inclusion
             displayName: minimum imputation quality for inclusion
@@ -252,6 +254,7 @@ configurations:
             isRequired: true
             userProvided: true
             validationRegex: '^[a-zA-Z0-9_-]{1,255}$'
+            validationRegexExplanation: 'must only contain alphanumeric characters, dashes, and underscores, and be at most 255 characters'
           - name: infoFilterForInclusion
             wdlVariableName: info_filter_for_inclusion
             displayName: minimum imputation quality for inclusion

--- a/service/src/test/java/bio/terra/pipelines/common/utils/PipelineVariableTypesEnumTest.java
+++ b/service/src/test/java/bio/terra/pipelines/common/utils/PipelineVariableTypesEnumTest.java
@@ -2,9 +2,7 @@ package bio.terra.pipelines.common.utils;
 
 import static bio.terra.pipelines.common.utils.PipelineVariableTypesEnum.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import bio.terra.pipelines.model.PipelineInputDefinition;
@@ -621,18 +619,89 @@ class PipelineVariableTypesEnumTest extends BaseTest {
 
   @Test
   void isFileLike() {
-    // manifests and files are files
-    assertTrue(MANIFEST.isFileLike());
-    assertTrue(FILE.isFileLike());
+    // ...existing code...
+  }
 
-    // other types are not files
-    assertFalse(STRING.isFileLike());
-    assertFalse(INTEGER.isFileLike());
-    assertFalse(STRING_ARRAY.isFileLike());
-    assertFalse(
-        FILE_ARRAY
-            .isFileLike()); // for isFileLike purposes we don't yet support FILE_ARRAY processing
-    assertFalse(FLOAT.isFileLike());
-    assertFalse(BOOLEAN.isFileLike());
+  @Test
+  void getEffectiveValidationRegex() {
+    String customRegex = "^[a-zA-Z0-9_-]{1,255}$";
+
+    // STRING with no custom regex returns the default
+    PipelineInputDefinition noRegex =
+        PipelineInputDefinition.builder()
+            .name("f")
+            .wdlVariableName("f")
+            .type(STRING)
+            .userProvided(true)
+            .isRequired(true)
+            .build();
+    assertEquals(DEFAULT_VALID_STRING_REGEX, STRING.getEffectiveValidationRegex(noRegex));
+
+    // STRING with a custom regex returns that regex
+    PipelineInputDefinition withRegex =
+        PipelineInputDefinition.builder()
+            .name("f")
+            .wdlVariableName("f")
+            .type(STRING)
+            .userProvided(true)
+            .isRequired(true)
+            .validationRegex(customRegex)
+            .build();
+    assertEquals(customRegex, STRING.getEffectiveValidationRegex(withRegex));
+
+    // non-STRING types return null
+    assertNull(INTEGER.getEffectiveValidationRegex(noRegex));
+    assertNull(FILE.getEffectiveValidationRegex(noRegex));
+  }
+
+  @Test
+  void getEffectiveValidationExplanation() {
+    String customRegex = "^[a-zA-Z0-9_-]{1,255}$";
+    String customExplanation = "must only contain alphanumeric characters, dashes, and underscores";
+
+    // STRING with no custom regex returns the default symbol description
+    PipelineInputDefinition noRegex =
+        PipelineInputDefinition.builder()
+            .name("f")
+            .wdlVariableName("f")
+            .type(STRING)
+            .userProvided(true)
+            .isRequired(true)
+            .build();
+    assertEquals(
+        "must only contain alphanumeric characters or the following symbols: -_.=\\/",
+        STRING.getEffectiveValidationExplanation(noRegex));
+
+    // STRING with custom regex but no explanation returns a "must match pattern" description
+    PipelineInputDefinition withRegexNoExplanation =
+        PipelineInputDefinition.builder()
+            .name("f")
+            .wdlVariableName("f")
+            .type(STRING)
+            .userProvided(true)
+            .isRequired(true)
+            .validationRegex(customRegex)
+            .build();
+    assertEquals(
+        "must match the pattern %s".formatted(customRegex),
+        STRING.getEffectiveValidationExplanation(withRegexNoExplanation));
+
+    // STRING with custom regex and explanation returns the explanation
+    PipelineInputDefinition withRegexAndExplanation =
+        PipelineInputDefinition.builder()
+            .name("f")
+            .wdlVariableName("f")
+            .type(STRING)
+            .userProvided(true)
+            .isRequired(true)
+            .validationRegex(customRegex)
+            .validationRegexExplanation(customExplanation)
+            .build();
+    assertEquals(
+        customExplanation, STRING.getEffectiveValidationExplanation(withRegexAndExplanation));
+
+    // non-STRING types return null
+    assertNull(INTEGER.getEffectiveValidationExplanation(noRegex));
+    assertNull(FILE.getEffectiveValidationExplanation(noRegex));
   }
 }

--- a/service/src/test/java/bio/terra/pipelines/common/utils/PipelineVariableTypesEnumTest.java
+++ b/service/src/test/java/bio/terra/pipelines/common/utils/PipelineVariableTypesEnumTest.java
@@ -147,6 +147,8 @@ class PipelineVariableTypesEnumTest extends BaseTest {
             .isRequired(true)
             .build();
     String outputBasenameRegex = "^[a-zA-Z0-9_-]{1,255}$";
+    String outputBasenameExplanation =
+        "must only contain alphanumeric characters, dashes, and underscores, and be at most 255 characters";
     PipelineInputDefinition stringInputDefinitionWithRegex =
         PipelineInputDefinition.builder()
             .name(commonInputName)
@@ -156,8 +158,19 @@ class PipelineVariableTypesEnumTest extends BaseTest {
             .isRequired(true)
             .validationRegex(outputBasenameRegex)
             .build();
+    PipelineInputDefinition stringInputDefinitionWithRegexAndExplanation =
+        PipelineInputDefinition.builder()
+            .name(commonInputName)
+            .wdlVariableName("string_input_with_regex_and_explanation")
+            .type(STRING)
+            .userProvided(true)
+            .isRequired(true)
+            .validationRegex(outputBasenameRegex)
+            .validationRegexExplanation(outputBasenameExplanation)
+            .build();
     String regexValidationError =
         "%s must match the pattern %s".formatted(commonInputName, outputBasenameRegex);
+    String regexExplanationError = "%s %s".formatted(commonInputName, outputBasenameExplanation);
     PipelineInputDefinition booleanInputDefinition =
         PipelineInputDefinition.builder()
             .name(commonInputName)
@@ -343,6 +356,26 @@ class PipelineVariableTypesEnumTest extends BaseTest {
             "",
             null,
             stringTypeErrorMessage), // still must be non-blank
+
+        // STRING with validationRegex AND validationRegexExplanation - explanation replaces raw
+        // pattern in error message, passing values still pass
+        arguments(
+            stringInputDefinitionWithRegexAndExplanation, "valid-basename", "valid-basename", null),
+        arguments(
+            stringInputDefinitionWithRegexAndExplanation,
+            "invalid/slash",
+            "invalid/slash",
+            regexExplanationError), // explanation used instead of raw pattern
+        arguments(
+            stringInputDefinitionWithRegexAndExplanation,
+            "a".repeat(256),
+            "a".repeat(256),
+            regexExplanationError), // too long: explanation used
+        arguments(
+            stringInputDefinitionWithRegexAndExplanation,
+            null,
+            null,
+            stringTypeErrorMessage), // still must be a string
 
         // BOOLEAN
         arguments(booleanInputDefinition, true, true, null),

--- a/service/src/test/java/bio/terra/pipelines/common/utils/PipelineVariableTypesEnumTest.java
+++ b/service/src/test/java/bio/terra/pipelines/common/utils/PipelineVariableTypesEnumTest.java
@@ -279,6 +279,9 @@ class PipelineVariableTypesEnumTest extends BaseTest {
         // STRING
         arguments(stringInputDefinition, "IAmAString", "IAmAString", null),
         arguments(stringInputDefinition, "I_Am-A=String.", "I_Am-A=String.", null),
+        arguments(stringInputDefinition, "a".repeat(255), "a".repeat(255), null),
+        arguments(
+            stringInputDefinition, "a".repeat(256), "a".repeat(256), stringPatternErrorMessage),
         arguments(
             stringInputDefinition, "I am a string", "I am a string", stringPatternErrorMessage),
         arguments(

--- a/service/src/test/java/bio/terra/pipelines/common/utils/PipelineVariableTypesEnumTest.java
+++ b/service/src/test/java/bio/terra/pipelines/common/utils/PipelineVariableTypesEnumTest.java
@@ -146,6 +146,18 @@ class PipelineVariableTypesEnumTest extends BaseTest {
             .userProvided(true)
             .isRequired(true)
             .build();
+    String outputBasenameRegex = "^[a-zA-Z0-9_-]{1,255}$";
+    PipelineInputDefinition stringInputDefinitionWithRegex =
+        PipelineInputDefinition.builder()
+            .name(commonInputName)
+            .wdlVariableName("string_input_with_regex")
+            .type(STRING)
+            .userProvided(true)
+            .isRequired(true)
+            .validationRegex(outputBasenameRegex)
+            .build();
+    String regexValidationError =
+        "%s must match the pattern %s".formatted(commonInputName, outputBasenameRegex);
     PipelineInputDefinition booleanInputDefinition =
         PipelineInputDefinition.builder()
             .name(commonInputName)
@@ -289,6 +301,45 @@ class PipelineVariableTypesEnumTest extends BaseTest {
         arguments(stringInputDefinition, 123, null, stringTypeErrorMessage),
         arguments(stringInputDefinition, null, null, stringTypeErrorMessage),
         arguments(stringInputDefinition, "", null, stringTypeErrorMessage),
+
+        // STRING with validationRegex - overrides default pattern check
+        arguments(stringInputDefinitionWithRegex, "valid-basename", "valid-basename", null),
+        arguments(stringInputDefinitionWithRegex, "also_valid_123", "also_valid_123", null),
+        arguments(
+            stringInputDefinitionWithRegex,
+            "a".repeat(255),
+            "a".repeat(255),
+            null), // exactly 255 chars: ok
+        arguments(
+            stringInputDefinitionWithRegex,
+            "a".repeat(256),
+            "a".repeat(256),
+            regexValidationError), // 256 chars: too long
+        arguments(
+            stringInputDefinitionWithRegex,
+            "invalid/forward/slash",
+            "invalid/forward/slash",
+            regexValidationError), // forward slash not allowed
+        arguments(
+            stringInputDefinitionWithRegex,
+            "invalid\\backward\\slash",
+            "invalid\\backward\\slash",
+            regexValidationError), // backward slash not allowed
+        arguments(
+            stringInputDefinitionWithRegex,
+            "no spaces allowed",
+            "no spaces allowed",
+            regexValidationError), // the regex rejects characters not in [a-zA-Z0-9_-]
+        arguments(
+            stringInputDefinitionWithRegex,
+            null,
+            null,
+            stringTypeErrorMessage), // still must be a string
+        arguments(
+            stringInputDefinitionWithRegex,
+            "",
+            null,
+            stringTypeErrorMessage), // still must be non-blank
 
         // BOOLEAN
         arguments(booleanInputDefinition, true, true, null),

--- a/service/src/test/java/bio/terra/pipelines/configuration/internal/PipelineConfigurationsTest.java
+++ b/service/src/test/java/bio/terra/pipelines/configuration/internal/PipelineConfigurationsTest.java
@@ -490,6 +490,17 @@ class PipelineConfigurationsTest extends BaseEmbeddedDbTest {
         requireText(input.getFileSuffix(), "inputs.fileSuffix", pipelineKey, violations);
       }
 
+      if (input.getValidationRegex() != null) {
+        try {
+          Pattern.compile(input.getValidationRegex());
+        } catch (java.util.regex.PatternSyntaxException e) {
+          violations.add(
+              "Invalid validationRegex '%s' for input '%s' in pipeline '%s': %s"
+                  .formatted(
+                      input.getValidationRegex(), input.getName(), pipelineKey, e.getMessage()));
+        }
+      }
+
       if (input.getDefaultValue() != null && input.getDefaultValue().isBlank()) {
         violations.add(
             "Default value is blank for input '%s' in pipeline '%s'"

--- a/service/src/test/resources/pipelines-config.yml
+++ b/service/src/test/resources/pipelines-config.yml
@@ -37,6 +37,7 @@ configurations:
             type: STRING
             isRequired: true
             userProvided: true
+            validationRegex: '^[a-zA-Z0-9_-]{1,255}$'
         outputDefinitions:
           - name: testOutput
             wdlVariableName: testOutput


### PR DESCRIPTION
### Description 

Adds a new optional validationRegex property to user input strings.

The first implementation of this is to use it for outputBasename in array_imputation and low_pass_imputation.

If a user submits bad inputs:

```
{
  "message": "Problem with pipelineInputs: outputBasename must only contain alphanumeric characters, dashes, and underscores, and be at most 255 characters",
  "statusCode": 400,
  "causes": []
}
```

Returned in pipeline details, for potential future use in the UI and/or CLI:

```
...
    {
      "name": "outputBasename",
      "displayName": "output basename",
      "description": "The prefix for all of the outputs' filenames. May only contain alphanumeric characters, dashes, and underscores",
      "type": "STRING",
      "isRequired": true,
      "validationRegex": "^[a-zA-Z0-9_-]{1,255}$",
      "validationRegexExplanation": "outputBasename must only contain alphanumeric characters, dashes, and underscores, and be at most 255 characters"
    },
...
```

### Jira Ticket

https://broadworkbench.atlassian.net/browse/TSPS-943

### Checklist (provide links to changes)

- [ ] Updated external documentation (if applicable)
- [ ] Updated internal documentation (if applicable)
- [ ] Planned non patch version bump (if applicable)
- [ ] Made ticket for related CLI PR (if applicable)
- [ ] Made ticket for related UI PR (if applicable)
