### PR TITLE
TSPS-970 remove v1 admin endpoints for getting and updating user quota

### DIFF
--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -49,53 +49,6 @@ paths:
         500:
           $ref: '#/components/responses/ServerError'
 
-  /api/admin/v1/quotas/{pipelineName}/{userId}:
-    parameters:
-      - $ref: '#/components/parameters/PipelineName'
-      - $ref: '#/components/parameters/UserId'
-    get:
-      deprecated: true
-      summary: Get quota for a given pipeline and user.
-      tags: [ admin ]
-      operationId: getQuotaForPipelineAndUser
-      responses:
-        200:
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/AdminQuota'
-        400:
-          $ref: '#/components/responses/BadRequest'
-        403:
-          $ref: '#/components/responses/PermissionDenied'
-        500:
-          $ref: '#/components/responses/ServerError'
-    patch:
-      deprecated: true
-      summary: Update quota limit for a given pipeline and user.
-      tags: [ admin ]
-      operationId: updateQuotaLimitForPipelineAndUser
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/UpdateQuotaLimitRequestBody'
-      responses:
-        200:
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/AdminQuota'
-        400:
-          $ref: '#/components/responses/BadRequest'
-        403:
-          $ref: '#/components/responses/PermissionDenied'
-        500:
-          $ref: '#/components/responses/ServerError'
-
   /api/admin/v2/quotas/{pipelineName}/{userEmail}:
     parameters:
       - $ref: '#/components/parameters/PipelineName'
@@ -831,22 +784,6 @@ components:
           $ref: "#/components/schemas/PipelineWorkspaceGoogleProject"
         updated:
           $ref: "#/components/schemas/PipelineRuntimeMetadataUpdated"
-
-    AdminQuota:
-      deprecated: true
-      description: |
-        Object containing the use id, pipeline identifier, quota limit, and quota usage of a Pipeline for a user.
-      type: object
-      required: [ userId, pipelineName, quotaLimit, quotaConsumed ]
-      properties:
-        userId:
-          $ref: "#/components/schemas/UserId"
-        pipelineName:
-          $ref: "#/components/schemas/PipelineName"
-        quotaLimit:
-          $ref: "#/components/schemas/QuotaLimit"
-        quotaConsumed:
-          $ref: "#/components/schemas/QuotaConsumed"
 
     AdminQuotaV2:
       description: |

--- a/service/src/main/java/bio/terra/pipelines/app/controller/AdminApiController.java
+++ b/service/src/main/java/bio/terra/pipelines/app/controller/AdminApiController.java
@@ -1,6 +1,5 @@
 package bio.terra.pipelines.app.controller;
 
-import bio.terra.common.exception.BadRequestException;
 import bio.terra.common.exception.NotFoundException;
 import bio.terra.common.iam.SamUser;
 import bio.terra.common.iam.SamUserFactory;
@@ -16,7 +15,6 @@ import bio.terra.pipelines.service.PipelinesService;
 import bio.terra.pipelines.service.QuotasService;
 import io.swagger.annotations.Api;
 import jakarta.servlet.http.HttpServletRequest;
-import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -72,34 +70,6 @@ public class AdminApiController implements AdminApi {
     return new ResponseEntity<>(pipelineToApiAdminPipeline(pipeline), HttpStatus.OK);
   }
 
-  /**
-   * Fetch the quota information for a given user and pipeline
-   *
-   * @deprecated use getQuotaForPipelineAndUserV2
-   */
-  @Override
-  @Deprecated(since = "5.1.0")
-  public ResponseEntity<ApiAdminQuota> getQuotaForPipelineAndUser(
-      String pipelineName, String userId) {
-    final SamUser authedUser = getAuthenticatedInfo();
-    samService.checkAdminAuthz(authedUser);
-    PipelinesEnum validatedPipelineName =
-        PipelineApiUtils.validatePipelineName(pipelineName, logger);
-
-    // Check if a row exists for this user + pipeline. Throw an error if it doesn't
-    // A row should exist if a user has run into a quota issue before.
-    Optional<UserQuota> userQuota =
-        quotasService.getQuotaForUserAndPipeline(userId, validatedPipelineName);
-    if (userQuota.isEmpty()) {
-      throw new BadRequestException(
-          String.format(
-              "User quota not found for user %s and pipeline %s",
-              userId, validatedPipelineName.getLowerCaseValue()));
-    }
-
-    return new ResponseEntity<>(userQuotaToApiAdminQuota(userQuota.get()), HttpStatus.OK);
-  }
-
   @Override
   public ResponseEntity<ApiAdminPipeline> updatePipeline(
       String pipelineName, Integer pipelineVersion, ApiUpdatePipelineRequestBody body) {
@@ -120,54 +90,6 @@ public class AdminApiController implements AdminApi {
             workspaceName,
             toolVersion);
     return new ResponseEntity<>(pipelineToApiAdminPipeline(updatedPipeline), HttpStatus.OK);
-  }
-
-  /**
-   * Update the quota information for a given user and pipeline
-   *
-   * @deprecated use updateQuotaLimitForPipelineAndUserV2
-   */
-  @Override
-  @Deprecated(since = "5.1.0")
-  public ResponseEntity<ApiAdminQuota> updateQuotaLimitForPipelineAndUser(
-      String pipelineName, String userId, ApiUpdateQuotaLimitRequestBody body) {
-    final SamUser authedUser = getAuthenticatedInfo();
-    samService.checkAdminAuthz(authedUser);
-    PipelinesEnum validatedPipelineName =
-        PipelineApiUtils.validatePipelineName(pipelineName, logger);
-
-    // Check if a row exists for this user + pipeline. Throw an error if it doesn't
-    // A row should exist if a user has run into a quota issue before.
-    UserQuota userQuota =
-        quotasService
-            .getQuotaForUserAndPipeline(userId, validatedPipelineName)
-            .orElseThrow(
-                () ->
-                    new BadRequestException(
-                        String.format(
-                            "User quota not found for user %s and pipeline %s",
-                            userId, validatedPipelineName.getLowerCaseValue())));
-
-    int newQuotaLimit = body.getQuotaLimit();
-    int originalQuotaLimit =
-        userQuota.getQuota(); // capture original limit for email notification before update
-
-    UserQuota updatedUserQuota = quotasService.adminUpdateQuotaLimit(userQuota, newQuotaLimit);
-
-    Pipeline pipeline = pipelinesService.getLatestPipeline(validatedPipelineName);
-    String pipelineDisplayName = pipeline.getDisplayName();
-    int quotaAvailableAfterChange = newQuotaLimit - userQuota.getQuotaConsumed();
-
-    // send email notification to user about quota change
-    notificationService.configureAndSendUserQuotaChangedNotification(
-        userQuota.getUserId(),
-        pipelineDisplayName,
-        originalQuotaLimit,
-        newQuotaLimit,
-        userQuota.getQuotaConsumed(),
-        quotaAvailableAfterChange);
-
-    return new ResponseEntity<>(userQuotaToApiAdminQuota(updatedUserQuota), HttpStatus.OK);
   }
 
   @Override
@@ -259,14 +181,6 @@ public class AdminApiController implements AdminApi {
         .workspaceGoogleProject(pipeline.getWorkspaceGoogleProject())
         .toolVersion(pipeline.getToolVersion())
         .updated(pipeline.getUpdated().toString());
-  }
-
-  public ApiAdminQuota userQuotaToApiAdminQuota(UserQuota userQuota) {
-    return new ApiAdminQuota()
-        .userId(userQuota.getUserId())
-        .pipelineName(userQuota.getPipelineName().getLowerCaseValue())
-        .quotaLimit(userQuota.getQuota())
-        .quotaConsumed(userQuota.getQuotaConsumed());
   }
 
   private ApiAdminQuotaV2 userQuotaToApiAdminQuotaV2(UserQuota userQuota, String userEmail) {

--- a/service/src/test/java/bio/terra/pipelines/controller/AdminApiControllerTest.java
+++ b/service/src/test/java/bio/terra/pipelines/controller/AdminApiControllerTest.java
@@ -23,7 +23,6 @@ import bio.terra.pipelines.common.utils.PipelinesEnum;
 import bio.terra.pipelines.db.entities.UserQuota;
 import bio.terra.pipelines.dependencies.sam.SamService;
 import bio.terra.pipelines.generated.model.ApiAdminPipeline;
-import bio.terra.pipelines.generated.model.ApiAdminQuota;
 import bio.terra.pipelines.generated.model.ApiAdminQuotaV2;
 import bio.terra.pipelines.generated.model.ApiUpdatePipelineRequestBody;
 import bio.terra.pipelines.generated.model.ApiUpdateQuotaLimitRequestBody;
@@ -36,7 +35,6 @@ import bio.terra.pipelines.testutils.TestUtils;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
-import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -312,184 +310,6 @@ class AdminApiControllerTest {
                     PipelinesEnum.ARRAY_IMPUTATION.getLowerCaseValue(),
                     TestUtils.TEST_PIPELINE_VERSION_1)))
         .andExpect(status().isForbidden());
-  }
-
-  @Nested
-  @Deprecated
-  @DisplayName("getQuotaForPipelineAndUser V1 tests")
-  class GetAdminQuotaV1Tests {
-
-    @Test
-    void getUserQuotaOk() throws Exception {
-      when(quotasServiceMock.getQuotaForUserAndPipeline(
-              TEST_SAM_USER.getSubjectId(), PipelinesEnum.ARRAY_IMPUTATION))
-          .thenReturn(Optional.of(TEST_USER_QUOTA_1));
-      MvcResult result =
-          mockMvc
-              .perform(
-                  get(
-                      String.format(
-                          "/api/admin/v1/quotas/%s/%s",
-                          PipelinesEnum.ARRAY_IMPUTATION.getLowerCaseValue(),
-                          TEST_SAM_USER.getSubjectId())))
-              .andExpect(status().isOk())
-              .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-              .andReturn();
-
-      ApiAdminQuota response =
-          new ObjectMapper()
-              .readValue(result.getResponse().getContentAsString(), ApiAdminQuota.class);
-
-      // this is all mocked data so really not worth checking values, really just testing that it's
-      // a 200 status with a properly formatted response
-      assertEquals(PipelinesEnum.ARRAY_IMPUTATION.getLowerCaseValue(), response.getPipelineName());
-      assertEquals(TEST_USER_QUOTA_1.getUserId(), response.getUserId());
-      assertEquals(TEST_USER_QUOTA_1.getQuota(), response.getQuotaLimit());
-      assertEquals(TEST_USER_QUOTA_1.getQuotaConsumed(), response.getQuotaConsumed());
-    }
-
-    @Test
-    void getAdminQuotaNotAdminUser() throws Exception {
-      doThrow(new ForbiddenException("error string"))
-          .when(samServiceMock)
-          .checkAdminAuthz(testUser);
-
-      mockMvc
-          .perform(
-              get(
-                  String.format(
-                      "/api/admin/v1/quotas/%s/%s",
-                      PipelinesEnum.ARRAY_IMPUTATION.getLowerCaseValue(),
-                      TEST_SAM_USER.getSubjectId())))
-          .andExpect(status().isForbidden());
-    }
-
-    @Test
-    void getAdminQuotaUserQuotaDoesntExist() throws Exception {
-      when(quotasServiceMock.getQuotaForUserAndPipeline(
-              TEST_SAM_USER.getSubjectId(), PipelinesEnum.ARRAY_IMPUTATION))
-          .thenReturn(Optional.empty());
-      mockMvc
-          .perform(
-              get(
-                  String.format(
-                      "/api/admin/v1/quotas/%s/%s",
-                      PipelinesEnum.ARRAY_IMPUTATION.getLowerCaseValue(),
-                      TEST_SAM_USER.getSubjectId())))
-          .andExpect(status().isBadRequest());
-    }
-  }
-
-  @Nested
-  @Deprecated
-  @DisplayName("updateQuotaLimitForPipelineAndUser V1 tests")
-  class UpdateAdminQuotaV1Tests {
-
-    @Test
-    void updateAdminQuotaOk() throws Exception {
-      UserQuota updatedUserQuota =
-          new UserQuota(PipelinesEnum.ARRAY_IMPUTATION, TEST_SAM_USER.getSubjectId(), 800, 0);
-      when(quotasServiceMock.getQuotaForUserAndPipeline(
-              TEST_SAM_USER.getSubjectId(), PipelinesEnum.ARRAY_IMPUTATION))
-          .thenReturn(Optional.of(TEST_USER_QUOTA_1));
-      when(quotasServiceMock.adminUpdateQuotaLimit(TEST_USER_QUOTA_1, 800))
-          .thenReturn(updatedUserQuota);
-      when(pipelinesServiceMock.getLatestPipeline(PipelinesEnum.ARRAY_IMPUTATION))
-          .thenReturn(MockMvcUtils.getTestPipeline());
-
-      MvcResult result =
-          mockMvc
-              .perform(
-                  patch(
-                          String.format(
-                              "/api/admin/v1/quotas/%s/%s",
-                              PipelinesEnum.ARRAY_IMPUTATION.getLowerCaseValue(),
-                              TEST_SAM_USER.getSubjectId()))
-                      .contentType(MediaType.APPLICATION_JSON)
-                      .content(createTestJobPostBody(800)))
-              .andExpect(status().isOk())
-              .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-              .andReturn();
-
-      ApiAdminQuota response =
-          new ObjectMapper()
-              .readValue(result.getResponse().getContentAsString(), ApiAdminQuota.class);
-
-      // this is all mocked data so really not worth checking values, really just testing that it's
-      // a 200 status with a properly formatted response
-      assertEquals(PipelinesEnum.ARRAY_IMPUTATION.getLowerCaseValue(), response.getPipelineName());
-      assertEquals(TEST_SAM_USER.getSubjectId(), response.getUserId());
-      assertEquals(800, response.getQuotaLimit());
-
-      // assert that NotificationService was called with right parameters
-      verify(notificationService)
-          .configureAndSendUserQuotaChangedNotification(
-              TEST_SAM_USER.getSubjectId(), "displayName", 1000, 800, 10, 790);
-    }
-
-    @Test
-    void updateAdminQuotaUserQuotaDoesntExist() throws Exception {
-      when(quotasServiceMock.getQuotaForUserAndPipeline(
-              TEST_SAM_USER.getSubjectId(), PipelinesEnum.ARRAY_IMPUTATION))
-          .thenReturn(Optional.empty());
-      mockMvc
-          .perform(
-              patch(
-                      String.format(
-                          "/api/admin/v1/quotas/%s/%s",
-                          PipelinesEnum.ARRAY_IMPUTATION.getLowerCaseValue(),
-                          TEST_SAM_USER.getSubjectId()))
-                  .contentType(MediaType.APPLICATION_JSON)
-                  .content(createTestJobPostBody(800)))
-          .andExpect(status().isBadRequest());
-
-      // assert NotificationService is never called
-      verify(notificationService, never())
-          .configureAndSendUserQuotaChangedNotification(
-              any(), any(), anyInt(), anyInt(), anyInt(), anyInt());
-    }
-
-    @Test
-    void updateAdminQuotaRequireQuotaLimit() throws Exception {
-      mockMvc
-          .perform(
-              patch(
-                      String.format(
-                          "/api/admin/v1/quotas/%s/%s",
-                          PipelinesEnum.ARRAY_IMPUTATION.getLowerCaseValue(),
-                          TEST_SAM_USER.getSubjectId()))
-                  .contentType(MediaType.APPLICATION_JSON)
-                  .content("{}"))
-          .andExpect(status().isBadRequest());
-
-      // assert NotificationService is never called
-      verify(notificationService, never())
-          .configureAndSendUserQuotaChangedNotification(
-              any(), any(), anyInt(), anyInt(), anyInt(), anyInt());
-    }
-
-    @Test
-    void updateAdminQuotaIdNotAdminUser() throws Exception {
-      doThrow(new ForbiddenException("error string"))
-          .when(samServiceMock)
-          .checkAdminAuthz(testUser);
-
-      mockMvc
-          .perform(
-              patch(
-                      String.format(
-                          "/api/admin/v1/quotas/%s/%s",
-                          PipelinesEnum.ARRAY_IMPUTATION.getLowerCaseValue(),
-                          TEST_SAM_USER.getSubjectId()))
-                  .contentType(MediaType.APPLICATION_JSON)
-                  .content(createTestJobPostBody(500)))
-          .andExpect(status().isForbidden());
-
-      // assert NotificationService is never called
-      verify(notificationService, never())
-          .configureAndSendUserQuotaChangedNotification(
-              any(), any(), anyInt(), anyInt(), anyInt(), anyInt());
-    }
   }
 
   @Nested


### PR DESCRIPTION
### Description 
Since these are admin endpoints we dont need to wait 3 months after deprecating to remove them.  Just make sthe codebase cleaner to do it sooner.

e2e tests were already update to use the v2 endpoints

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-970

### Checklist (provide links to changes)

- [ ] Updated external documentation (if applicable)
- [ ] Updated internal documentation (if applicable)
- [ ] Planned non patch version bump (if applicable)
- [ ] Made ticket for related CLI PR (if applicable)
- [ ] Made ticket for related UI PR (if applicable)
