### PR TITLE
[TSPS-1028] Fix race condition when creating quota row for new user

### DIFF
--- a/service/src/main/java/bio/terra/pipelines/service/QuotasService.java
+++ b/service/src/main/java/bio/terra/pipelines/service/QuotasService.java
@@ -52,6 +52,7 @@ public class QuotasService {
   public UserQuota getOrCreateQuotaForUserAndPipeline(String userId, PipelinesEnum pipelineName) {
     // try to get the user quota
     Optional<UserQuota> userQuota = getQuotaForUserAndPipeline(userId, pipelineName);
+
     // if the user quota is not found, grab the default pipeline quota and make a new row in user
     // quotas table
     if (userQuota.isEmpty()) {
@@ -59,13 +60,32 @@ public class QuotasService {
           "Couldn't find user quota for user {} and pipeline {}. Creating a new row",
           userId,
           pipelineName);
-      PipelineQuota pipelineQuota = getPipelineQuota(pipelineName);
-      UserQuota newUserQuota = new UserQuota();
-      newUserQuota.setUserId(userId);
-      newUserQuota.setPipelineName(pipelineName);
-      newUserQuota.setQuota(pipelineQuota.getDefaultQuota());
-      userQuotasRepository.save(newUserQuota);
-      return newUserQuota;
+      try {
+        /* Note: This try/catch relies on this method NOT being wrapped in an outer @Transactional.
+         * Because there is no outer transaction, CrudRepository.save() commits and flushes immediately,
+         * allowing us to catch the constraint violation. If you add @Transactional to this service
+         * in the future, the flush will be delayed and the try/catch will fail.
+         */
+        PipelineQuota pipelineQuota = getPipelineQuota(pipelineName);
+        UserQuota newUserQuota = new UserQuota();
+        newUserQuota.setUserId(userId);
+        newUserQuota.setPipelineName(pipelineName);
+        newUserQuota.setQuota(pipelineQuota.getDefaultQuota());
+        return userQuotasRepository.save(newUserQuota);
+      } catch (org.springframework.dao.DataIntegrityViolationException e) {
+        // Handle race condition: another thread may have created the quota between our check and
+        // insert
+        logger.info(
+            "Race condition detected while creating user quota for user {} and pipeline {}. Fetching existing record.",
+            userId,
+            pipelineName);
+        return getQuotaForUserAndPipeline(userId, pipelineName)
+            .orElseThrow(
+                () ->
+                    new IllegalStateException(
+                        "Quota should exist but was not found for user %s and pipeline %s."
+                            .formatted(userId, pipelineName)));
+      }
     }
     return userQuota.get();
   }

--- a/service/src/test/java/bio/terra/pipelines/service/QuotasServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/QuotasServiceTest.java
@@ -370,10 +370,10 @@ class QuotasServiceTest extends BaseEmbeddedDbTest {
             IllegalStateException.class,
             () -> serviceWithMock.getOrCreateQuotaForUserAndPipeline(userId, pipeline));
 
-    // Verify exception message contains user and pipeline info
-    assertTrue(exception.getMessage().contains(userId));
-    assertTrue(exception.getMessage().contains(pipeline.name()));
-    assertTrue(exception.getMessage().contains("Quota should exist but was not found"));
+    // Verify exception message
+    assertEquals(
+        "Quota should exist but was not found for user test-user-edge-case-rocket and pipeline ARRAY_IMPUTATION.",
+        exception.getMessage());
 
     // Verify the retry happened (findByUserIdAndPipelineName called twice)
     verify(mockRepo, times(2)).findByUserIdAndPipelineName(userId, pipeline);

--- a/service/src/test/java/bio/terra/pipelines/service/QuotasServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/QuotasServiceTest.java
@@ -11,6 +11,13 @@ import bio.terra.pipelines.db.entities.UserQuota;
 import bio.terra.pipelines.db.repositories.UserQuotasRepository;
 import bio.terra.pipelines.testutils.BaseEmbeddedDbTest;
 import bio.terra.pipelines.testutils.TestUtils;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -248,5 +255,82 @@ class QuotasServiceTest extends BaseEmbeddedDbTest {
         "Insufficient quota to run the pipeline. Quota available: 300, Minimum quota required: 500. "
             + "Please email scientific-services-support@broadinstitute.org if you would like to request a quota increase.",
         exception.getMessage());
+  }
+
+  /**
+   * This test simulates a race condition where multiple concurrent threads try to create the same
+   * user quota simultaneously. This verifies that the method handles the race condition correctly
+   * and doesn't throw duplicate key violations.
+   */
+  @Test
+  void testConcurrentUserQuotaCreation() throws Exception {
+    // Use a unique user ID for this test to avoid conflicts with other tests
+    String concurrentUserId = "concurrent-test-user-groot";
+    PipelinesEnum pipelineName = PipelinesEnum.ARRAY_IMPUTATION;
+
+    // Verify no quota exists for this user
+    assertTrue(
+        userQuotasRepository.findByUserIdAndPipelineName(concurrentUserId, pipelineName).isEmpty());
+
+    // Number of concurrent threads to simulate the race condition
+    int numberOfThreads = 10;
+    ExecutorService executor = Executors.newFixedThreadPool(numberOfThreads);
+    CountDownLatch startLatch = new CountDownLatch(1);
+    CountDownLatch endLatch = new CountDownLatch(numberOfThreads);
+
+    List<Future<UserQuota>> futures = new ArrayList<>();
+
+    // Create multiple threads that will all try to create the same quota simultaneously
+    for (int i = 0; i < numberOfThreads; i++) {
+      Future<UserQuota> future =
+          executor.submit(
+              () -> {
+                try {
+                  // Wait for all threads to be ready before starting
+                  startLatch.await();
+
+                  // All threads call this method at the same time
+                  return quotasService.getOrCreateQuotaForUserAndPipeline(
+                      concurrentUserId, pipelineName);
+                } finally {
+                  endLatch.countDown();
+                }
+              });
+      futures.add(future);
+    }
+
+    // Release all threads at once to maximize chance of race condition
+    startLatch.countDown();
+
+    // Wait for all threads to complete (with timeout)
+    assertTrue(endLatch.await(10, TimeUnit.SECONDS), "All threads should complete within timeout");
+
+    // Verify all futures completed successfully and returned valid results
+    int expectedDefaultQuota = quotasService.getPipelineQuota(pipelineName).getDefaultQuota();
+    List<Long> quotaIds = new ArrayList<>();
+    for (Future<UserQuota> future : futures) {
+      UserQuota quota = future.get(1, TimeUnit.SECONDS);
+      assertNotNull(quota, "UserQuota should not be null");
+      assertNotNull(quota.getId(), "UserQuota ID should not be null");
+      assertEquals(concurrentUserId, quota.getUserId());
+      assertEquals(pipelineName, quota.getPipelineName());
+      assertEquals(expectedDefaultQuota, quota.getQuota());
+      assertEquals(0, quota.getQuotaConsumed());
+      quotaIds.add(quota.getId());
+    }
+
+    // Verify that only ONE row was created in the database despite concurrent attempts
+    List<UserQuota> dbQuotas = userQuotasRepository.findByUserId(concurrentUserId);
+    assertEquals(
+        1,
+        dbQuotas.size(),
+        "Only one quota should exist in database despite concurrent creation attempts");
+
+    // Verify all threads received the SAME entity (same ID) from the database
+    long uniqueIdCount = quotaIds.stream().distinct().count();
+    assertEquals(
+        1, uniqueIdCount, "All threads should have returned the same UserQuota entity (same ID)");
+
+    executor.shutdown();
   }
 }

--- a/service/src/test/java/bio/terra/pipelines/service/QuotasServiceTest.java
+++ b/service/src/test/java/bio/terra/pipelines/service/QuotasServiceTest.java
@@ -1,6 +1,8 @@
 package bio.terra.pipelines.service;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
 
 import bio.terra.common.exception.BadRequestException;
 import bio.terra.common.exception.InternalServerErrorException;
@@ -13,6 +15,7 @@ import bio.terra.pipelines.testutils.BaseEmbeddedDbTest;
 import bio.terra.pipelines.testutils.TestUtils;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -20,6 +23,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
 
 class QuotasServiceTest extends BaseEmbeddedDbTest {
   @Autowired QuotasService quotasService;
@@ -332,5 +336,47 @@ class QuotasServiceTest extends BaseEmbeddedDbTest {
         1, uniqueIdCount, "All threads should have returned the same UserQuota entity (same ID)");
 
     executor.shutdown();
+  }
+
+  /**
+   * Unit test to verify IllegalStateException is thrown in the edge case where
+   * DataIntegrityViolationException occurs but the retry fetch returns empty. This test has been
+   * added to satisfy SonarQube's requirement for coverage of the catch block in
+   * getOrCreateQuotaForUserAndPipeline.
+   */
+  @Test
+  void testRaceConditionRetryReturnsEmpty() {
+    // Create a mock repository to simulate the edge case
+    UserQuotasRepository mockRepo = mock(UserQuotasRepository.class);
+    QuotasService serviceWithMock = new QuotasService(mockRepo, pipelineConfigurations);
+
+    String userId = "test-user-edge-case-rocket";
+    PipelinesEnum pipeline = PipelinesEnum.ARRAY_IMPUTATION;
+
+    // First call: findByUserIdAndPipelineName returns empty (no quota exists)
+    // Second call: after catching exception, findByUserIdAndPipelineName still returns empty to
+    // simulate the edge case
+    when(mockRepo.findByUserIdAndPipelineName(userId, pipeline))
+        .thenReturn(Optional.empty())
+        .thenReturn(Optional.empty());
+
+    // save() throws DataIntegrityViolationException (simulating race condition)
+    when(mockRepo.save(any(UserQuota.class)))
+        .thenThrow(new DataIntegrityViolationException("duplicate key"));
+
+    // Execute and verify IllegalStateException is thrown
+    IllegalStateException exception =
+        assertThrows(
+            IllegalStateException.class,
+            () -> serviceWithMock.getOrCreateQuotaForUserAndPipeline(userId, pipeline));
+
+    // Verify exception message contains user and pipeline info
+    assertTrue(exception.getMessage().contains(userId));
+    assertTrue(exception.getMessage().contains(pipeline.name()));
+    assertTrue(exception.getMessage().contains("Quota should exist but was not found"));
+
+    // Verify the retry happened (findByUserIdAndPipelineName called twice)
+    verify(mockRepo, times(2)).findByUserIdAndPipelineName(userId, pipeline);
+    verify(mockRepo, times(1)).save(any(UserQuota.class));
   }
 }


### PR DESCRIPTION
### Description 

This PR adds a try-catch in `getOrCreateQuotaForUserAndPipeline` to catch the DataIntegrityViolationException when multiple threads try to fetch and insert a row for a user whose quota doesn't exist in the table. 

Alternative solutions considered:
- UPSERT: Native SQL UPSERT would require custom queries and bypass Spring Data JPA and add complexity
- Table Locking: Pessimistic locking would require `@Transactional` context and hold locks during the entire transaction, significantly reducing throughput
- Row Locking: Cannot lock a row that doesn't exist yet

Try-catch approach leverages the existing unique constraint and works with the current repository pattern. It also assumes conflicts are rare (since this race condition only happens when multiple threads are called to fetch data for a new user) and only retries on actual collisions, providing better performance.

I have added information about why this race condition might be happening in ticket comment - https://broadworkbench.atlassian.net/browse/TSPS-1028?focusedCommentId=116091 

### Jira Ticket - https://broadworkbench.atlassian.net/browse/TSPS-1028

### Checklist (provide links to changes)

- [ ] Updated external documentation (if applicable)
- [ ] Updated internal documentation (if applicable)
- [ ] Planned non patch version bump (if applicable)
- [ ] Made ticket for related CLI PR (if applicable)
- [ ] Made ticket for related UI PR (if applicable)
