### PR TITLE
[TSPS-792] Link to job details page in success & failure email notifications

### DIFF
--- a/notification-templates/job_failed.html
+++ b/notification-templates/job_failed.html
@@ -178,7 +178,7 @@
 
                             <!-- Buttons -->
                             <div class="btn-section">
-                                <a href="https://services.terra.bio/#pipelines/imputation/history" class="btn"
+                                <a href="https://services.terra.bio/#pipelines/imputation/history/%jobId%" class="btn"
                                    target="_blank">View in web portal</a>
                                 <a href="https://broadscientificservices.zendesk.com/hc/en-us/articles/39901313672859"
                                    class="btn" target="_blank">View using CLI</a>

--- a/notification-templates/job_succeeded.html
+++ b/notification-templates/job_succeeded.html
@@ -187,7 +187,7 @@
 
                             <!-- Buttons -->
                             <div class="btn-section">
-                                <a href="https://services.terra.bio/#pipelines/imputation/history" class="btn"
+                                <a href="https://services.terra.bio/#pipelines/imputation/history/%jobId%" class="btn"
                                    target="_blank">Download in web portal</a>
                                 <a href="https://broadscientificservices.zendesk.com/hc/en-us/articles/39901313672859"
                                    class="btn" target="_blank">Download using CLI</a>
@@ -195,7 +195,7 @@
 
                             <!-- Expiry Notice -->
                             <div class="expiry-notice">
-                                <p>Results are available to download for 14 days</p>
+                                <p>Results are available for 14 days. You can either download the outputs directly or deliver them to a bucket in Google Cloud Storage.</p>
                             </div>
 
                             <!-- Job Details-->


### PR DESCRIPTION
### Description 

Link to job details page in success/failure email notifications

The email templates have been updated in dev Sendgrid. Once the PR is approved I will update the prod Sendgrid templates as well.
Dev templates
- failure: https://sendgrid.com/templates/f66d44a9-655b-4d56-97fd-636c89f6c146/versions/3300c3e3-d1f6-499f-86b3-bb30a515691a/preview
- success: https://sendgrid.com/templates/00f8c11a-dbed-48ea-b855-947d2f16f442/versions/5583c28d-8cfb-40a2-9240-a21aa0e2042b/preview

Tested the changes in BEE -

Modified description to make it clear that user can deliver data to bucket as well
<img width="777" height="764" alt="Screenshot 2026-07-07 at 4 45 13 PM" src="https://github.com/user-attachments/assets/26b75f47-c626-4389-880f-5da98c35113f" />



### Jira Ticket - https://broadworkbench.atlassian.net/browse/TSPS-792

### Checklist (provide links to changes)

- [ ] Updated external documentation (if applicable)
- [ ] Updated internal documentation (if applicable)
- [ ] Planned non patch version bump (if applicable)
- [ ] Made ticket for related CLI PR (if applicable)
- [ ] Made ticket for related UI PR (if applicable)
