### PR TITLE
TSPS-1141 set low pass wgs imputation defaultQuota to 100 and add hyphen to low-pass

### DIFF
--- a/docs/wdl_based_pipelines/low_pass_imputation.MD
+++ b/docs/wdl_based_pipelines/low_pass_imputation.MD
@@ -1,7 +1,7 @@
-# Teaspoons Low Pass WGS Imputation Pipeline Overview
+# Teaspoons Low-Pass WGS Imputation Pipeline Overview
 
 ## Purpose
-We want an internal doc we can refer to for a refresher on the Low Pass WGS Imputation (also known as the BGE or GLIMPSE) pipeline.  This will describe the pipeline inputs/outputs as well as pointers to all the different wdls involved in the pipeline.
+We want an internal doc we can refer to for a refresher on the Low-Pass WGS Imputation (also known as the BGE or GLIMPSE) pipeline.  This will describe the pipeline inputs/outputs as well as pointers to all the different wdls involved in the pipeline.
 
 ## Stairway Flight
 Information about the stairway flight used to launch this pipeline is [here](wdl_based_pipelines.MD)

--- a/service/src/main/resources/pipelines-config.yml
+++ b/service/src/main/resources/pipelines-config.yml
@@ -234,8 +234,8 @@ configurations:
             isRequired: true
     lowPassImputation:
       1:
-        displayName: All of Us + AnVIL Low Pass WGS Imputation
-        description: Impute low pass WGS or BGE data using GLIMPSE2 with the All of Us + AnVIL reference panel of 515,579 samples.
+        displayName: All of Us + AnVIL Low-Pass WGS Imputation
+        description: Impute low-pass WGS or BGE data using GLIMPSE2 with the All of Us + AnVIL reference panel of 515,579 samples.
         pipelineType: imputation
         toolName: Glimpse2LowPassImputation
         memoryRetryMultiplier: 1.5

--- a/service/src/main/resources/pipelines-config.yml
+++ b/service/src/main/resources/pipelines-config.yml
@@ -36,7 +36,7 @@ configurations:
       maxQuotaConsumed: 10000
       quotaUnits: SAMPLES
     lowPassImputation:
-      defaultQuota: 0
+      defaultQuota: 100
       minQuotaConsumed: 100
       maxQuotaConsumed: 1000
       quotaUnits: SAMPLES


### PR DESCRIPTION
### Description 

For public release of the low pass WGS imputation pipeline we need the defaultQuota to be nonzero. Setting to 100.

Also update user-facing text to use a hyphen in "Low-Pass WGS"

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-1141

### Checklist (provide links to changes)

- [ ] Updated external documentation (if applicable)
- [ ] Updated internal documentation (if applicable)
- [ ] Planned non patch version bump (if applicable)
- [ ] Made ticket for related CLI PR (if applicable)
- [ ] Made ticket for related UI PR (if applicable)
