### PR TITLE
TSPS-1061 CompareBcfs wdl for evaluating SV output

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -2,6 +2,13 @@ version: 1.2
 workflows:
 
   - subclass: WDL
+    name: CompareBcfs
+    primaryDescriptorPath: /pipelines/sv_imputation/testing/CompareBcfs.wdl
+    authors:
+      - name: Terra Scientific Services
+        email: teaspoons-developers@broadinstitute.org
+
+  - subclass: WDL
     name: CompareVcfs
     primaryDescriptorPath: /pipelines/array_imputation/testing/CompareVcfs.wdl
     authors:

--- a/pipelines/sv_imputation/testing/CompareBcfs.wdl
+++ b/pipelines/sv_imputation/testing/CompareBcfs.wdl
@@ -45,7 +45,7 @@ task CompareBcfsTask {
     }
 
     runtime {
-        docker: "gcr.io/gcp-runtimes/ubuntu_16_0_4@sha256:025124e2f1cf4d29149958f17270596bffe13fc6acca6252977c572dd5ba01bf"
+        docker: "us.gcr.io/broad-gotc-prod/bcftools-vcftools:sps_sv_docker_images"
         disks: "local-disk ${disk_size_gb} SSD"
         memory: "${memory_gb} GiB"
         preemptible: preemptible_tries

--- a/pipelines/sv_imputation/testing/CompareBcfs.wdl
+++ b/pipelines/sv_imputation/testing/CompareBcfs.wdl
@@ -45,7 +45,7 @@ task CompareBcfsTask {
     }
 
     runtime {
-        docker: "us.gcr.io/broad-gotc-prod/bcftools-vcftools:sps_sv_docker_images"
+        docker: "us.gcr.io/broad-gotc-prod/bcftools-vcftools:2.0.0-1.24-0.1.17-1784569943"
         disks: "local-disk ${disk_size_gb} SSD"
         memory: "${memory_gb} GiB"
         preemptible: preemptible_tries

--- a/pipelines/sv_imputation/testing/CompareBcfs.wdl
+++ b/pipelines/sv_imputation/testing/CompareBcfs.wdl
@@ -1,0 +1,53 @@
+version 1.0
+
+workflow CompareBcfs {
+
+    input {
+        File test_bcf
+        File truth_bcf
+
+        Int memory_gb = 64
+        Int preemptible_tries = 0
+    }
+
+    call CompareBcfsTask {
+        input:
+            file1 = test_bcf,
+            file2 = truth_bcf,
+            patternForLinesToExcludeFromComparison = "##", # ignore headers but do compare sample names,
+            memory_gb = memory_gb,
+            preemptible_tries = preemptible_tries
+    }
+}
+
+task CompareBcfsTask {
+    input {
+        File file1
+        File file2
+
+        String patternForLinesToExcludeFromComparison = ""
+
+        Int memory_gb = 64
+        Int preemptible_tries = 0
+    }
+
+    Int disk_size_gb = ceil(10 * size(file1, "GiB")) + ceil(10 * size(file2, "GiB")) + 50
+
+    command {
+        set -eo pipefail
+
+        if [ -z "~{patternForLinesToExcludeFromComparison}" ]; then
+            diff <(bcftools view -O v ~{file1}) <(bcftools view -O v ~{file2})
+        else
+            echo "patternForLinesToExcludeFromComparison is defined: '~{patternForLinesToExcludeFromComparison}'"
+            diff <(bcftools view -O v ~{file1} | grep -v '~{patternForLinesToExcludeFromComparison}') <(bcftools view -O v ~{file2} | grep -v '~{patternForLinesToExcludeFromComparison}')
+        fi
+    }
+
+    runtime {
+        docker: "gcr.io/gcp-runtimes/ubuntu_16_0_4@sha256:025124e2f1cf4d29149958f17270596bffe13fc6acca6252977c572dd5ba01bf"
+        disks: "local-disk ${disk_size_gb} SSD"
+        memory: "${memory_gb} GiB"
+        preemptible: preemptible_tries
+    }
+}

--- a/pipelines/sv_imputation/testing/README.md
+++ b/pipelines/sv_imputation/testing/README.md
@@ -1,0 +1,12 @@
+## CompareBcfs
+### Purpose
+This wdl is intended to be used to compare the imputed output BCFs from different versions of the SV imputation wdl.
+When used with patternForLinesToExcludeFromComparison = "##", it ignores the header lines in the BCFs but checks the sample
+names and the remaining contents of the BCFs. The workflow fails if any differences are found.
+
+#### Inputs
+* test_bcf
+* truth_bcf
+
+#### Outputs
+none (workflow success indicates that the BCFs are identical aside from headers)


### PR DESCRIPTION
### Description 

Adds a CompareBcfs wdl akin to CompareVcfs that compares the non-header lines of two bcf files. Used to evaluate whether the SV pipeline could be run deterministically.

Related warp PR: https://github.com/broadinstitute/warp/pull/1886

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-1061

### Checklist (provide links to changes)

- [ ] Updated external documentation (if applicable)
- [ ] Updated internal documentation (if applicable)
- [ ] Planned non patch version bump (if applicable)
- [ ] Made ticket for related CLI PR (if applicable)
- [ ] Made ticket for related UI PR (if applicable)
