### PR TITLE
[TSPS-984] Upgrade netty version to 4.2.15.Final

### DIFF
--- a/buildSrc/src/main/groovy/bio.terra.pipelines.java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/bio.terra.pipelines.java-common-conventions.gradle
@@ -44,7 +44,7 @@ dependencies {
 
     testImplementation 'org.hamcrest:hamcrest:2.2'
 
-    implementation 'bio.terra:terra-common-lib:1.1.76-SNAPSHOT'
+    implementation 'bio.terra:terra-common-lib:1.1.77-SNAPSHOT'
     implementation platform('com.google.cloud:libraries-bom:26.33.0') // required for TCL
 
     implementation 'io.swagger.core.v3:swagger-annotations:2.2.12'

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -47,7 +47,7 @@ configurations {
             // artifacts use a separate versioning scheme (2.x.y.Final) and must not be touched.
             if (details.requested.group == 'io.netty' && details.requested.version?.startsWith('4.')) {
                 details.useVersion '4.2.15.Final'
-                details.because 'Upgrade Netty to 4.2.15 for CVE-2026-45416 (previously 4.2.x for terra-common-lib/stairway-azure)'
+                details.because 'Upgrade Netty to 4.2.15 for CVE-2026-45416'
             }
         }
     }

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -46,8 +46,8 @@ configurations {
             // Only override core Netty 4.x modules — netty-tcnative-boringssl-static and similar
             // artifacts use a separate versioning scheme (2.x.y.Final) and must not be touched.
             if (details.requested.group == 'io.netty' && details.requested.version?.startsWith('4.')) {
-                details.useVersion '4.2.13.Final'
-                details.because 'Upgrade Netty to 4.2.x as required by terra-common-lib/stairway-azure'
+                details.useVersion '4.2.15.Final'
+                details.because 'Upgrade Netty to 4.2.15 for CVE-2026-45416 (previously 4.2.x for terra-common-lib/stairway-azure)'
             }
         }
     }


### PR DESCRIPTION
### Description 

Fixes [CVE-2026-45416](https://nvd.nist.gov/vuln/detail/CVE-2026-45416). Associated TCL PR - https://github.com/DataBiosphere/terra-common-lib/pull/291

```
 % ./gradlew :service:dependencies --configuration runtimeClasspath | grep netty
|    |         \--- software.amazon.awssdk:netty-nio-client:2.42.22
|    |              +--- io.netty:netty-codec-http:4.1.130.Final -> 4.2.15.Final
|    |              |    +--- io.netty:netty-common:4.2.15.Final
|    |              |    +--- io.netty:netty-buffer:4.2.15.Final
|    |              |    |    \--- io.netty:netty-common:4.2.15.Final
|    |              |    +--- io.netty:netty-transport:4.2.15.Final
|    |              |    |    +--- io.netty:netty-common:4.2.15.Final
|    |              |    |    +--- io.netty:netty-buffer:4.2.15.Final (*)
|    |              |    |    \--- io.netty:netty-resolver:4.2.15.Final
|    |              |    |         \--- io.netty:netty-common:4.2.15.Final
|    |              |    +--- io.netty:netty-codec-base:4.2.15.Final
|    |              |    |    +--- io.netty:netty-common:4.2.15.Final
|    |              |    |    +--- io.netty:netty-buffer:4.2.15.Final (*)
|    |              |    |    \--- io.netty:netty-transport:4.2.15.Final (*)
|    |              |    +--- io.netty:netty-codec-compression:4.2.15.Final
|    |              |    |    +--- io.netty:netty-common:4.2.15.Final
|    |              |    |    +--- io.netty:netty-buffer:4.2.15.Final (*)
|    |              |    |    +--- io.netty:netty-transport:4.2.15.Final (*)
|    |              |    |    \--- io.netty:netty-codec-base:4.2.15.Final (*)
|    |              |    \--- io.netty:netty-handler:4.2.15.Final
|    |              |         +--- io.netty:netty-common:4.2.15.Final
|    |              |         +--- io.netty:netty-resolver:4.2.15.Final (*)
|    |              |         +--- io.netty:netty-buffer:4.2.15.Final (*)
|    |              |         +--- io.netty:netty-transport:4.2.15.Final (*)
|    |              |         +--- io.netty:netty-transport-native-unix-common:4.2.15.Final
|    |              |         |    +--- io.netty:netty-common:4.2.15.Final
|    |              |         |    +--- io.netty:netty-buffer:4.2.15.Final (*)
|    |              |         |    \--- io.netty:netty-transport:4.2.15.Final (*)
|    |              |         \--- io.netty:netty-codec-base:4.2.15.Final (*)
|    |              +--- io.netty:netty-codec-http2:4.1.130.Final -> 4.2.15.Final
|    |              |    +--- io.netty:netty-common:4.2.15.Final
|    |              |    +--- io.netty:netty-buffer:4.2.15.Final (*)
|    |              |    +--- io.netty:netty-transport:4.2.15.Final (*)
|    |              |    +--- io.netty:netty-codec-base:4.2.15.Final (*)
|    |              |    +--- io.netty:netty-handler:4.2.15.Final (*)
|    |              |    \--- io.netty:netty-codec-http:4.2.15.Final (*)
|    |              +--- io.netty:netty-codec:4.1.130.Final -> 4.2.15.Final
|    |              |    +--- io.netty:netty-common:4.2.15.Final
|    |              |    +--- io.netty:netty-buffer:4.2.15.Final (*)
|    |              |    +--- io.netty:netty-transport:4.2.15.Final (*)
|    |              |    +--- io.netty:netty-codec-base:4.2.15.Final (*)
|    |              |    +--- io.netty:netty-codec-compression:4.2.15.Final (*)
|    |              |    +--- io.netty:netty-codec-protobuf:4.2.15.Final
|    |              |    |    +--- io.netty:netty-common:4.2.15.Final
|    |              |    |    +--- io.netty:netty-buffer:4.2.15.Final (*)
|    |              |    |    +--- io.netty:netty-transport:4.2.15.Final (*)
|    |              |    |    \--- io.netty:netty-codec-base:4.2.15.Final (*)
|    |              |    \--- io.netty:netty-codec-marshalling:4.2.15.Final
|    |              |         +--- io.netty:netty-common:4.2.15.Final
|    |              |         +--- io.netty:netty-buffer:4.2.15.Final (*)
|    |              |         +--- io.netty:netty-transport:4.2.15.Final (*)
|    |              |         \--- io.netty:netty-codec-base:4.2.15.Final (*)
|    |              +--- io.netty:netty-transport:4.1.130.Final -> 4.2.15.Final (*)
|    |              +--- io.netty:netty-common:4.1.130.Final -> 4.2.15.Final
|    |              +--- io.netty:netty-buffer:4.1.130.Final -> 4.2.15.Final (*)
|    |              +--- io.netty:netty-handler:4.1.130.Final -> 4.2.15.Final (*)
|    |              +--- io.netty:netty-transport-classes-epoll:4.1.130.Final -> 4.2.15.Final
|    |              |    +--- io.netty:netty-common:4.2.15.Final
|    |              |    +--- io.netty:netty-buffer:4.2.15.Final (*)
|    |              |    +--- io.netty:netty-transport:4.2.15.Final (*)
|    |              |    \--- io.netty:netty-transport-native-unix-common:4.2.15.Final (*)
|    |              +--- io.netty:netty-resolver:4.1.130.Final -> 4.2.15.Final (*)
|    |    +--- io.grpc:grpc-netty-shaded:1.81.0 (c)
|    |    +--- io.grpc:grpc-netty-shaded:1.81.0
|    |    |    \--- com.azure:azure-core-http-netty:1.16.4
|    |    |         +--- io.netty:netty-handler:4.1.132.Final -> 4.2.15.Final (*)
|    |    |         +--- io.netty:netty-handler-proxy:4.1.132.Final -> 4.2.15.Final
|    |    |         |    +--- io.netty:netty-common:4.2.15.Final
|    |    |         |    +--- io.netty:netty-buffer:4.2.15.Final (*)
|    |    |         |    +--- io.netty:netty-transport:4.2.15.Final (*)
|    |    |         |    +--- io.netty:netty-codec-base:4.2.15.Final (*)
|    |    |         |    +--- io.netty:netty-codec-socks:4.2.15.Final
|    |    |         |    |    +--- io.netty:netty-common:4.2.15.Final
|    |    |         |    |    +--- io.netty:netty-buffer:4.2.15.Final (*)
|    |    |         |    |    +--- io.netty:netty-transport:4.2.15.Final (*)
|    |    |         |    |    \--- io.netty:netty-codec-base:4.2.15.Final (*)
|    |    |         |    +--- io.netty:netty-codec-http:4.2.15.Final (*)
|    |    |         |    \--- io.netty:netty-handler:4.2.15.Final (*)
|    |    |         +--- io.netty:netty-buffer:4.1.132.Final -> 4.2.15.Final (*)
|    |    |         +--- io.netty:netty-codec:4.1.132.Final -> 4.2.15.Final (*)
|    |    |         +--- io.netty:netty-codec-http:4.1.132.Final -> 4.2.15.Final (*)
|    |    |         +--- io.netty:netty-codec-http2:4.1.132.Final -> 4.2.15.Final (*)
|    |    |         +--- io.netty:netty-transport-native-unix-common:4.1.132.Final -> 4.2.15.Final (*)
|    |    |         +--- io.netty:netty-transport-native-epoll:4.1.132.Final -> 4.2.15.Final
|    |    |         |    +--- io.netty:netty-common:4.2.15.Final
|    |    |         |    +--- io.netty:netty-buffer:4.2.15.Final (*)
|    |    |         |    +--- io.netty:netty-transport:4.2.15.Final (*)
|    |    |         |    +--- io.netty:netty-transport-native-unix-common:4.2.15.Final (*)
|    |    |         |    \--- io.netty:netty-transport-classes-epoll:4.2.15.Final (*)
|    |    |         +--- io.netty:netty-transport-native-kqueue:4.1.132.Final -> 4.2.15.Final
|    |    |         |    +--- io.netty:netty-common:4.2.15.Final
|    |    |         |    +--- io.netty:netty-buffer:4.2.15.Final (*)
|    |    |         |    +--- io.netty:netty-transport:4.2.15.Final (*)
|    |    |         |    +--- io.netty:netty-transport-native-unix-common:4.2.15.Final (*)
|    |    |         |    \--- io.netty:netty-transport-classes-kqueue:4.2.15.Final
|    |    |         |         +--- io.netty:netty-common:4.2.15.Final
|    |    |         |         +--- io.netty:netty-buffer:4.2.15.Final (*)
|    |    |         |         +--- io.netty:netty-transport:4.2.15.Final (*)
|    |    |         |         \--- io.netty:netty-transport-native-unix-common:4.2.15.Final (*)
|    |    |         +--- io.netty:netty-tcnative-boringssl-static:2.0.75.Final
|    |    |         |    \--- io.netty:netty-tcnative-classes:2.0.75.Final
|    |    |         +--- io.projectreactor.netty:reactor-netty-http:1.2.16 -> 1.2.17
|    |    |         |    +--- io.netty:netty-codec-http:4.1.132.Final -> 4.2.15.Final (*)
|    |    |         |    +--- io.netty:netty-codec-http2:4.1.132.Final -> 4.2.15.Final (*)
|    |    |         |    +--- io.netty:netty-resolver-dns:4.1.132.Final -> 4.2.15.Final
|    |    |         |    |    +--- io.netty:netty-common:4.2.15.Final
|    |    |         |    |    +--- io.netty:netty-buffer:4.2.15.Final (*)
|    |    |         |    |    +--- io.netty:netty-resolver:4.2.15.Final (*)
|    |    |         |    |    +--- io.netty:netty-transport:4.2.15.Final (*)
|    |    |         |    |    +--- io.netty:netty-codec-base:4.2.15.Final (*)
|    |    |         |    |    +--- io.netty:netty-codec-dns:4.2.15.Final
|    |    |         |    |    |    +--- io.netty:netty-common:4.2.15.Final
|    |    |         |    |    |    +--- io.netty:netty-buffer:4.2.15.Final (*)
|    |    |         |    |    |    +--- io.netty:netty-transport:4.2.15.Final (*)
|    |    |         |    |    |    \--- io.netty:netty-codec-base:4.2.15.Final (*)
|    |    |         |    |    \--- io.netty:netty-handler:4.2.15.Final (*)
|    |    |         |    +--- io.netty:netty-resolver-dns-native-macos:4.1.132.Final -> 4.2.15.Final
|    |    |         |    |    \--- io.netty:netty-resolver-dns-classes-macos:4.2.15.Final
|    |    |         |    |         +--- io.netty:netty-common:4.2.15.Final
|    |    |         |    |         +--- io.netty:netty-resolver-dns:4.2.15.Final (*)
|    |    |         |    |         \--- io.netty:netty-transport-native-unix-common:4.2.15.Final (*)
|    |    |         |    +--- io.netty:netty-transport-native-epoll:4.1.132.Final -> 4.2.15.Final (*)
|    |    |         |    +--- io.projectreactor.netty:reactor-netty-core:1.2.17
|    |    |         |    |    +--- io.netty:netty-handler:4.1.132.Final -> 4.2.15.Final (*)
|    |    |         |    |    +--- io.netty:netty-handler-proxy:4.1.132.Final -> 4.2.15.Final (*)
|    |    |         |    |    +--- io.netty:netty-resolver-dns:4.1.132.Final -> 4.2.15.Final (*)
|    |    |         |    |    +--- io.netty:netty-resolver-dns-native-macos:4.1.132.Final -> 4.2.15.Final (*)
|    |    |         |    |    +--- io.netty:netty-transport-native-epoll:4.1.132.Final -> 4.2.15.Final (*)
|    |    |         \--- io.netty:netty-common:4.1.132.Final -> 4.2.15.Final
|    |    |    +--- com.azure:azure-core-http-netty:1.16.4 (*)
|    |    +--- io.netty:netty-bom:4.2.13.Final -> 4.2.15.Final
|    |    |    +--- io.netty:netty-codec-http:4.2.15.Final (c)
|    |    |    +--- io.netty:netty-codec-http2:4.2.15.Final (c)
|    |    |    +--- io.netty:netty-codec:4.2.15.Final (c)
|    |    |    +--- io.netty:netty-transport:4.2.15.Final (c)
|    |    |    +--- io.netty:netty-common:4.2.15.Final (c)
|    |    |    +--- io.netty:netty-buffer:4.2.15.Final (c)
|    |    |    +--- io.netty:netty-handler:4.2.15.Final (c)
|    |    |    +--- io.netty:netty-transport-classes-epoll:4.2.15.Final (c)
|    |    |    +--- io.netty:netty-resolver:4.2.15.Final (c)
|    |    |    +--- io.netty:netty-handler-proxy:4.2.15.Final (c)
|    |    |    +--- io.netty:netty-transport-native-unix-common:4.2.15.Final (c)
|    |    |    +--- io.netty:netty-transport-native-epoll:4.2.15.Final (c)
|    |    |    +--- io.netty:netty-transport-native-kqueue:4.2.15.Final (c)
|    |    |    +--- io.netty:netty-tcnative-boringssl-static:2.0.77.Final -> 2.0.75.Final (c)
|    |    |    +--- io.netty:netty-codec-base:4.2.15.Final (c)
|    |    |    +--- io.netty:netty-codec-compression:4.2.15.Final (c)
|    |    |    +--- io.netty:netty-codec-protobuf:4.2.15.Final (c)
|    |    |    +--- io.netty:netty-codec-marshalling:4.2.15.Final (c)
|    |    |    +--- io.netty:netty-resolver-dns:4.2.15.Final (c)
|    |    |    +--- io.netty:netty-resolver-dns-native-macos:4.2.15.Final (c)
|    |    |    +--- io.netty:netty-codec-socks:4.2.15.Final (c)
|    |    |    +--- io.netty:netty-transport-classes-kqueue:4.2.15.Final (c)
|    |    |    +--- io.netty:netty-tcnative-classes:2.0.77.Final -> 2.0.75.Final (c)
|    |    |    +--- io.netty:netty-codec-dns:4.2.15.Final (c)
|    |    |    \--- io.netty:netty-resolver-dns-classes-macos:4.2.15.Final (c)
|    |    |    +--- io.grpc:grpc-netty-shaded:1.81.0
|    |    |    +--- io.grpc:grpc-netty-shaded:1.81.0
|    |    +--- io.grpc:grpc-netty-shaded:1.81.0
|    +--- io.grpc:grpc-netty-shaded:1.81.0
```

### Jira Ticket - https://broadworkbench.atlassian.net/browse/TSPS-984

### Checklist (provide links to changes)

- [ ] Updated external documentation (if applicable)
- [ ] Updated internal documentation (if applicable)
- [ ] Planned non patch version bump (if applicable)
- [ ] Made ticket for related CLI PR (if applicable)
- [ ] Made ticket for related UI PR (if applicable)
